### PR TITLE
api: Add stub ClusterVersion CRD so that installer can reference it

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: clusterversions.config.openshift.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: config.openshift.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+  # either Namespaced or Cluster
+  scope: Cluster
+  subresources:
+    # enable spec/status
+    status: {}
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: clusterversions
+    # singular name to be used as an alias on the CLI and for display
+    singular: clusterversion
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: ClusterVersion
+  additionalPrinterColumns:
+  - name: Version
+    type: string
+    JSONPath: .status.current.version
+  - name: Available
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Available")].status
+  - name: Progressing
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Progressing")].status
+  - name: Since
+    type: date
+    JSONPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+  - name: Status
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Progressing")].message


### PR DESCRIPTION
Create the new API definition for CRD so installer can start creating
the new object. Extracted from PR #45, no changes.