### PR TITLE
manifest: show the Failing condition in a column

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -16,6 +16,10 @@ spec:
     description: Whether the operator is processing changes.
     name: Progressing
     type: string
+  - JSONPath: .status.conditions[?(@.type=="Failing")].status
+    description: Whether the operator is failing changes.
+    name: Failing
+    type: string
   - JSONPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
     description: The time the operator's Available status last changed.
     name: Since


### PR DESCRIPTION
Knowing if the operator is failing is critical for determining health of the cluster
so we should show it by default

/assign @abhinavdahiya 