### PR TITLE
docs: cluster-config-operator needs runlevel

### DIFF
--- a/docs/dev/operators.md
+++ b/docs/dev/operators.md
@@ -72,7 +72,7 @@ For example, the Kube core operators run in runlevel 10-19 and have filenames li
 Assigned runlevels
 
 - 00-04 - CVO
-- 05 - Checkpointer operator
+- 05 - cluster-config-operator
 - 07 - Network operator
 - 08 - DNS operator
 - 09 - Service signer CA


### PR DESCRIPTION
The checkpointer is gone and the cluster-config-operator needs an early runlevel

/assign @smarterclayton @abhinavdahiya 