### PR TITLE
WIP: start: Resolve the release image to an exact value instead of using tag

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -38,6 +38,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/lib/resourcebuilder/core.go
+++ b/lib/resourcebuilder/core.go
@@ -1,11 +1,18 @@
 package resourcebuilder
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/golang/glog"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
 	"github.com/openshift/cluster-version-operator/lib/resourceread"
-	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 )
 
 type serviceAccountBuilder struct {
@@ -114,4 +121,37 @@ func (b *serviceBuilder) Do() error {
 	}
 	_, _, err := resourceapply.ApplyService(b.client, service)
 	return err
+}
+
+// WaitForPodSuccess waits for pod to complete successfully and returns an error if it doesn't.
+// It will always return the last valid pod it had for the caller to check additional information.
+func WaitForPodSuccess(client coreclientv1.PodsGetter, pod *corev1.Pod) (*corev1.Pod, error) {
+	var lastPod *corev1.Pod
+	err := wait.Poll(jobPollInterval, jobPollTimeout, func() (bool, error) {
+		p, err := client.Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("error getting Pod %s: %v", pod.Name, err)
+			return false, nil
+		}
+
+		lastPod = p
+
+		switch p.Status.Phase {
+		case corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodPending, corev1.PodRunning, corev1.PodUnknown:
+			return false, nil
+		case corev1.PodFailed:
+			msg := "unknown error"
+			if len(p.Status.Message) > 0 {
+				msg = p.Status.Message
+			}
+			return false, fmt.Errorf("pod failed: %v", msg)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return lastPod, err
+	}
+	return lastPod, nil
 }


### PR DESCRIPTION
If the CVO is started with a tag, it's possible the tag can drift from the
initial value and the cluster would start updating at a random time. Instead,
during startup the CVO attempts to identify the precise pull spec as
Kubernetes reports it and use that as the release version. When the reconciler
runs we will update ourself to that version.

This is one way to approach the problem (there are others) that relies on
the values Kubernetes knows about itself to be correct. If the imageID
value reported by the container runtime is unstable, we would loop, but
imageID being unstable is really a bug:

    quay.io/openshift/ocp-release:4.0.X ->
    quay.io/openshift/ocp-release@sha256:XXXX ->
    secure.quay.io/openshift/ocp-release@sha256:XXXX ->
    quay.io/openshift/ocp-release@sha256:XXXX ->
    ... // forever

Otherwise, this has the nice property of being self converging even if
the user gives us wierd output.

TODO:

* [x] do this when we download the next payload and resolve the tag id