### PR TITLE
api: Remove operatorstatus object before 4.0

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -76,28 +76,3 @@ spec:
   - name: v1
     served: true
     storage: true
----
-# XXX: This CRD will be removed before 4.0
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: operatorstatuses.operatorstatus.openshift.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created.
-    name: Age
-    type: date
-  group: operatorstatus.openshift.io
-  names:
-    kind: OperatorStatus
-    listKind: OperatorStatusList
-    plural: operatorstatuses
-    singular: operatorstatus
-  scope: Namespaced
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true


### PR DESCRIPTION
This removes the old operator status object as it is no longer set
and the cluster scoped ClusterOperator is being leveraged for 4.0.