### PR TITLE
metrics: Default metrics port conflicts with node-exporter

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -57,7 +57,7 @@ var (
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-	startCmd.PersistentFlags().StringVar(&startOpts.listenAddr, "listen", "0.0.0.0:9101", "Address to listen on for metrics")
+	startCmd.PersistentFlags().StringVar(&startOpts.listenAddr, "listen", "0.0.0.0:9099", "Address to listen on for metrics")
 	startCmd.PersistentFlags().StringVar(&startOpts.kubeconfig, "kubeconfig", "", "Kubeconfig file to access a remote cluster (testing only)")
 	startCmd.PersistentFlags().StringVar(&startOpts.nodeName, "node-name", "", "kubernetes node name CVO is scheduled on.")
 	startCmd.PersistentFlags().BoolVar(&startOpts.enableAutoUpdate, "enable-auto-update", true, "Enables the autoupdate controller.")
@@ -234,9 +234,9 @@ func createControllerContext(cb *clientBuilder, stop <-chan struct{}) *controlle
 		InformerFactory:       sharedInformers,
 		KubeInformerFactory:   kubeSharedInformer,
 		APIExtInformerFactory: apiExtSharedInformer,
-		Stop:             stop,
-		InformersStarted: make(chan struct{}),
-		ResyncPeriod:     resyncPeriod(),
+		Stop:                  stop,
+		InformersStarted:      make(chan struct{}),
+		ResyncPeriod:          resyncPeriod(),
 	}
 }
 

--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -11,4 +11,4 @@ spec:
     k8s-app: cluster-version-operator
   ports:
   - name: metrics
-    port: 9101 # chosen to be in the internal open range
+    port: 9099 # chosen to be in the internal open range


### PR DESCRIPTION
Change to 9099, I will create a document in openshift/origin to track
claimed ports.