### PR TITLE
Requeue clusteroperator on NotFound

### DIFF
--- a/lib/resourcebuilder/errors.go
+++ b/lib/resourcebuilder/errors.go
@@ -1,0 +1,10 @@
+package resourcebuilder
+
+// RetryLaterError instructs the resource can't be reconciled right now, so retry later.
+type RetryLaterError struct {
+	Message string
+}
+
+func (e *RetryLaterError) Error() string {
+	return e.Message
+}

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -6,6 +6,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	"github.com/golang/glog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -67,7 +68,15 @@ func (b *clusterOperatorBuilder) Do() error {
 		b.modifier(os)
 	}
 
-	return waitForOperatorStatusToBeDone(b.client, os)
+	eos, err := b.client.ClusterOperators().Get(os.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return &resourcebuilder.RetryLaterError{Message: err.Error()}
+	}
+	if err != nil {
+		return err
+	}
+
+	return waitForOperatorStatusToBeDone(b.client, eos)
 }
 
 const (

--- a/pkg/cvo/sync.go
+++ b/pkg/cvo/sync.go
@@ -151,12 +151,15 @@ func (st *syncTask) Run(version string, rc *rest.Config) error {
 }
 
 func shouldRequeueOnErr(err error, manifest *lib.Manifest) bool {
+	cause := errors.Cause(err)
+	if _, ok := cause.(*resourcebuilder.RetryLaterError); ok {
+		return true
+	}
+
 	ok, errs := hasRequeueOnErrorAnnotation(manifest.Object().GetAnnotations())
 	if !ok {
 		return false
 	}
-	cause := errors.Cause(err)
-
 	should := false
 	for _, e := range errs {
 		if ef, ok := requeueOnErrorCauseToCheck[e]; ok {
@@ -166,6 +169,7 @@ func shouldRequeueOnErr(err error, manifest *lib.Manifest) bool {
 			}
 		}
 	}
+
 	return should
 }
 

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -169,6 +169,14 @@ func TestShouldRequeueOnErr(t *testing.T) {
 		}`,
 
 		exp: false,
+	}, {
+		err: &updateError{cause: &resourcebuilder.RetryLaterError{}},
+		manifest: `{
+			"apiVersion": "v1",
+			"kind": "ConfigMap"
+		}`,
+
+		exp: true,
 	}}
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {


### PR DESCRIPTION
* Add RetryLaterError to reasons for sync task requeue
* clusteroperator is not present on installation and requeuing when not found allows progress on installation with sync only finishing when all clusteroperators are available.