### PR TITLE
Drop CVO from release manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,3 @@ COPY install /manifests
 COPY bootstrap /bootstrap
 
 ENTRYPOINT ["/bin/cluster-version-operator"]
-LABEL io.openshift.release.operator true

--- a/pkg/cvo/render.go
+++ b/pkg/cvo/render.go
@@ -15,7 +15,7 @@ import (
 // Render renders all the manifests from /manifests to outputDir.
 func Render(outputDir, releaseImage string) error {
 	var (
-		manifestsDir  = "/manifests"
+		manifestsDir  = filepath.Join(defaultUpdatePayloadDir, cvoManifestDir)
 		oManifestsDir = filepath.Join(outputDir, "manifests")
 		bootstrapDir  = "/bootstrap"
 		oBootstrapDir = filepath.Join(outputDir, "bootstrap")


### PR DESCRIPTION
CVO loads `manifests` dir for manifests that define CVO.
CVO loads `release-manifests` dir for manifests that release-image contains.

CVO still keeps the order `cvo manifests` > `release-image` manifests

/cc @smarterclayton 