### PR TITLE
metrics: Move default metrics port to 9101 in the open internal range

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -57,7 +57,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-	startCmd.PersistentFlags().StringVar(&startOpts.listenAddr, "listen", "0.0.0.0:11345", "Address to listen on for metrics")
+	startCmd.PersistentFlags().StringVar(&startOpts.listenAddr, "listen", "0.0.0.0:9101", "Address to listen on for metrics")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.nodeName, "node-name", "", "kubernetes node name CVO is scheduled on.")
 	startCmd.PersistentFlags().BoolVar(&startOpts.enableAutoUpdate, "enable-auto-update", true, "Enables the autoupdate controller.")

--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -3,10 +3,12 @@ kind: Service
 metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
+  labels:
+    k8s-app: cluster-version-operator
 spec:
   type: ClusterIP
   selector:
     k8s-app: cluster-version-operator
   ports:
   - name: metrics
-    port: 11345
+    port: 9101 # chosen to be in the internal open range


### PR DESCRIPTION
OpenShift opens 9000-9999 for internal host network use for services that
must be scraped like node-exporter but must also be on host network, and
which may be on the master. Move CVO to listen on 9101 so that prometheus
can scrape it to get cluster version metrics.