### PR TITLE
Allow overrides for components

### DIFF
--- a/lib/resourcemerge/cv.go
+++ b/lib/resourcemerge/cv.go
@@ -14,7 +14,7 @@ func EnsureCVOConfig(modified *bool, existing *cvv1.CVOConfig, required cvv1.CVO
 		*modified = true
 		existing.Channel = required.Channel
 	}
-	if existing.ClusterID.String() != required.ClusterID.String() {
+	if existing.ClusterID != required.ClusterID {
 		*modified = true
 		existing.ClusterID = required.ClusterID
 	}

--- a/pkg/apis/clusterversion.openshift.io/v1/cluster_id.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/cluster_id.go
@@ -1,0 +1,30 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// UnmarshalJSON unmarshals RFC4122 uuid from string.
+func (cid *ClusterID) UnmarshalJSON(b []byte) error {
+	var strid string
+	if err := json.Unmarshal(b, &strid); err != nil {
+		return err
+	}
+
+	uid, err := uuid.Parse(strid)
+	if err != nil {
+		return err
+	}
+	if uid.Variant() != uuid.RFC4122 {
+		return fmt.Errorf("invalid ClusterID %q, must be an RFC4122-variant UUID: found %s", strid, uid.Variant())
+	}
+	if uid.Version() != 4 {
+		return fmt.Errorf("Invalid ClusterID %q, must be a version-4 UUID: found %s", strid, uid.Version())
+	}
+
+	*cid = ClusterID(uid.String())
+	return nil
+}

--- a/pkg/apis/clusterversion.openshift.io/v1/types.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/types.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,10 +23,14 @@ type CVOConfig struct {
 
 	Upstream  URL       `json:"upstream"`
 	Channel   string    `json:"channel"`
-	ClusterID uuid.UUID `json:"clusterId"`
+	ClusterID ClusterID `json:"clusterID"`
 
 	DesiredUpdate Update `json:"desiredUpdate"`
 }
+
+// ClusterID is string RFC4122 uuid.
+type ClusterID string
+
 
 // URL is a thin wrapper around string that ensures the string is a valid URL.
 type URL string

--- a/pkg/apis/clusterversion.openshift.io/v1/types.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/types.go
@@ -26,11 +26,29 @@ type CVOConfig struct {
 	ClusterID ClusterID `json:"clusterID"`
 
 	DesiredUpdate Update `json:"desiredUpdate"`
+
+	// Overrides is list of overides for components that are managed by
+	// cluster version operator
+	Overrides []ComponentOverride `json:"overrides,omitempty"`
 }
 
 // ClusterID is string RFC4122 uuid.
 type ClusterID string
 
+// ComponentOverride allows overriding cluster version operator's behavior
+// for a component.
+type ComponentOverride struct {
+	// Kind should match the TypeMeta.Kind for object.
+	Kind string `json:"kind"`
+
+	// The Namespace and Name for the component.
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	// Unmanaged controls if cluster version operator should stop managing.
+	// Default: false
+	Unmanaged bool `json:"unmanaged"`
+}
 
 // URL is a thin wrapper around string that ensures the string is a valid URL.
 type URL string

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -65,13 +65,14 @@ type Operator struct {
 
 	syncHandler func(key string) error
 
-	cvoConfigLister      cvlistersv1.CVOConfigLister
 	operatorStatusLister oslistersv1.OperatorStatusLister
 
-	crdLister          apiextlistersv1beta1.CustomResourceDefinitionLister
-	deployLister       appslisterv1.DeploymentLister
-	crdListerSynced    cache.InformerSynced
-	deployListerSynced cache.InformerSynced
+	crdLister             apiextlistersv1beta1.CustomResourceDefinitionLister
+	deployLister          appslisterv1.DeploymentLister
+	cvoConfigLister       cvlistersv1.CVOConfigLister
+	crdListerSynced       cache.InformerSynced
+	deployListerSynced    cache.InformerSynced
+	cvoConfigListerSynced cache.InformerSynced
 
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue workqueue.RateLimitingInterface
@@ -113,13 +114,14 @@ func New(
 
 	optr.syncHandler = optr.sync
 
-	optr.cvoConfigLister = cvoConfigInformer.Lister()
 	optr.operatorStatusLister = operatorStatusInformer.Lister()
 
 	optr.crdLister = crdInformer.Lister()
 	optr.crdListerSynced = crdInformer.Informer().HasSynced
 	optr.deployLister = deployInformer.Lister()
 	optr.deployListerSynced = deployInformer.Informer().HasSynced
+	optr.cvoConfigLister = cvoConfigInformer.Lister()
+	optr.cvoConfigListerSynced = cvoConfigInformer.Informer().HasSynced
 
 	return optr
 }
@@ -135,6 +137,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	if !cache.WaitForCacheSync(stopCh,
 		optr.crdListerSynced,
 		optr.deployListerSynced,
+		optr.cvoConfigListerSynced,
 	) {
 		return
 	}

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -248,6 +248,12 @@ func (optr *Operator) getConfig() (*cvv1.CVOConfig, error) {
 	upstream := cvv1.URL("http://localhost:8080/graph")
 	channel := "fast"
 	id, _ := uuid.NewRandom()
+	if id.Variant() != uuid.RFC4122 {
+		return nil, fmt.Errorf("invalid %q, must be an RFC4122-variant UUID: found %s", id, id.Variant())
+	}
+	if id.Version() != 4 {
+		return nil, fmt.Errorf("Invalid %q, must be a version-4 UUID: found %s", id, id.Version())
+	}
 
 	// XXX: generate CVOConfig from options calculated above.
 	config := &cvv1.CVOConfig{
@@ -257,13 +263,7 @@ func (optr *Operator) getConfig() (*cvv1.CVOConfig, error) {
 		},
 		Upstream:  upstream,
 		Channel:   channel,
-		ClusterID: id,
-	}
-	if config.ClusterID.Variant() != uuid.RFC4122 {
-		return nil, fmt.Errorf("invalid ClusterID %q, must be an RFC4122-variant UUID: found %s", config.ClusterID, config.ClusterID.Variant())
-	}
-	if config.ClusterID.Version() != 4 {
-		return nil, fmt.Errorf("Invalid ClusterID %q, must be a version-4 UUID: found %s", config.ClusterID, config.ClusterID.Version())
+		ClusterID: cvv1.ClusterID(id.String()),
 	}
 
 	actual, _, err := resourceapply.ApplyCVOConfigFromCache(optr.cvoConfigLister, optr.client.ClusterversionV1(), config)

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -3,6 +3,8 @@ package cvo
 import (
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
 	cvv1 "github.com/openshift/cluster-version-operator/pkg/apis/clusterversion.openshift.io/v1"
 	osv1 "github.com/openshift/cluster-version-operator/pkg/apis/operatorstatus.openshift.io/v1"
@@ -76,5 +78,9 @@ func (optr *Operator) syncDegradedStatus(ierr error) error {
 }
 
 func checkForUpdate(config cvv1.CVOConfig) ([]cincinnati.Update, error) {
-	return cincinnati.NewClient(config.ClusterID).GetUpdates(string(config.Upstream), config.Channel, version.Version)
+	uuid, err := uuid.Parse(string(config.ClusterID))
+	if err != nil {
+		return nil, err
+	}
+	return cincinnati.NewClient(uuid).GetUpdates(string(config.Upstream), config.Channel, version.Version)
 }


### PR DESCRIPTION
1. update cvoconfig's clusterid 
Making CLusterID a string type allows makes the config better in
terms of human readble.

Added the UnmarshalJSON for string CLusterID with validations that
ensure that uuid type.

This does not prevent users from setting wrong uuid type, but CRDs
don't allow high level validation server side. CVO will not use invalid
uuid.

2. add overrides per component basis
component override allow user to make one of the CVO's owned component
unmanaged.