### PR TITLE
*: update default upstream URL

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -11,7 +11,7 @@ cluster_version{payload="test/image:1",type="current",version="4.0.2"} 1
 cluster_version{payload="test/image:1",type="failure",version="4.0.2"} 1
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge
-cluster_version_available_updates{channel="fast",upstream="http://localhost:8080/graph"} 0
+cluster_version_available_updates{channel="fast",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0
 ```
 
 Metrics about cluster operators:

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -144,7 +144,7 @@ func New(
 
 		minimumUpdateCheckInterval: minimumInterval,
 		payloadDir:                 overridePayloadDir,
-		defaultUpstreamServer:      "http://localhost:8080/graph",
+		defaultUpstreamServer:      "https://api.openshift.com/api/upgrades_info/v1/graph",
 		syncBackoff: wait.Backoff{
 			Duration: time.Second * 10,
 			Factor:   1.3,


### PR DESCRIPTION
The production Cincinnati stack is going to run at the given URL. Once
it has been turned up, CVO will be able to automatically check for
updates.

cc @smarterclayton @steveej @jhernand

Hold while we wait for confirmation about that URL...
/hold