### PR TITLE
WIP: cvo: Allow payloads to retrieve images from an alternate location

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -190,6 +190,18 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:d7da23741e2be291bda3be66c16887a9bbebf48a1ea133a5fcd210c02b8ccee0"
+  name = "github.com/openshift/library-go"
+  packages = [
+    "pkg/image/internal/digest",
+    "pkg/image/internal/reference",
+    "pkg/image/reference",
+  ]
+  pruneopts = "NUT"
+  revision = "c01b3a0b77b43b7de296d5a0df884da60a16d907"
+
+[[projects]]
+  branch = "master"
   digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
@@ -632,10 +644,10 @@
     "github.com/openshift/api/image/v1",
     "github.com/openshift/api/security/v1",
     "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1",
+    "github.com/openshift/library-go/pkg/image/reference",
     "github.com/spf13/cobra",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",
-    "k8s.io/api/batch/v1beta1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/api/rbac/v1beta1",

--- a/pkg/apis/clusterversion.openshift.io/v1/types.go
+++ b/pkg/apis/clusterversion.openshift.io/v1/types.go
@@ -70,4 +70,11 @@ type CVOStatus struct {
 type Update struct {
 	Version string `json:"version"`
 	Payload string `json:"payload"`
+
+	// PayloadRepository is an optional field that instructs the ClusterVersionOperator
+	// to load images in the payload from a specific image repository, instead of
+	// from the location the payload specified. The images are still loaded via their
+	// unique identifier (digest) in order to prevent the linked content from being
+	// altered. This value matches the location you mirror an update to.
+	PayloadRepository string `json:"payloadRepository"`
 }

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -235,7 +235,7 @@ func (optr *Operator) sync(key string) error {
 	if config.DesiredUpdate.Payload != "" {
 		releaseImage = config.DesiredUpdate.Payload
 	}
-	payload, err := loadUpdatePayload(payloadDir, releaseImage)
+	payload, err := loadUpdatePayload(payloadDir, releaseImage, config.DesiredUpdate.PayloadRepository)
 	if err != nil {
 		return err
 	}

--- a/pkg/cvo/image.go
+++ b/pkg/cvo/image.go
@@ -5,7 +5,7 @@ import "fmt"
 // ImageForShortName returns the image using the updatepayload embedded in
 // the Operator.
 func ImageForShortName(name string) (string, error) {
-	up, err := loadUpdatePayload(defaultUpdatePayloadDir, "")
+	up, err := loadUpdatePayload(defaultUpdatePayloadDir, "", "")
 	if err != nil {
 		return "", fmt.Errorf("error loading update payload from %q: %v", defaultUpdatePayloadDir, err)
 	}

--- a/pkg/cvo/override.go
+++ b/pkg/cvo/override.go
@@ -1,0 +1,68 @@
+package cvo
+
+import (
+	"fmt"
+	"regexp"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	imagereference "github.com/openshift/library-go/pkg/image/reference"
+)
+
+type manifestMapper func(data []byte) ([]byte, error)
+
+// exactImageFormat attempts to match a string on word boundaries
+const exactImageFormat = `\b%s\b`
+
+// newManifestOverrideMapper returns a function that will replace any image defined in imageRef
+// with a rewritten image inside of imageRepository that uses the same digest, ensuring the manifest
+// points to a different location. For example, if the imageRef contains a tag "etcd" pointing to
+// "quay.io/coreos/etcd@sha256:1234...", and imageRepository is set to "myregistry.com/mirror/v1.0",
+// any matching image reference in the manifest will be replaced with
+// "myregistry.com/mirror/v1.0@sha256:1234...". An error is returned if the imageRepository is not a
+// valid image reference as defined by the docker distribution spec, or if the input imageRef has
+// tags that point to invalid image references.
+func newManifestOverrideMapper(imageRepository string, imageRef *imagev1.ImageStream) (manifestMapper, error) {
+	ref, err := imagereference.Parse(imageRepository)
+	if err != nil {
+		return nil, fmt.Errorf("the payload repository is invalid: %v", err)
+	}
+	if len(ref.ID) > 0 || len(ref.Tag) > 0 {
+		return nil, fmt.Errorf("the payload repository may not have a tag or digest specified")
+	}
+
+	replacements := make(map[string]string)
+	for _, tag := range imageRef.Spec.Tags {
+		if tag.From == nil || tag.From.Kind != "DockerImage" {
+			continue
+		}
+		oldImage := tag.From.Name
+
+		oldRef, err := imagereference.Parse(oldImage)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse image reference for tag %q from payload: %v", tag.Name, err)
+		}
+		if len(oldRef.Tag) > 0 || len(oldRef.ID) == 0 {
+			return nil, fmt.Errorf("image reference tag %q in payload does not point to an image digest - unable to rewrite payload", tag.Name)
+		}
+		newRef := ref
+		newRef.ID = oldRef.ID
+		replacements[oldImage] = newRef.Exact()
+	}
+
+	patterns := make(map[string]*regexp.Regexp)
+	for from, to := range replacements {
+		pattern := fmt.Sprintf(exactImageFormat, regexp.QuoteMeta(from))
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		patterns[to] = re
+	}
+
+	return func(data []byte) ([]byte, error) {
+		for to, pattern := range patterns {
+			data = pattern.ReplaceAll(data, []byte(to))
+		}
+		return data, nil
+	}, nil
+}

--- a/pkg/cvo/override_test.go
+++ b/pkg/cvo/override_test.go
@@ -1,0 +1,140 @@
+package cvo
+
+import (
+	"strings"
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_newManifestOverrideMapper(t *testing.T) {
+	type args struct {
+		override string
+		imageRef *imagev1.ImageStream
+	}
+	imageRef1 := &imagev1.ImageStream{
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{Name: "image1", From: &corev1.ObjectReference{Kind: "DockerImage", Name: "reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289"}},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		input   string
+		output  string
+		wantErr string
+	}{
+		{
+			name: "replace at beginning of file",
+			args: args{
+				override: "reg2/repo2",
+				imageRef: imageRef1,
+			},
+			input:  "reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\n",
+			output: "reg2/repo2@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\n",
+		},
+		{
+			name: "replace at end of file",
+			args: args{
+				override: "reg2/repo2",
+				imageRef: imageRef1,
+			},
+			input:  "image: reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\n",
+			output: "image: reg2/repo2@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\n",
+		},
+		{
+			name: "replace in quotes",
+			args: args{
+				override: "reg2/repo2",
+				imageRef: imageRef1,
+			},
+			input:  "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			output: "image: \"reg2/repo2@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+		},
+		{
+			name: "skip - require kind DockerImage",
+			args: args{
+				override: "reg2/repo2",
+				imageRef: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "image1", From: &corev1.ObjectReference{Kind: "Other", Name: "reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289"}},
+						},
+					},
+				},
+			},
+			input:  "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			output: "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+		},
+		{
+			name: "error - ref is not parseable",
+			args: args{
+				override: "reg2/repo2",
+				imageRef: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "image1", From: &corev1.ObjectReference{Kind: "DockerImage", Name: "reg/repo@sha256:1234"}},
+						},
+					},
+				},
+			},
+			input:   "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			wantErr: "unable to parse image reference for tag \"image1\" from payload: invalid reference format",
+		},
+		{
+			name: "error - override has tag",
+			args: args{
+				override: "reg2/repo2:tag",
+				imageRef: imageRef1,
+			},
+			input:   "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			wantErr: "the payload repository may not have a tag or digest specified",
+		},
+		{
+			name: "error - override has valid digest",
+			args: args{
+				override: "reg2/repo2@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289",
+				imageRef: imageRef1,
+			},
+			input:   "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			wantErr: "the payload repository may not have a tag or digest specified",
+		},
+		{
+			name: "error - override has invalid digest (too short)",
+			args: args{
+				override: "reg2/repo2@sha256:e7b80",
+				imageRef: imageRef1,
+			},
+			input:   "image: \"reg/repo@sha256:e7b801fc86f79eefd63b881feb1d2a6dc00e7d79bbd09765a2c3efb3996a1289\"",
+			wantErr: "the payload repository is invalid: invalid reference format",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := newManifestOverrideMapper(tt.args.override, tt.args.imageRef)
+			if (err != nil) != (len(tt.wantErr) > 0) {
+				t.Fatal(err)
+			}
+			if err != nil {
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error did not contain %q: %v", tt.wantErr, err)
+				}
+				return
+			}
+			out, err := m([]byte(tt.input))
+			if (err != nil) != (len(tt.wantErr) > 0) {
+				t.Fatal(err)
+			}
+			if err != nil {
+				return
+			}
+			if string(out) != tt.output {
+				t.Errorf("unexpected output, wanted\n%s\ngot\n%s", tt.output, string(out))
+			}
+		})
+	}
+}

--- a/vendor/github.com/openshift/library-go/LICENSE
+++ b/vendor/github.com/openshift/library-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
@@ -1,0 +1,138 @@
+package digest
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Digest allows simple protection of hex formatted digest strings, prefixed
+// by their algorithm. Strings of type Digest have some guarantee of being in
+// the correct format and it provides quick access to the components of a
+// digest string.
+//
+// The following is an example of the contents of Digest types:
+//
+// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//
+// This allows to abstract the digest behind this type and work only in those
+// terms.
+type Digest string
+
+// NewDigest returns a Digest from alg and a hash.Hash object.
+func NewDigest(alg Algorithm, h hash.Hash) Digest {
+	return NewDigestFromBytes(alg, h.Sum(nil))
+}
+
+// NewDigestFromBytes returns a new digest from the byte contents of p.
+// Typically, this can come from hash.Hash.Sum(...) or xxx.SumXXX(...)
+// functions. This is also useful for rebuilding digests from binary
+// serializations.
+func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
+	return Digest(fmt.Sprintf("%s:%x", alg, p))
+}
+
+// NewDigestFromHex returns a Digest from alg and a the hex encoded digest.
+func NewDigestFromHex(alg, hex string) Digest {
+	return Digest(fmt.Sprintf("%s:%s", alg, hex))
+}
+
+// DigestRegexp matches valid digest types.
+var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
+
+// DigestRegexpAnchored matches valid digest types, anchored to the start and end of the match.
+var DigestRegexpAnchored = regexp.MustCompile(`^` + DigestRegexp.String() + `$`)
+
+var (
+	// ErrDigestInvalidFormat returned when digest format invalid.
+	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
+
+	// ErrDigestInvalidLength returned when digest has invalid length.
+	ErrDigestInvalidLength = fmt.Errorf("invalid checksum digest length")
+
+	// ErrDigestUnsupported returned when the digest algorithm is unsupported.
+	ErrDigestUnsupported = fmt.Errorf("unsupported digest algorithm")
+)
+
+// ParseDigest parses s and returns the validated digest object. An error will
+// be returned if the format is invalid.
+func ParseDigest(s string) (Digest, error) {
+	d := Digest(s)
+
+	return d, d.Validate()
+}
+
+// FromReader returns the most valid digest for the underlying content using
+// the canonical digest algorithm.
+func FromReader(rd io.Reader) (Digest, error) {
+	return Canonical.FromReader(rd)
+}
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) Digest {
+	return Canonical.FromBytes(p)
+}
+
+// Validate checks that the contents of d is a valid digest, returning an
+// error if not.
+func (d Digest) Validate() error {
+	s := string(d)
+
+	if !DigestRegexpAnchored.MatchString(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return ErrDigestInvalidFormat
+	}
+
+	// case: "sha256:" with no hex.
+	if i+1 == len(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	switch algorithm := Algorithm(s[:i]); algorithm {
+	case SHA256, SHA384, SHA512:
+		if algorithm.Size()*2 != len(s[i+1:]) {
+			return ErrDigestInvalidLength
+		}
+	default:
+		return ErrDigestUnsupported
+	}
+
+	return nil
+}
+
+// Algorithm returns the algorithm portion of the digest. This will panic if
+// the underlying digest is not in a valid format.
+func (d Digest) Algorithm() Algorithm {
+	return Algorithm(d[:d.sepIndex()])
+}
+
+// Hex returns the hex digest portion of the digest. This will panic if the
+// underlying digest is not in a valid format.
+func (d Digest) Hex() string {
+	return string(d[d.sepIndex()+1:])
+}
+
+func (d Digest) String() string {
+	return string(d)
+}
+
+func (d Digest) sepIndex() int {
+	i := strings.Index(string(d), ":")
+
+	if i < 0 {
+		panic("could not find ':' in digest: " + d)
+	}
+
+	return i
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
@@ -1,0 +1,155 @@
+package digest
+
+import (
+	"crypto"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// Algorithm identifies and implementation of a digester by an identifier.
+// Note the that this defines both the hash algorithm used and the string
+// encoding.
+type Algorithm string
+
+// supported digest types
+const (
+	SHA256 Algorithm = "sha256" // sha256 with hex encoding
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding
+
+	// Canonical is the primary digest algorithm used with the distribution
+	// project. Other digests may be used but this one is the primary storage
+	// digest.
+	Canonical = SHA256
+)
+
+var (
+	// TODO(stevvooe): Follow the pattern of the standard crypto package for
+	// registration of digests. Effectively, we are a registerable set and
+	// common symbol access.
+
+	// algorithms maps values to hash.Hash implementations. Other algorithms
+	// may be available but they cannot be calculated by the digest package.
+	algorithms = map[Algorithm]crypto.Hash{
+		SHA256: crypto.SHA256,
+		SHA384: crypto.SHA384,
+		SHA512: crypto.SHA512,
+	}
+)
+
+// Available returns true if the digest type is available for use. If this
+// returns false, New and Hash will return nil.
+func (a Algorithm) Available() bool {
+	h, ok := algorithms[a]
+	if !ok {
+		return false
+	}
+
+	// check availability of the hash, as well
+	return h.Available()
+}
+
+func (a Algorithm) String() string {
+	return string(a)
+}
+
+// Size returns number of bytes returned by the hash.
+func (a Algorithm) Size() int {
+	h, ok := algorithms[a]
+	if !ok {
+		return 0
+	}
+	return h.Size()
+}
+
+// Set implemented to allow use of Algorithm as a command line flag.
+func (a *Algorithm) Set(value string) error {
+	if value == "" {
+		*a = Canonical
+	} else {
+		// just do a type conversion, support is queried with Available.
+		*a = Algorithm(value)
+	}
+
+	return nil
+}
+
+// New returns a new digester for the specified algorithm. If the algorithm
+// does not have a digester implementation, nil will be returned. This can be
+// checked by calling Available before calling New.
+func (a Algorithm) New() Digester {
+	return &digester{
+		alg:  a,
+		hash: a.Hash(),
+	}
+}
+
+// Hash returns a new hash as used by the algorithm. If not available, the
+// method will panic. Check Algorithm.Available() before calling.
+func (a Algorithm) Hash() hash.Hash {
+	if !a.Available() {
+		// NOTE(stevvooe): A missing hash is usually a programming error that
+		// must be resolved at compile time. We don't import in the digest
+		// package to allow users to choose their hash implementation (such as
+		// when using stevvooe/resumable or a hardware accelerated package).
+		//
+		// Applications that may want to resolve the hash at runtime should
+		// call Algorithm.Available before call Algorithm.Hash().
+		panic(fmt.Sprintf("%v not available (make sure it is imported)", a))
+	}
+
+	return algorithms[a].New()
+}
+
+// FromReader returns the digest of the reader using the algorithm.
+func (a Algorithm) FromReader(rd io.Reader) (Digest, error) {
+	digester := a.New()
+
+	if _, err := io.Copy(digester.Hash(), rd); err != nil {
+		return "", err
+	}
+
+	return digester.Digest(), nil
+}
+
+// FromBytes digests the input and returns a Digest.
+func (a Algorithm) FromBytes(p []byte) Digest {
+	digester := a.New()
+
+	if _, err := digester.Hash().Write(p); err != nil {
+		// Writes to a Hash should never fail. None of the existing
+		// hash implementations in the stdlib or hashes vendored
+		// here can return errors from Write. Having a panic in this
+		// condition instead of having FromBytes return an error value
+		// avoids unnecessary error handling paths in all callers.
+		panic("write to hash function returned error: " + err.Error())
+	}
+
+	return digester.Digest()
+}
+
+// TODO(stevvooe): Allow resolution of verifiers using the digest type and
+// this registration system.
+
+// Digester calculates the digest of written data. Writes should go directly
+// to the return value of Hash, while calling Digest will return the current
+// value of the digest.
+type Digester interface {
+	Hash() hash.Hash // provides direct access to underlying hash instance.
+	Digest() Digest
+}
+
+// digester provides a simple digester definition that embeds a hasher.
+type digester struct {
+	alg  Algorithm
+	hash hash.Hash
+}
+
+func (d *digester) Hash() hash.Hash {
+	return d.hash
+}
+
+func (d *digester) Digest() Digest {
+	return NewDigest(d.alg, d.hash)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
@@ -1,0 +1,5 @@
+// digest is a copy from "github.com/docker/distribution/digest" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package digest

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
@@ -1,0 +1,5 @@
+// reference is a copy from "github.com/docker/distribution/reference" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package reference

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
@@ -1,0 +1,370 @@
+// Package reference provides a general type to represent any way of referencing images within the registry.
+// Its main purpose is to abstract tags and digests (content-addressable hash).
+//
+// Grammar
+//
+// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	name                            := [hostname '/'] component ['/' component]*
+//	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	port-number                     := /[0-9]+/
+//	component                       := alpha-numeric [separator alpha-numeric]*
+// 	alpha-numeric                   := /[a-z0-9]+/
+//	separator                       := /[_.]|__|[-]*/
+//
+//	tag                             := /[\w][\w.-]{0,127}/
+//
+//	digest                          := digest-algorithm ":" digest-hex
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm-separator      := /[+.-_]/
+//	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+//	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+package reference
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+)
+
+const (
+	// NameTotalLengthMax is the maximum total number of characters in a repository name.
+	NameTotalLengthMax = 255
+)
+
+var (
+	// ErrReferenceInvalidFormat represents an error while trying to parse a string as a reference.
+	ErrReferenceInvalidFormat = errors.New("invalid reference format")
+
+	// ErrTagInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrTagInvalidFormat = errors.New("invalid tag format")
+
+	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameContainsUppercase is returned for invalid repository names that contain uppercase characters.
+	ErrNameContainsUppercase = errors.New("repository name must be lowercase")
+
+	// ErrNameEmpty is returned for empty, invalid repository names.
+	ErrNameEmpty = errors.New("repository name must have at least one component")
+
+	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Field provides a wrapper type for resolving correct reference types when
+// working with encoding.
+type Field struct {
+	reference Reference
+}
+
+// AsField wraps a reference in a Field for encoding.
+func AsField(reference Reference) Field {
+	return Field{reference}
+}
+
+// Reference unwraps the reference type from the field to
+// return the Reference object. This object should be
+// of the appropriate type to further check for different
+// reference types.
+func (f Field) Reference() Reference {
+	return f.reference
+}
+
+// MarshalText serializes the field to byte text which
+// is the string of the reference.
+func (f Field) MarshalText() (p []byte, err error) {
+	return []byte(f.reference.String()), nil
+}
+
+// UnmarshalText parses text bytes by invoking the
+// reference parser to ensure the appropriately
+// typed reference object is wrapped by field.
+func (f *Field) UnmarshalText(p []byte) error {
+	r, err := Parse(string(p))
+	if err != nil {
+		return err
+	}
+
+	f.reference = r
+	return nil
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// Tagged is an object which has a tag
+type Tagged interface {
+	Reference
+	Tag() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Digested is an object which has a digest
+// in which it can be referenced by
+type Digested interface {
+	Reference
+	Digest() digest.Digest
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with hostname and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// SplitHostname splits a named reference into a
+// hostname and name string. If no valid hostname is
+// found, the hostname is empty and the full value
+// is returned as name
+func SplitHostname(named Named) (string, string) {
+	name := named.Name()
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if len(match) != 3 {
+		return "", name
+	}
+	return match[1], match[2]
+}
+
+// Parse parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: Parse will not handle short digests.
+func Parse(s string) (Reference, error) {
+	matches := ReferenceRegexp.FindStringSubmatch(s)
+	if matches == nil {
+		if s == "" {
+			return nil, ErrNameEmpty
+		}
+		if ReferenceRegexp.FindStringSubmatch(strings.ToLower(s)) != nil {
+			return nil, ErrNameContainsUppercase
+		}
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(matches[1]) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	ref := reference{
+		name: matches[1],
+		tag:  matches[2],
+	}
+	if matches[3] != "" {
+		var err error
+		ref.digest, err = digest.ParseDigest(matches[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	r := getBestReferenceType(ref)
+	if r == nil {
+		return nil, ErrNameEmpty
+	}
+
+	return r, nil
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name, otherwise an error is
+// returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	ref, err := Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	named, isNamed := ref.(Named)
+	if !isNamed {
+		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	}
+	return named, nil
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	if len(name) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+	if !anchoredNameRegexp.MatchString(name) {
+		return nil, ErrReferenceInvalidFormat
+	}
+	return repository(name), nil
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	if !anchoredTagRegexp.MatchString(tag) {
+		return nil, ErrTagInvalidFormat
+	}
+	if canonical, ok := name.(Canonical); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tag,
+			digest: canonical.Digest(),
+		}, nil
+	}
+	return taggedReference{
+		name: name.Name(),
+		tag:  tag,
+	}, nil
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	if !anchoredDigestRegexp.MatchString(digest.String()) {
+		return nil, ErrDigestInvalidFormat
+	}
+	if tagged, ok := name.(Tagged); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tagged.Tag(),
+			digest: digest,
+		}, nil
+	}
+	return canonicalReference{
+		name:   name.Name(),
+		digest: digest,
+	}, nil
+}
+
+// Match reports whether ref matches the specified pattern.
+// See https://godoc.org/path#Match for supported patterns.
+func Match(pattern string, ref Reference) (bool, error) {
+	matched, err := path.Match(pattern, ref.String())
+	if namedRef, isNamed := ref.(Named); isNamed && !matched {
+		matched, _ = path.Match(pattern, namedRef.Name())
+	}
+	return matched, err
+}
+
+// TrimNamed removes any tag or digest from the named reference.
+func TrimNamed(ref Named) Named {
+	return repository(ref.Name())
+}
+
+func getBestReferenceType(ref reference) Reference {
+	if ref.name == "" {
+		// Allow digest only references
+		if ref.digest != "" {
+			return digestReference(ref.digest)
+		}
+		return nil
+	}
+	if ref.tag == "" {
+		if ref.digest != "" {
+			return canonicalReference{
+				name:   ref.name,
+				digest: ref.digest,
+			}
+		}
+		return repository(ref.name)
+	}
+	if ref.digest == "" {
+		return taggedReference{
+			name: ref.name,
+			tag:  ref.tag,
+		}
+	}
+
+	return ref
+}
+
+type reference struct {
+	name   string
+	tag    string
+	digest digest.Digest
+}
+
+func (r reference) String() string {
+	return r.name + ":" + r.tag + "@" + r.digest.String()
+}
+
+func (r reference) Name() string {
+	return r.name
+}
+
+func (r reference) Tag() string {
+	return r.tag
+}
+
+func (r reference) Digest() digest.Digest {
+	return r.digest
+}
+
+type repository string
+
+func (r repository) String() string {
+	return string(r)
+}
+
+func (r repository) Name() string {
+	return string(r)
+}
+
+type digestReference digest.Digest
+
+func (d digestReference) String() string {
+	return string(d)
+}
+
+func (d digestReference) Digest() digest.Digest {
+	return digest.Digest(d)
+}
+
+type taggedReference struct {
+	name string
+	tag  string
+}
+
+func (t taggedReference) String() string {
+	return t.name + ":" + t.tag
+}
+
+func (t taggedReference) Name() string {
+	return t.name
+}
+
+func (t taggedReference) Tag() string {
+	return t.tag
+}
+
+type canonicalReference struct {
+	name   string
+	digest digest.Digest
+}
+
+func (c canonicalReference) String() string {
+	return c.name + "@" + c.digest.String()
+}
+
+func (c canonicalReference) Name() string {
+	return c.name
+}
+
+func (c canonicalReference) Digest() digest.Digest {
+	return c.digest
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
@@ -1,0 +1,124 @@
+package reference
+
+import "regexp"
+
+var (
+	// alphaNumericRegexp defines the alpha numeric atom, typically a
+	// component of names. This only allows lower case characters and digits.
+	alphaNumericRegexp = match(`[a-z0-9]+`)
+
+	// separatorRegexp defines the separators allowed to be embedded in name
+	// components. This allow one period, one or two underscore and multiple
+	// dashes.
+	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+
+	// nameComponentRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponentRegexp = expression(
+		alphaNumericRegexp,
+		optional(repeated(separatorRegexp, alphaNumericRegexp)))
+
+	// hostnameComponentRegexp restricts the registry hostname component of a
+	// repository name to start with a component as defined by hostnameRegexp
+	// and followed by an optional port.
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+
+	// hostnameRegexp defines the structure of potential hostname components
+	// that may be part of image names. This is purposely a subset of what is
+	// allowed by DNS to ensure backwards compatibility with Docker image
+	// names.
+	hostnameRegexp = expression(
+		hostnameComponentRegexp,
+		optional(repeated(literal(`.`), hostnameComponentRegexp)),
+		optional(literal(`:`), match(`[0-9]+`)))
+
+	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
+	TagRegexp = match(`[\w][\w.-]{0,127}`)
+
+	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// end of the matched string.
+	anchoredTagRegexp = anchored(TagRegexp)
+
+	// DigestRegexp matches valid digests.
+	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
+
+	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// end of the matched string.
+	anchoredDigestRegexp = anchored(DigestRegexp)
+
+	// NameRegexp is the format for the name component of references. The
+	// regexp has capturing groups for the hostname and name part omitting
+	// the separating forward slash from either.
+	NameRegexp = expression(
+		optional(hostnameRegexp, literal(`/`)),
+		nameComponentRegexp,
+		optional(repeated(literal(`/`), nameComponentRegexp)))
+
+	// anchoredNameRegexp is used to parse a name value, capturing the
+	// hostname and trailing components.
+	anchoredNameRegexp = anchored(
+		optional(capture(hostnameRegexp), literal(`/`)),
+		capture(nameComponentRegexp,
+			optional(repeated(literal(`/`), nameComponentRegexp))))
+
+	// ReferenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	ReferenceRegexp = anchored(capture(NameRegexp),
+		optional(literal(":"), capture(TagRegexp)),
+		optional(literal("@"), capture(DigestRegexp)))
+)
+
+// match compiles the string to a regular expression.
+var match = regexp.MustCompile
+
+// literal compiles s into a literal regular expression, escaping any regexp
+// reserved characters.
+func literal(s string) *regexp.Regexp {
+	re := match(regexp.QuoteMeta(s))
+
+	if _, complete := re.LiteralPrefix(); !complete {
+		panic("must be a literal")
+	}
+
+	return re
+}
+
+// expression defines a full expression, where each regular expression must
+// follow the previous.
+func expression(res ...*regexp.Regexp) *regexp.Regexp {
+	var s string
+	for _, re := range res {
+		s += re.String()
+	}
+
+	return match(s)
+}
+
+// optional wraps the expression in a non-capturing group and makes the
+// production optional.
+func optional(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `?`)
+}
+
+// repeated wraps the regexp in a non-capturing group to get one or more
+// matches.
+func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `+`)
+}
+
+// group wraps the regexp in a non-capturing group.
+func group(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `)`)
+}
+
+// capture wraps the expression in a capturing group.
+func capture(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(` + expression(res...).String() + `)`)
+}
+
+// anchored anchors the regular expression by adding start and end delimiters.
+func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`^` + expression(res...).String() + `$`)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
@@ -1,0 +1,245 @@
+package reference
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+	"github.com/openshift/library-go/pkg/image/internal/reference"
+)
+
+// DockerImageReference points to a Docker image.
+type DockerImageReference struct {
+	Registry  string
+	Namespace string
+	Name      string
+	Tag       string
+	ID        string
+}
+
+const (
+	// DockerDefaultRegistry is the value for the registry when none was provided.
+	DockerDefaultRegistry = "docker.io"
+	// DockerDefaultV1Registry is the host name of the default v1 registry
+	DockerDefaultV1Registry = "index." + DockerDefaultRegistry
+	// DockerDefaultV2Registry is the host name of the default v2 registry
+	DockerDefaultV2Registry = "registry-1." + DockerDefaultRegistry
+)
+
+// Parse parses a Docker pull spec string into a
+// DockerImageReference.
+func Parse(spec string) (DockerImageReference, error) {
+	var ref DockerImageReference
+
+	namedRef, err := reference.ParseNamed(spec)
+	if err != nil {
+		return ref, err
+	}
+
+	name := namedRef.Name()
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ":.") && name[:i] != "localhost") {
+		ref.Name = name
+	} else {
+		ref.Registry, ref.Name = name[:i], name[i+1:]
+	}
+
+	if named, ok := namedRef.(reference.NamedTagged); ok {
+		ref.Tag = named.Tag()
+	}
+
+	if named, ok := namedRef.(reference.Canonical); ok {
+		ref.ID = named.Digest().String()
+	}
+
+	// It's not enough just to use the reference.ParseNamed(). We have to fill
+	// ref.Namespace from ref.Name
+	if i := strings.IndexRune(ref.Name, '/'); i != -1 {
+		ref.Namespace, ref.Name = ref.Name[:i], ref.Name[i+1:]
+	}
+
+	return ref, nil
+}
+
+// Equal returns true if the other DockerImageReference is equivalent to the
+// reference r. The comparison applies defaults to the Docker image reference,
+// so that e.g., "foobar" equals "docker.io/library/foobar:latest".
+func (r DockerImageReference) Equal(other DockerImageReference) bool {
+	defaultedRef := r.DockerClientDefaults()
+	otherDefaultedRef := other.DockerClientDefaults()
+	return defaultedRef == otherDefaultedRef
+}
+
+// DockerClientDefaults sets the default values used by the Docker client.
+func (r DockerImageReference) DockerClientDefaults() DockerImageReference {
+	if len(r.Registry) == 0 {
+		r.Registry = DockerDefaultRegistry
+	}
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	if len(r.Tag) == 0 {
+		r.Tag = "latest"
+	}
+	return r
+}
+
+// Minimal reduces a DockerImageReference to its minimalist form.
+func (r DockerImageReference) Minimal() DockerImageReference {
+	if r.Tag == "latest" {
+		r.Tag = ""
+	}
+	return r
+}
+
+// AsRepository returns the reference without tags or IDs.
+func (r DockerImageReference) AsRepository() DockerImageReference {
+	r.Tag = ""
+	r.ID = ""
+	return r
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RepositoryName() string {
+	r.Tag = ""
+	r.ID = ""
+	r.Registry = ""
+	return r.Exact()
+}
+
+// RegistryHostPort returns the registry hostname and the port.
+// If the port is not specified in the registry hostname we default to 443.
+// This will also default to Docker client defaults if the registry hostname is empty.
+func (r DockerImageReference) RegistryHostPort(insecure bool) (string, string) {
+	registryHost := r.AsV2().DockerClientDefaults().Registry
+	if strings.Contains(registryHost, ":") {
+		hostname, port, _ := net.SplitHostPort(registryHost)
+		return hostname, port
+	}
+	if insecure {
+		return registryHost, "80"
+	}
+	return registryHost, "443"
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RegistryURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   r.AsV2().Registry,
+	}
+}
+
+// DaemonMinimal clears defaults that Docker assumes.
+func (r DockerImageReference) DaemonMinimal() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultV2Registry:
+		r.Registry = DockerDefaultRegistry
+	}
+	if IsRegistryDockerHub(r.Registry) && r.Namespace == "library" {
+		r.Namespace = ""
+	}
+	return r.Minimal()
+}
+
+func (r DockerImageReference) AsV2() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultRegistry:
+		r.Registry = DockerDefaultV2Registry
+	}
+	return r
+}
+
+// MostSpecific returns the most specific image reference that can be constructed from the
+// current ref, preferring an ID over a Tag. Allows client code dealing with both tags and IDs
+// to get the most specific reference easily.
+func (r DockerImageReference) MostSpecific() DockerImageReference {
+	if len(r.ID) == 0 {
+		return r
+	}
+	if _, err := digest.ParseDigest(r.ID); err == nil {
+		r.Tag = ""
+		return r
+	}
+	if len(r.Tag) == 0 {
+		r.Tag, r.ID = r.ID, ""
+		return r
+	}
+	return r
+}
+
+// NameString returns the name of the reference with its tag or ID.
+func (r DockerImageReference) NameString() string {
+	switch {
+	case len(r.Name) == 0:
+		return ""
+	case len(r.Tag) > 0:
+		return r.Name + ":" + r.Tag
+	case len(r.ID) > 0:
+		var ref string
+		if _, err := digest.ParseDigest(r.ID); err == nil {
+			// if it parses as a digest, its v2 pull by id
+			ref = "@" + r.ID
+		} else {
+			// if it doesn't parse as a digest, it's presumably a v1 registry by-id tag
+			ref = ":" + r.ID
+		}
+		return r.Name + ref
+	default:
+		return r.Name
+	}
+}
+
+// Exact returns a string representation of the set fields on the DockerImageReference
+func (r DockerImageReference) Exact() string {
+	name := r.NameString()
+	if len(name) == 0 {
+		return name
+	}
+	s := r.Registry
+	if len(s) > 0 {
+		s += "/"
+	}
+
+	if len(r.Namespace) != 0 {
+		s += r.Namespace + "/"
+	}
+	return s + name
+}
+
+// String converts a DockerImageReference to a Docker pull spec (which implies a default namespace
+// according to V1 Docker registry rules). Use Exact() if you want no defaulting.
+func (r DockerImageReference) String() string {
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	return r.Exact()
+}
+
+// IsRegistryDockerHub returns true if the given registry name belongs to
+// Docker hub.
+func IsRegistryDockerHub(registry string) bool {
+	switch registry {
+	case DockerDefaultRegistry, DockerDefaultV1Registry, DockerDefaultV2Registry:
+		return true
+	default:
+		return false
+	}
+}
+
+// DeepCopyInto writing into out. in must be non-nil.
+func (in *DockerImageReference) DeepCopyInto(out *DockerImageReference) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver, creating a new DockerImageReference.
+func (in *DockerImageReference) DeepCopy() *DockerImageReference {
+	if in == nil {
+		return nil
+	}
+	out := new(DockerImageReference)
+	in.DeepCopyInto(out)
+	return out
+}


### PR DESCRIPTION
NOTE: Not a complete implementation, just creating prototype code I can test in an install.  Design coming after I poke around.

JIRA: https://jira.coreos.com/browse/CORS-715

Allow a payload to specify an alternate image repository to use instead of
using the location the payload specifies. When manifests are being
pre-processed, the following algorithm is applied:

1. search the manifest for any string that matches the name of an image
   defined in image-references (with leading and trailing word breaks) 
2. parse the image location, replacing all but the digest with the new
   payloadRepository 
3. replace the string in the manifest with the new location

When the CVO applies the payload, images will be fetched from the override
location rather than the location the payload defined. However, since we
preserve the digest, we ensure that the contents still match.

TODO:

* [ ] explore how installer can accept the mirror location (either accept a mirror location on install or we just force people to rewrite during mirroring - advantages to either)
* [ ] consider moving payload repository to the root of CVOConfig (disadvantage is you can't turn off mirroring by selecting an update from the cloud)