### PR TITLE
manifests: Add a service for CVO so that a ServiceMonitor can scrape it

### DIFF
--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-version-operator
+  namespace: openshift-cluster-version
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: cluster-version-operator
+  ports:
+  - name: metrics
+    port: 11345


### PR DESCRIPTION
A service is required for the cluster monitoring operator to scrape a target
with prometheus. Create the service and define a metrics port.