### PR TITLE
lib: add DaemonSet as managed resource

### DIFF
--- a/lib/resourcebuilder/register.go
+++ b/lib/resourcebuilder/register.go
@@ -18,6 +18,7 @@ func init() {
 	rm.RegisterGVK(apiregv1.SchemeGroupVersion.WithKind("APIService"), newAPIServiceBuilder)
 	rm.RegisterGVK(apiregv1beta1.SchemeGroupVersion.WithKind("APIService"), newAPIServiceBuilder)
 	rm.RegisterGVK(appsv1.SchemeGroupVersion.WithKind("Deployment"), newDeploymentBuilder)
+	rm.RegisterGVK(appsv1.SchemeGroupVersion.WithKind("DaemonSet"), newDaemonsetBuilder)
 	rm.RegisterGVK(batchv1.SchemeGroupVersion.WithKind("Job"), newJobBuilder)
 	rm.RegisterGVK(corev1.SchemeGroupVersion.WithKind("ServiceAccount"), newServiceAccountBuilder)
 	rm.RegisterGVK(corev1.SchemeGroupVersion.WithKind("ConfigMap"), newConfigMapBuilder)

--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -21,3 +21,20 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
 }
+
+// EnsureDaemonSet ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureDaemonSet(modified *bool, existing *appsv1.DaemonSet, required appsv1.DaemonSet) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if existing.Spec.Selector == nil {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.Selector, required.Spec.Selector) {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+
+	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}


### PR DESCRIPTION
Few operators like the network operator and CVO itself are going to have to be
daemonsets to workaround the scheduler bug (not scheduling deployment pods in
hostnetwork when node is reporting Network NotReady)

/cc @crawford 