### PR TITLE
cvo: Report errors to conditions more consistently

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -221,6 +221,14 @@
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   digest = "1:aa2da1df3327c3a338bb42f978407c07de74cd0a5bef35e9411881dffd444214"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -693,8 +701,10 @@
     "github.com/openshift/api/image/v1",
     "github.com/openshift/api/security/v1",
     "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1",
+    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/client_model/go",
     "github.com/spf13/cobra",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",
@@ -705,7 +715,6 @@
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions",
-    "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -731,7 +740,6 @@
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/informers",
-    "k8s.io/client-go/informers/apps/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/apps/v1",

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -2,6 +2,20 @@
 
 The Cluster Version Operator reports the following metrics:
 
+Core metrics for the version
+
+```
+# HELP cluster_version Reports the version of the cluster.
+# TYPE cluster_version gauge
+cluster_version{payload="test/image:1",type="current",version="4.0.2"} 1
+cluster_version{payload="test/image:1",type="failure",version="4.0.2"} 1
+# HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
+# TYPE cluster_version_available_updates gauge
+cluster_version_available_updates{channel="fast",upstream="http://localhost:8080/graph"} 0
+```
+
+Metrics about cluster operators:
+
 ```
 # HELP cluster_operator_conditions Report the conditions for active cluster operators. 0 is False and 1 is True.
 # TYPE cluster_operator_conditions gauge
@@ -12,10 +26,16 @@ cluster_operator_conditions{condition="RetrievedUpdates",name="version",namespac
 # HELP cluster_operator_up Reports key highlights of the active cluster operators.
 # TYPE cluster_operator_up gauge
 cluster_operator_up{name="version",namespace="openshift-cluster-version",version="4.0.1"} 1
-# HELP cluster_version Reports the version of the cluster.
-# TYPE cluster_version gauge
-cluster_version{payload="test/image:1",type="current",version="4.0.2"} 1
-# HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
-# TYPE cluster_version_available_updates gauge
-cluster_version_available_updates{channel="fast",upstream="http://localhost:8080/graph"} 0
+```
+
+Metrics reported while applying the payload:
+
+```
+# HELP cluster_version_payload Report the number of entries in the payload.
+# TYPE cluster_version_payload gauge
+cluster_version_payload{type="applied",version="4.0.3"} 0
+cluster_version_payload{type="pending",version="4.0.3"} 1
+# HELP cluster_operator_payload_errors Report the number of errors encountered applying the payload.
+# TYPE cluster_operator_payload_errors gauge
+cluster_operator_payload_errors{version="4.0.3"} 10
 ```

--- a/lib/resourceapply/cv.go
+++ b/lib/resourceapply/cv.go
@@ -41,8 +41,7 @@ func ApplyClusterVersionFromCache(lister cvlistersv1.ClusterVersionLister, clien
 	}
 
 	// Don't want to mutate cache.
-	existing := new(cvv1.ClusterVersion)
-	obj.DeepCopyInto(existing)
+	existing := obj.DeepCopy()
 	modified := pointer.BoolPtr(false)
 	resourcemerge.EnsureClusterVersion(modified, existing, *required)
 	if !*modified {

--- a/lib/resourcemerge/os.go
+++ b/lib/resourcemerge/os.go
@@ -93,3 +93,17 @@ func IsOperatorStatusConditionPresentAndEqual(conditions []osv1.ClusterOperatorS
 	}
 	return false
 }
+
+func IsOperatorStatusConditionNotIn(conditions []osv1.ClusterOperatorStatusCondition, conditionType osv1.ClusterStatusConditionType, status ...osv1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			for _, s := range status {
+				if s == condition.Status {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return true
+}

--- a/pkg/cvo/internal/dynamicclient/client.go
+++ b/pkg/cvo/internal/dynamicclient/client.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -66,7 +68,7 @@ func (c *resourceClientFactory) getResourceClient(gvk schema.GroupVersionKind, n
 		gvr, namespaced, err = gvkToGVR(gvk, c.restMapper)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get resource type: %v", err)
+		return nil, errors.WithMessage(err, fmt.Sprintf("failed to get resource type: %v", err))
 	}
 
 	// sometimes manifests of non-namespaced resources
@@ -85,7 +87,7 @@ func gvkToGVR(gvk schema.GroupVersionKind, restMapper *restmapper.DeferredDiscov
 		return nil, false, err
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to get the resource REST mapping for GroupVersionKind(%s): %v", gvk.String(), err)
+		return nil, false, errors.WithMessage(err, fmt.Sprintf("failed to get the resource REST mapping for GroupVersionKind(%s): ", gvk.String()))
 	}
 
 	return &mapping.Resource, mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -94,7 +94,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			name: "collects available updates",
 			optr: &Operator{
 				name: "test",
-				cvoConfigLister: &cvLister{
+				cvLister: &cvLister{
 					Items: []*cvv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -122,7 +122,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			name: "collects available updates and reports 0 when updates fetched",
 			optr: &Operator{
 				name: "test",
-				cvoConfigLister: &cvLister{
+				cvLister: &cvLister{
 					Items: []*cvv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -151,7 +151,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
 				name:           "test",
-				cvoConfigLister: &cvLister{
+				cvLister: &cvLister{
 					Items: []*cvv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -178,7 +178,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
 				name:           "test",
-				cvoConfigLister: &cvLister{
+				cvLister: &cvLister{
 					Items: []*cvv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -212,7 +212,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
 				name:           "test",
-				cvoConfigLister: &cvLister{
+				cvLister: &cvLister{
 					Items: []*cvv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -238,8 +238,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.optr.cvoConfigLister == nil {
-				tt.optr.cvoConfigLister = &cvLister{}
+			if tt.optr.cvLister == nil {
+				tt.optr.cvLister = &cvLister{}
 			}
 			if tt.optr.clusterOperatorLister == nil {
 				tt.optr.clusterOperatorLister = &coLister{}

--- a/pkg/cvo/sync.go
+++ b/pkg/cvo/sync.go
@@ -2,10 +2,15 @@ package cvo
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/cluster-version-operator/lib"
@@ -29,8 +34,14 @@ func (optr *Operator) loadUpdatePayload(config *cvv1.ClusterVersion) (*updatePay
 
 // syncUpdatePayload applies the manifests in the payload to the cluster.
 func (optr *Operator) syncUpdatePayload(config *cvv1.ClusterVersion, payload *updatePayload) error {
-	for _, manifest := range payload.manifests {
-		taskName := fmt.Sprintf("(%s) %s/%s", manifest.GVK.String(), manifest.Object().GetNamespace(), manifest.Object().GetName())
+	version := payload.releaseVersion
+	if len(version) == 0 {
+		version = payload.releaseImage
+	}
+	for i, manifest := range payload.manifests {
+		metricPayload.WithLabelValues(version, "pending").Set(float64(len(payload.manifests) - i))
+		metricPayload.WithLabelValues(version, "applied").Set(float64(i))
+		taskName := taskName(&manifest, i+1, len(payload.manifests))
 		glog.V(4).Infof("Running sync for %s", taskName)
 		glog.V(6).Infof("Manifest: %s", string(manifest.Raw))
 
@@ -40,6 +51,7 @@ func (optr *Operator) syncUpdatePayload(config *cvv1.ClusterVersion, payload *up
 			continue
 		}
 
+		var lastErr error
 		if err := wait.ExponentialBackoff(wait.Backoff{
 			Duration: time.Second * 10,
 			Factor:   1.3,
@@ -54,22 +66,117 @@ func (optr *Operator) syncUpdatePayload(config *cvv1.ClusterVersion, payload *up
 				b, err = internal.NewGenericBuilder(optr.restConfig, manifest)
 			}
 			if err != nil {
-				glog.Errorf("error creating resourcebuilder for %s: %v", taskName, err)
+				utilruntime.HandleError(fmt.Errorf("error creating resourcebuilder for %s: %v", taskName, err))
+				lastErr = err
+				metricPayloadErrors.WithLabelValues(version).Inc()
 				return false, nil
 			}
 			// run builder for the manifest
 			if err := b.Do(); err != nil {
-				glog.Errorf("error running apply for %s: %v", taskName, err)
+				utilruntime.HandleError(fmt.Errorf("error running apply for %s: %v", taskName, err))
+				lastErr = err
+				metricPayloadErrors.WithLabelValues(version).Inc()
 				return false, nil
 			}
 			return true, nil
 		}); err != nil {
-			return fmt.Errorf("timed out trying to apply %s", taskName)
+			reason, cause := reasonForPayloadSyncError(lastErr)
+			if len(cause) > 0 {
+				cause = ": " + cause
+			}
+			return &updateError{
+				Reason:  reason,
+				Message: fmt.Sprintf("Could not update %s%s", taskName, cause),
+			}
 		}
 
 		glog.V(4).Infof("Done syncing for %s", taskName)
 	}
+	metricPayload.WithLabelValues(version, "applied").Set(float64(len(payload.manifests)))
+	metricPayload.WithLabelValues(version, "pending").Set(0)
 	return nil
+}
+
+type updateError struct {
+	Reason  string
+	Message string
+}
+
+func (e *updateError) Error() string {
+	return e.Message
+}
+
+// reasonForUpdateError provides a succint explanation of a known error type for use in a human readable
+// message during update. Since all objects in the payload should be successfully applied, messages
+// should direct the reader (likely a cluster administrator) to a possible cause in their own config.
+func reasonForPayloadSyncError(err error) (string, string) {
+	err = errors.Cause(err)
+	switch {
+	case apierrors.IsNotFound(err), apierrors.IsAlreadyExists(err):
+		return "UpdatePayloadResourceNotFound", "resource may have been deleted"
+	case apierrors.IsConflict(err):
+		return "UpdatePayloadResourceConflict", "someone else is updating this resource"
+	case apierrors.IsTimeout(err), apierrors.IsServiceUnavailable(err), apierrors.IsUnexpectedServerError(err):
+		return "UpdatePayloadClusterDown", "the server is down or not responding"
+	case apierrors.IsInternalError(err):
+		return "UpdatePayloadClusterError", "the server is reporting an internal error"
+	case apierrors.IsInvalid(err):
+		return "UpdatePayloadResourceInvalid", "the object is invalid, possibly due to local cluster configuration"
+	case apierrors.IsUnauthorized(err):
+		return "UpdatePayloadClusterUnauthorized", "could not authenticate to the server"
+	case apierrors.IsForbidden(err):
+		return "UpdatePayloadResourceForbidden", "the server has forbidden updates to this resource"
+	case apierrors.IsServerTimeout(err), apierrors.IsTooManyRequests(err):
+		return "UpdatePayloadClusterOverloaded", "the server is overloaded and is not accepting updates"
+	case meta.IsNoMatchError(err):
+		return "UpdatePayloadResourceTypeMissing", "the server does not recognize this resource, check extension API servers"
+	default:
+		return "UpdatePayloadFailed", ""
+	}
+}
+
+func summaryForReason(reason string) string {
+	switch reason {
+
+	// likely temporary errors
+	case "UpdatePayloadResourceNotFound", "UpdatePayloadResourceConflict":
+		return "some resources could not be updated"
+	case "UpdatePayloadClusterDown":
+		return "the control plane is down or not responding"
+	case "UpdatePayloadClusterError":
+		return "the control plane is reporting an internal error"
+	case "UpdatePayloadClusterOverloaded":
+		return "the control plane is overloaded and is not accepting updates"
+	case "UpdatePayloadClusterUnauthorized":
+		return "could not authenticate to the server"
+	case "UpdatePayloadRetrievalFailed":
+		return "could not download the update"
+
+	// likely a policy or other configuration error due to end user action
+	case "UpdatePayloadResourceForbidden":
+		return "the server is rejecting updates"
+
+	// the payload may not be correct, or the cluster may be in an unexpected
+	// state
+	case "UpdatePayloadResourceTypeMissing":
+		return "a required extension is not available to update"
+	case "UpdatePayloadResourceInvalid":
+		return "some cluster configuration is invalid"
+	case "UpdatePayloadIntegrity":
+		return "the contents of the update are invalid"
+	}
+	if strings.HasPrefix(reason, "UpdatePayload") {
+		return "the update could not be applied"
+	}
+	return "an unknown error has occurred"
+}
+
+func taskName(manifest *lib.Manifest, index, total int) string {
+	ns := manifest.Object().GetNamespace()
+	if len(ns) == 0 {
+		return fmt.Sprintf("%s %q (%s, %d of %d)", strings.ToLower(manifest.GVK.Kind), manifest.Object().GetName(), manifest.GVK.GroupVersion().String(), index, total)
+	}
+	return fmt.Sprintf("%s \"%s/%s\" (%s, %d of %d)", strings.ToLower(manifest.GVK.Kind), ns, manifest.Object().GetName(), manifest.GVK.GroupVersion().String(), index, total)
 }
 
 // getOverrideForManifest returns the override and true when override exists for manifest.

--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -138,7 +138,10 @@ func loadUpdatePayload(dir, releaseImage string) (*updatePayload, error) {
 
 	agg := utilerrors.NewAggregate(errs)
 	if agg != nil {
-		return nil, fmt.Errorf("error loading manifests from %s: %v", dir, agg.Error())
+		return nil, &updateError{
+			Reason:  "UpdatePayloadIntegrity",
+			Message: fmt.Sprintf("Error loading manifests from %s: %v", dir, agg.Error()),
+		}
 	}
 
 	hash := fnv.New64()
@@ -161,7 +164,10 @@ func (optr *Operator) baseDirectory() string {
 func (optr *Operator) updatePayloadDir(config *cvv1.ClusterVersion) (string, error) {
 	tdir, err := optr.targetUpdatePayloadDir(config)
 	if err != nil {
-		return "", fmt.Errorf("error fetching targetUpdatePayloadDir: %v", err)
+		return "", &updateError{
+			Reason:  "UpdatePayloadRetrievalFailed",
+			Message: fmt.Sprintf("Unable to download and prepare the update: %v", err),
+		}
 	}
 	if len(tdir) > 0 {
 		return tdir, nil

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
Reporting sync errors to the user via the ClusterVersion status is important for usability - this will be the first place user interfaces check when errors occur. Improve the exit paths from the core payload sync path to capture errors.

```
$ oc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE     STATUS
version   4.0.2     False       True          56m       Unable to apply 4.0.3: a required extension is not available to update
```

```
# describe snippet:
Status:
  Available Updates:  <nil>
  Conditions:
    Last Transition Time:  2018-11-05T02:01:24Z
    Status:                False
    Type:                  Available
    Last Transition Time:  2018-11-05T02:01:24Z
    Message:               Unable to apply 4.0.3: a required extension is not available to update
    Reason:                UpdatePayloadResourceTypeMissing
    Status:                True
    Type:                  Progressing
    Last Transition Time:  2018-11-05T02:01:47Z
    Message:               Could not update widget "test" (custom.resource/v1, 1 of 1): the server does not recognize this resource, check extension API servers
    Reason:                UpdatePayloadResourceTypeMissing
    Status:                True
    Type:                  Failing
    Last Transition Time:  2018-11-05T01:54:48Z
    Message:               Unable to retrieve available updates: Get http://localhost:8080/graph: dial tcp [::1]:8080: connect: connection refused
    Reason:                RemoteFailed
    Status:                False
    Type:                  RetrievedUpdates
```

Improve the consistency of error behavior by having the Failing condition contain the error text exactly, and have Progressing summarize the error in the condition in the context of the action the operator was taking (reconcile, upgrade). Attempt to preserve the status of the Progressing and Failing conditions when performing the opposite update so as to keep users from seeing results that strobe.

Follows on to #45 - some stylistic feedback is included here.