### PR TITLE
Revert "switch workload resource to daemonset"

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -1,11 +1,9 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
 spec:
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: cluster-version-operator


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#35

In the 4.0 release, we want a deployment.  There is a suspect scheduling bug that must be resolved to switch back: https://bugzilla.redhat.com/show_bug.cgi?id=1638132 .

We made the change so we could remove a static pod that we don't want long term and ensure that bootstrapping sequence doesn't end up with accidental dependencies because of that.  

/hold

hold until the bug is fixed.

/assign @sjenning 
@sjenning I'm not sure who will be driving this change back in, but it's a thing we'll need to fix in 4.0 to avoid management issues related to a daemonset operator.

@abhinavdahiya fyi