### PR TITLE
cvo: report entire update in status

### DIFF
--- a/pkg/apis/clusterversion.openshift.io/v1/types.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/types.go
@@ -110,5 +110,11 @@ type CVOStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	AvailablePayloads []string `json:"availablePayloads"`
+	AvailableUpdates []AvailableUpdate `json:"availableUpdates"`
+}
+
+// AvailableUpdate represents a potential update to the cluster.
+type AvailableUpdate struct {
+	Version string `json:"version"`
+	Payload string `json:"payload"`
 }

--- a/pkg/apis/clusterversion.openshift.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/zz_generated.deepcopy.go
@@ -62,9 +62,9 @@ func (in *CVOStatus) DeepCopyInto(out *CVOStatus) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.AvailablePayloads != nil {
-		in, out := &in.AvailablePayloads, &out.AvailablePayloads
-		*out = make([]string, len(*in))
+	if in.AvailableUpdates != nil {
+		in, out := &in.AvailableUpdates, &out.AvailableUpdates
+		*out = make([]AvailableUpdate, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
Rather than just showing the payload, the status will now show the
version number. This is needed if payloads don't use human-readable tags
or if they use digests instead.