### PR TITLE
cvo: Panic when we try to sync available updates and no change needed

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -23,7 +23,7 @@ func (optr *Operator) syncAvailableUpdatesStatus(original *cvv1.ClusterVersion) 
 
 	// only report change if we actually updated the server
 	updated, err := applyClusterVersionStatus(optr.client.ConfigV1(), config, original)
-	return updated.ResourceVersion != original.ResourceVersion, err
+	return updated != nil && updated.ResourceVersion != original.ResourceVersion, err
 }
 
 func (optr *Operator) syncProgressingStatus(config *cvv1.ClusterVersion) error {


### PR DESCRIPTION
In a running cluster we panicked because no update was performed. This also
had a side effect, which was to cause the CVO to reevaluate its pull tag (the rolling v4.0 one)
which caused the cluster to get updated to a newer build, which caused other flakes.

The CVO will be fixed separately to resolve its own tag in #51

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x100c904]

goroutine 48 [running]:
github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x107
panic(0x11e7b60, 0x1d1f260)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/openshift/cluster-version-operator/pkg/cvo.(*Operator).syncAvailableUpdatesStatus(0xc4200d1600, 0xc4206a01c0, 0x13, 0xc4206f1c88, 0x1)
	/go/src/github.com/openshift/cluster-version-operator/pkg/cvo/status.go:26 +0x104
github.com/openshift/cluster-version-operator/pkg/cvo.(*Operator).sync(0xc4200d1600, 0xc420097350, 0x21, 0x0, 0x0)
	/go/src/github.com/openshift/cluster-version-operator/pkg/cvo/cvo.go:289 +0x2e8
github.com/openshift/cluster-version-operator/pkg/cvo.(*Operator).(github.com/openshift/cluster-version-operator/pkg/cvo.sync)-fm(0xc420097350, 0x21, 0xc42000af40, 0x117fa20)
	/go/src/github.com/openshift/cluster-version-operator/pkg/cvo/cvo.go:206 +0x3e
github.com/openshift/cluster-version-operator/pkg/cvo.processNextWorkItem(0x14afe20, 0xc42000af40, 0xc4206f1e68, 0xc4206f1e28, 0x1232300)
```