### PR TITLE
switch workload resource to daemonset

### DIFF
--- a/install/0000_00_cluster-version-operator_03_daemonset.yaml
+++ b/install/0000_00_cluster-version-operator_03_daemonset.yaml
@@ -1,9 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
 spec:
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: cluster-version-operator


### PR DESCRIPTION
This change switches the CVO to be installed as a daemonset instead of a deployment so that it can temporarily bypass the scheduling problem it faces as a deployment.  This allows us to 

1. avoid having the static pod which cannot be managed via `kubectl` 
2. ensures that a CVO rollout to a new image doesn't get backleveled by a static pod
3. ensures that the CVO is automatically balanced on new masters so that should one kube-apiserver go down, you don't lose all three CVO pods (deployments don't do this)

If we later want to switch back to deployments we can, but this change eliminates an unnecessary static pod and places the CVO at the right logical point in the installation flow.

/assign @abhinavdahiya 

@ironcladlou @smarterclayton @mfojtik 