### PR TITLE
WIP: cvo: Label all applied resources with the current version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -504,13 +504,14 @@
   version = "kubernetes-1.11.1"
 
 [[projects]]
-  digest = "1:e9232c127196055e966ae56877363f82fb494dd8c7fda0112b477e1339082d05"
+  digest = "1:df623efa281121be190731b5fba78d24f5ceb4fb9345c4ee45a385f8645b7d2c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "discovery/cached",
     "discovery/fake",
     "dynamic",
+    "dynamic/fake",
     "informers",
     "informers/admissionregistration",
     "informers/admissionregistration/v1alpha1",
@@ -761,6 +762,7 @@
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/cached",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -77,8 +77,9 @@ type Operator struct {
 	// which case no available updates will be returned.
 	releaseVersion string
 
-	// restConfig is used to create resourcebuilder.
 	restConfig *rest.Config
+	// resourceBuilder is exposed for testing and defaults to defaultResourceBuilder
+	resourceBuilder func(version string) ResourceBuilder
 
 	client        clientset.Interface
 	kubeClient    kubernetes.Interface
@@ -151,7 +152,9 @@ func New(
 			Steps:    3,
 		},
 
-		restConfig:    restConfig,
+		// resourceBuilder is the default implementation of how objects are applied to the server
+		restConfig: restConfig,
+
 		client:        client,
 		kubeClient:    kubeClient,
 		apiExtClient:  apiExtClient,
@@ -161,6 +164,7 @@ func New(
 		availableUpdatesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "availableupdates"),
 	}
 
+	optr.resourceBuilder = optr.defaultResourceBuilder
 	optr.updatePayloadHandler = optr.syncUpdatePayload
 
 	cvInformer.Informer().AddEventHandler(optr.eventHandler())

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -11,12 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 
 	"github.com/openshift/client-go/config/clientset/versioned/scheme"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
-	"github.com/openshift/cluster-version-operator/pkg/cvo/internal/dynamicclient"
 )
 
 // readUnstructuredV1OrDie reads operatorstatus object from bytes. Panics on error.
@@ -67,11 +65,7 @@ type genericBuilder struct {
 
 // NewGenericBuilder returns an implentation of resourcebuilder.Interface that
 // uses dynamic clients for applying.
-func NewGenericBuilder(config *rest.Config, m lib.Manifest) (resourcebuilder.Interface, error) {
-	client, err := dynamicclient.New(config, m.GVK, m.Object().GetNamespace())
-	if err != nil {
-		return nil, err
-	}
+func NewGenericBuilder(client dynamic.ResourceInterface, m lib.Manifest) (resourcebuilder.Interface, error) {
 	return &genericBuilder{
 		client: client,
 		raw:    m.Raw,

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -4,18 +4,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/davecgh/go-spew/spew"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
+	clientgotesting "k8s.io/client-go/testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
+	"github.com/openshift/cluster-version-operator/pkg/cvo/internal"
 )
 
 func TestHasRequeueOnErrorAnnotation(t *testing.T) {
@@ -196,7 +204,8 @@ func TestSyncUpdatePayload(t *testing.T) {
 		manifests []string
 		reactors  map[action]error
 
-		check func(*testing.T, []action)
+		check   func(*testing.T, []action)
+		wantErr bool
 	}{{
 		manifests: []string{
 			`{
@@ -220,13 +229,13 @@ func TestSyncUpdatePayload(t *testing.T) {
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 2 {
 				spew.Dump(actions)
-				t.Fatal("expected only 2 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[1], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[1], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -250,15 +259,16 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 3 {
 				spew.Dump(actions)
-				t.Fatal("expected only 3 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -285,21 +295,22 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 7 {
 				spew.Dump(actions)
-				t.Fatal("expected only 7 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[3], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[3], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[4], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[4], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -329,22 +340,23 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 9 {
 				spew.Dump(actions)
-				t.Fatal("expected only 12 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[3], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[3], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[6], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[6], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -362,6 +374,7 @@ func TestSyncUpdatePayload(t *testing.T) {
 
 			up := &updatePayload{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
 			op := &Operator{}
+			op.resourceBuilder = op.defaultResourceBuilder
 			op.syncBackoff = wait.Backoff{Steps: 3}
 			config := &configv1.ClusterVersion{}
 			r := &recorder{}
@@ -370,20 +383,216 @@ func TestSyncUpdatePayload(t *testing.T) {
 			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, newTestBuilder(r, test.reactors))
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
-			op.syncUpdatePayload(config, up)
+			err := op.syncUpdatePayload(config, up)
 			test.check(t, r.actions)
+
+			if (err != nil) != test.wantErr {
+				t.Fatalf("unexpected err: %v", err)
+			}
 		})
 	}
 }
 
+func TestSyncUpdatePayloadGeneric(t *testing.T) {
+	tests := []struct {
+		manifests []string
+		modifiers []resourcebuilder.MetaV1ObjectModifierFunc
+
+		check func(t *testing.T, client *dynamicfake.FakeDynamicClient)
+	}{
+		{
+			manifests: []string{
+				`{
+				"apiVersion": "test.cvo.io/v1",
+				"kind": "TestA",
+				"metadata": {
+					"namespace": "default",
+					"name": "testa"
+				}
+			}`,
+				`{
+				"apiVersion": "test.cvo.io/v1",
+				"kind": "TestB",
+				"metadata": {
+					"namespace": "default",
+					"name": "testb"
+				}
+			}`,
+			},
+			check: func(t *testing.T, client *dynamicfake.FakeDynamicClient) {
+				actions := client.Actions()
+				if len(actions) != 4 {
+					spew.Dump(actions)
+					t.Fatal("expected only 4 actions")
+				}
+
+				got := actions[1].(clientgotesting.CreateAction).GetObject()
+				exp := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestA",
+						"metadata": map[string]interface{}{
+							"name":      "testa",
+							"namespace": "default",
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+
+				got = actions[3].(clientgotesting.CreateAction).GetObject()
+				exp = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestB",
+						"metadata": map[string]interface{}{
+							"name":      "testb",
+							"namespace": "default",
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+			},
+		},
+		{
+			modifiers: []resourcebuilder.MetaV1ObjectModifierFunc{
+				func(obj metav1.Object) {
+					m := obj.GetLabels()
+					if m == nil {
+						m = make(map[string]string)
+					}
+					m["test/label"] = "a"
+					obj.SetLabels(m)
+				},
+			},
+			manifests: []string{
+				`{
+					"apiVersion": "test.cvo.io/v1",
+					"kind": "TestA",
+					"metadata": {
+						"namespace": "default",
+						"name": "testa"
+					}
+				}`,
+				`{
+					"apiVersion": "test.cvo.io/v1",
+					"kind": "TestB",
+					"metadata": {
+						"namespace": "default",
+						"name": "testb"
+					}
+				}`,
+			},
+			check: func(t *testing.T, client *dynamicfake.FakeDynamicClient) {
+				actions := client.Actions()
+				if len(actions) != 4 {
+					spew.Dump(actions)
+					t.Fatalf("got %d actions", len(actions))
+				}
+
+				got := actions[1].(clientgotesting.CreateAction).GetObject()
+				exp := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestA",
+						"metadata": map[string]interface{}{
+							"name":      "testa",
+							"namespace": "default",
+							"labels":    map[string]interface{}{"test/label": "a"},
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+
+				got = actions[3].(clientgotesting.CreateAction).GetObject()
+				exp = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestB",
+						"metadata": map[string]interface{}{
+							"name":      "testb",
+							"namespace": "default",
+							"labels":    map[string]interface{}{"test/label": "a"},
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+			},
+		},
+	}
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
+			var manifests []lib.Manifest
+			for _, s := range test.manifests {
+				m := lib.Manifest{}
+				if err := json.Unmarshal([]byte(s), &m); err != nil {
+					t.Fatal(err)
+				}
+				manifests = append(manifests, m)
+			}
+
+			dynamicScheme := runtime.NewScheme()
+			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, &unstructured.Unstructured{})
+			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, &unstructured.Unstructured{})
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
+
+			up := &updatePayload{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
+			op := &Operator{}
+			op.resourceBuilder = func(version string) ResourceBuilder {
+				return &testResourceBuilder{
+					client:    dynamicClient,
+					modifiers: test.modifiers,
+				}
+			}
+			op.syncBackoff = wait.Backoff{Steps: 3}
+			config := &configv1.ClusterVersion{}
+
+			err := op.syncUpdatePayload(config, up)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.check(t, dynamicClient)
+		})
+	}
+}
+
+// testResourceBuilder uses a fake dynamic client to exercise the generic builder in tests.
+type testResourceBuilder struct {
+	client    *dynamicfake.FakeDynamicClient
+	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
+}
+
+func (b *testResourceBuilder) Apply(m *lib.Manifest) error {
+	ns := m.Object().GetNamespace()
+	fakeGVR := schema.GroupVersionResource{Group: m.GVK.Group, Version: m.GVK.Version, Resource: strings.ToLower(m.GVK.Kind)}
+	client := b.client.Resource(fakeGVR).Namespace(ns)
+	builder, err := internal.NewGenericBuilder(client, *m)
+	if err != nil {
+		return err
+	}
+	for _, m := range b.modifiers {
+		builder = builder.WithModifier(m)
+	}
+	return builder.Do()
+}
+
 type testBuilder struct {
 	*recorder
-	reactors map[action]error
+	reactors  map[action]error
+	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
 
 	m *lib.Manifest
 }
 
-func (t *testBuilder) WithModifier(_ resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
+func (t *testBuilder) WithModifier(m resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
+	t.modifiers = append(t.modifiers, m)
 	return t
 }
 
@@ -412,4 +621,8 @@ type action struct {
 	GVK       schema.GroupVersionKind
 	Namespace string
 	Name      string
+}
+
+func newAction(gvk schema.GroupVersionKind, namespace, name string) action {
+	return action{GVK: gvk, Namespace: namespace, Name: name}
 }

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+var _ dynamic.Interface = &FakeDynamicClient{}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	for _, item := range entireList.Items {
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}


### PR DESCRIPTION
Knowing that an object has changed is very useful when debugging the state
of a cluster, and the version also allows us to perform downward API
actions from deployments to match the desired version out into the outcome
status.

Right now this tags all objects. An alternative would be to only tag:

1. Namespaces and deployments
2. Objects that have the label `cvo.openshift.io/version` already set (i.e. they request it)
3. Objects that don't have the label set

There is other useful metadata that isn't set (but may be more appropriate to annotations):

* Which file in the payload it came from (for debugging)

One unfortunate side effect is that this forces all objects to be updated,
but in practice we do that anyway.

Refactor the internal structure of the resource builder so that we can
inject testing of dynamic client actions. The interface may change in the
future, so this is merely to improve the testing of payload application for
now.