### PR TITLE
sync: Do config syncing in the background

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -504,13 +504,14 @@
   version = "kubernetes-1.11.1"
 
 [[projects]]
-  digest = "1:e9232c127196055e966ae56877363f82fb494dd8c7fda0112b477e1339082d05"
+  digest = "1:df623efa281121be190731b5fba78d24f5ceb4fb9345c4ee45a385f8645b7d2c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "discovery/cached",
     "discovery/fake",
     "dynamic",
+    "dynamic/fake",
     "informers",
     "informers/admissionregistration",
     "informers/admissionregistration/v1alpha1",
@@ -761,6 +762,7 @@
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/cached",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",

--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ podman run --rm -ti \
 1. Use CVO `render` to render all the manifests from release-payload to a directory. [here](#using-cvo-to-render-the-release-payload-locally)
 
 2. Create the operators from the manifests by using `oc create -f <directory when CVO rendered manfiests>`.
+
+## Running CVO tests
+
+```sh
+# Run all unit tests
+go test ./...
+
+# Run integration tests against a cluster (creates content in a given namespace)
+# Requires the CVO CRD to be installed.
+export KUBECONFIG=<admin kubeconfig>
+TEST_INTEGRATION=1 go test ./... -test.run=^TestIntegration
+```

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base=$( dirname "${BASH_SOURCE[0]}")
+
+go run "${base}/test-prerequisites.go"
+TEST_INTEGRATION=1 go test ./... -test.run=^TestIntegration -args -alsologtostderr -v=5

--- a/hack/test-prerequisites.go
+++ b/hack/test-prerequisites.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"time"
+
+	"github.com/ghodss/yaml"
+	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// main installs the CV CRD to a cluster for integration testing.
+func main() {
+	log.SetFlags(0)
+	kcfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	cfg, err := kcfg.ClientConfig()
+	if err != nil {
+		log.Fatalf("cannot load config: %v", err)
+	}
+
+	client := apiext.NewForConfigOrDie(cfg)
+	for _, path := range []string{
+		"install/0000_00_cluster-version-operator_01_clusterversion.crd.yaml",
+		"install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml",
+	} {
+		var name string
+		err := wait.PollImmediate(time.Second, 30*time.Second, func() (bool, error) {
+			data, err := ioutil.ReadFile(path)
+			if err != nil {
+				log.Fatalf("Unable to read %s: %v", path, err)
+			}
+			var crd v1beta1.CustomResourceDefinition
+			if err := yaml.Unmarshal(data, &crd); err != nil {
+				log.Fatalf("Unable to parse CRD %s: %v", path, err)
+			}
+			name = crd.Name
+			_, err = client.Apiextensions().CustomResourceDefinitions().Create(&crd)
+			if errors.IsAlreadyExists(err) {
+				return true, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			log.Printf("Installed %s CRD", crd.Name)
+			return true, nil
+		})
+		if err != nil {
+			log.Fatalf("Could not install %s CRD: %v", name, err)
+		}
+	}
+}

--- a/pkg/cvo/cvo_integration_test.go
+++ b/pkg/cvo/cvo_integration_test.go
@@ -1,0 +1,712 @@
+package cvo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	v1 "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	randutil "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	configv1 "github.com/openshift/api/config/v1"
+	clientset "github.com/openshift/client-go/config/clientset/versioned"
+	informers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
+)
+
+var (
+	version_0_0_1 = map[string]interface{}{
+		"release-manifests": map[string]interface{}{
+			"image-references": `
+			{
+				"kind": "ImageStream",
+				"apiVersion": "image.openshift.io/v1",
+				"metadata": {
+					"name": "0.0.1"
+				}
+			}
+			`,
+			// this manifest should not have ReleaseImage replaced because it is part of the user facing payload
+			"config2.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config2",
+					"namespace": "$(NAMESPACE)"
+				},
+				"data": {
+					"version": "0.0.1",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+		"manifests": map[string]interface{}{
+			// this manifest is part of the innate payload and should have ReleaseImage replaced
+			"config1.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config1",
+					"namespace": "$(NAMESPACE)"
+				},
+				"data": {
+					"version": "0.0.1",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+	}
+	version_0_0_2 = map[string]interface{}{
+		"release-manifests": map[string]interface{}{
+			"image-references": `
+			{
+				"kind": "ImageStream",
+				"apiVersion": "image.openshift.io/v1",
+				"metadata": {
+					"name": "0.0.2"
+				}
+			}
+			`,
+			"config2.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config2",
+					"namespace": "$(NAMESPACE)"
+				},
+				"data": {
+					"version": "0.0.2",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+		"manifests": map[string]interface{}{
+			"config1.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config1",
+					"namespace": "$(NAMESPACE)"
+				},
+				"data": {
+					"version": "0.0.2",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+	}
+	version_0_0_2_failing = map[string]interface{}{
+		"release-manifests": map[string]interface{}{
+			"image-references": `
+			{
+				"kind": "ImageStream",
+				"apiVersion": "image.openshift.io/v1",
+				"metadata": {
+					"name": "0.0.2"
+				}
+			}
+			`,
+			// has invalid label value, API server will reject
+			"config2.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config2",
+					"namespace": "$(NAMESPACE)",
+					"labels": {"": ""}
+				},
+				"data": {
+					"version": "0.0.2",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+		"manifests": map[string]interface{}{
+			"config1.json": `
+			{
+				"kind": "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "config1",
+					"namespace": "$(NAMESPACE)"
+				},
+				"data": {
+					"version": "0.0.2",
+					"releaseImage": "{{.ReleaseImage}}"
+				}
+			}
+			`,
+		},
+	}
+)
+
+func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") != "1" {
+		t.Skipf("Integration tests are disabled unless TEST_INTEGRATION=1")
+	}
+	t.Parallel()
+
+	kcfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	cfg, err := kcfg.ClientConfig()
+	if err != nil {
+		t.Fatalf("cannot load config: %v", err)
+	}
+
+	kc := kubernetes.NewForConfigOrDie(cfg)
+	client := clientset.NewForConfigOrDie(cfg)
+	apiExtClient := apiext.NewForConfigOrDie(cfg)
+
+	ns := fmt.Sprintf("e2e-cvo-%s", randutil.String(4))
+
+	if _, err := kc.Core().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := client.Config().ClusterVersions().Delete(ns, nil); err != nil {
+			t.Logf("failed to delete cluster version %s: %v", ns, err)
+		}
+		if err := kc.Core().Namespaces().Delete(ns, nil); err != nil {
+			t.Logf("failed to delete namespace %s: %v", ns, err)
+		}
+	}()
+
+	cvInformer := informers.NewFilteredSharedInformerFactory(client, 1*time.Minute, "", func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fmt.Sprintf("metadata.name=%s", ns)
+	})
+	sharedInformers := informers.NewSharedInformerFactory(client, 1*time.Minute)
+
+	dir, err := ioutil.TempDir("", "cvo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	if err := createContent(filepath.Join(dir, "0.0.1"), version_0_0_1, map[string]string{"NAMESPACE": ns}); err != nil {
+		t.Fatal(err)
+	}
+	if err := createContent(filepath.Join(dir, "0.0.2"), version_0_0_2, map[string]string{"NAMESPACE": ns}); err != nil {
+		t.Fatal(err)
+	}
+	payloadImage1 := "arbitrary/release:image"
+	payloadImage2 := "arbitrary/release:image-2"
+	retriever := &mapPayloadRetriever{map[string]string{
+		payloadImage1: filepath.Join(dir, "0.0.1"),
+		payloadImage2: filepath.Join(dir, "0.0.2"),
+	}}
+
+	optr := New(
+		"", ns, ns, payloadImage1,
+		filepath.Join(dir, "ignored"),
+		5*time.Second,
+		cvInformer.Config().V1().ClusterVersions(),
+		sharedInformers.Config().V1().ClusterOperators(),
+		cfg,
+		client, kc, apiExtClient,
+		false,
+	)
+
+	worker := optr.configSync.(*SyncWorker)
+	worker.retriever = retriever
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cvInformer.Start(stopCh)
+	go sharedInformers.Start(stopCh)
+	go optr.Run(1, stopCh)
+
+	t.Logf("wait until we observe the cluster version become available")
+	lastCV, err := waitForAvailableUpdate(t, client, ns, false, "0.0.1")
+	if err != nil {
+		t.Logf("latest version:\n%s", printCV(lastCV))
+		t.Fatalf("cluster version never became available: %v", err)
+	}
+
+	status := optr.configSync.(*SyncWorker).Status()
+
+	t.Logf("verify the available cluster version's status matches our expectations")
+	t.Logf("Cluster version:\n%s", printCV(lastCV))
+	verifyClusterVersionStatus(t, lastCV, configv1.Update{Payload: payloadImage1, Version: "0.0.1"}, 1)
+	verifyReleasePayload(t, kc, ns, "0.0.1", payloadImage1)
+
+	t.Logf("wait for the next resync and verify that status didn't change")
+	if err := wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+		updated := optr.configSync.(*SyncWorker).Status()
+		if updated.Completed > status.Completed {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	cv, err := client.Config().ClusterVersions().Get(ns, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cv.Status, lastCV.Status) {
+		t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(lastCV.Status, cv.Status))
+	}
+	verifyReleasePayload(t, kc, ns, "0.0.1", payloadImage1)
+
+	t.Logf("trigger an update to a new version")
+	cv, err = client.Config().ClusterVersions().Patch(ns, types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"payload":"%s"}}}`, payloadImage2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cv.Spec.DesiredUpdate == nil {
+		t.Fatalf("cluster desired version was not preserved: %s", printCV(cv))
+	}
+
+	t.Logf("wait for the new version to be available")
+	lastCV, err = waitForAvailableUpdate(t, client, ns, false, "0.0.1", "0.0.2")
+	if err != nil {
+		t.Logf("latest version:\n%s", printCV(lastCV))
+		t.Fatalf("cluster version never reached available at 0.0.2: %v", err)
+	}
+	t.Logf("Upgraded version:\n%s", printCV(lastCV))
+	verifyClusterVersionStatus(t, lastCV, configv1.Update{Payload: payloadImage2, Version: "0.0.2"}, 2)
+	verifyReleasePayload(t, kc, ns, "0.0.2", payloadImage2)
+
+	t.Logf("delete an object so that the next resync will recover it")
+	if err := kc.CoreV1().ConfigMaps(ns).Delete("config1", nil); err != nil {
+		t.Fatalf("couldn't delete CVO managed object: %v", err)
+	}
+
+	status = optr.configSync.(*SyncWorker).Status()
+
+	t.Logf("wait for the next resync and verify that status didn't change")
+	if err := wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+		updated := optr.configSync.(*SyncWorker).Status()
+		if updated.Completed > status.Completed {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	cv, err = client.Config().ClusterVersions().Get(ns, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cv.Status, lastCV.Status) {
+		t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(lastCV.Status, cv.Status))
+	}
+
+	// should have recreated our deleted object
+	verifyReleasePayload(t, kc, ns, "0.0.2", payloadImage2)
+}
+
+func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") != "1" {
+		t.Skipf("Integration tests are disabled unless TEST_INTEGRATION=1")
+	}
+	t.Parallel()
+
+	kcfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	cfg, err := kcfg.ClientConfig()
+	if err != nil {
+		t.Fatalf("cannot load config: %v", err)
+	}
+
+	kc := kubernetes.NewForConfigOrDie(cfg)
+	client := clientset.NewForConfigOrDie(cfg)
+	apiExtClient := apiext.NewForConfigOrDie(cfg)
+
+	ns := fmt.Sprintf("e2e-cvo-%s", randutil.String(4))
+
+	if _, err := kc.Core().Namespaces().Create(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := client.Config().ClusterVersions().Delete(ns, nil); err != nil {
+			t.Logf("failed to delete cluster version %s: %v", ns, err)
+		}
+		if err := kc.Core().Namespaces().Delete(ns, nil); err != nil {
+			t.Logf("failed to delete namespace %s: %v", ns, err)
+		}
+	}()
+
+	cvInformer := informers.NewFilteredSharedInformerFactory(client, 1*time.Minute, "", func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fmt.Sprintf("metadata.name=%s", ns)
+	})
+	sharedInformers := informers.NewSharedInformerFactory(client, 1*time.Minute)
+
+	dir, err := ioutil.TempDir("", "cvo-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	if err := createContent(filepath.Join(dir, "0.0.1"), version_0_0_1, map[string]string{"NAMESPACE": ns}); err != nil {
+		t.Fatal(err)
+	}
+	if err := createContent(filepath.Join(dir, "0.0.2"), version_0_0_2_failing, map[string]string{"NAMESPACE": ns}); err != nil {
+		t.Fatal(err)
+	}
+	payloadImage1 := "arbitrary/release:image"
+	payloadImage2 := "arbitrary/release:image-2-failing"
+	retriever := &mapPayloadRetriever{map[string]string{
+		payloadImage1: filepath.Join(dir, "0.0.1"),
+		payloadImage2: filepath.Join(dir, "0.0.2"),
+	}}
+
+	optr := New(
+		"", ns, ns, payloadImage1,
+		filepath.Join(dir, "ignored"),
+		10*time.Second,
+		cvInformer.Config().V1().ClusterVersions(),
+		sharedInformers.Config().V1().ClusterOperators(),
+		cfg,
+		client, kc, apiExtClient,
+		false,
+	)
+
+	worker := optr.configSync.(*SyncWorker)
+	worker.retriever = retriever
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cvInformer.Start(stopCh)
+	go sharedInformers.Start(stopCh)
+	go optr.Run(1, stopCh)
+
+	t.Logf("wait until we observe the cluster version become available")
+	lastCV, err := waitForAvailableUpdate(t, client, ns, false, "0.0.1")
+	if err != nil {
+		t.Logf("latest version:\n%s", printCV(lastCV))
+		t.Fatalf("cluster version never became available: %v", err)
+	}
+
+	t.Logf("verify the available cluster version's status matches our expectations")
+	t.Logf("Cluster version:\n%s", printCV(lastCV))
+	verifyClusterVersionStatus(t, lastCV, configv1.Update{Payload: payloadImage1, Version: "0.0.1"}, 1)
+	verifyReleasePayload(t, kc, ns, "0.0.1", payloadImage1)
+
+	t.Logf("trigger an update to a new version that should fail")
+	cv, err := client.Config().ClusterVersions().Patch(ns, types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"payload":"%s"}}}`, payloadImage2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cv.Spec.DesiredUpdate == nil {
+		t.Fatalf("cluster desired version was not preserved: %s", printCV(cv))
+	}
+
+	t.Logf("wait for operator to report failure")
+	lastCV, err = waitUntilUpgradeFails(
+		t, client, ns,
+		"UpdatePayloadResourceInvalid",
+		fmt.Sprintf(
+			`Could not update configmap "%s/config2" (v1, 2 of 2): the object is invalid, possibly due to local cluster configuration`,
+			ns,
+		),
+		"Unable to apply 0.0.2: some cluster configuration is invalid",
+		"0.0.1", "0.0.2",
+	)
+	if err != nil {
+		t.Logf("latest version:\n%s", printCV(lastCV))
+		t.Fatalf("cluster version didn't report failure: %v", err)
+	}
+
+	t.Logf("ensure that one config map was updated and the other was not")
+	verifyReleasePayloadConfigMap1(t, kc, ns, "0.0.2", payloadImage2)
+	verifyReleasePayloadConfigMap2(t, kc, ns, "0.0.1", payloadImage1)
+
+	t.Logf("switch back to 0.0.1 and verify it succeeds")
+	cv, err = client.Config().ClusterVersions().Patch(ns, types.MergePatchType, []byte(`{"spec":{"desiredUpdate":{"payload":"", "version":"0.0.1"}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cv.Spec.DesiredUpdate == nil {
+		t.Fatalf("cluster desired version was not preserved: %s", printCV(cv))
+	}
+	lastCV, err = waitForAvailableUpdate(t, client, ns, true, "0.0.2", "0.0.1")
+	if err != nil {
+		t.Logf("latest version:\n%s", printCV(lastCV))
+		t.Fatalf("cluster version never reverted to 0.0.1: %v", err)
+	}
+	verifyClusterVersionStatus(t, lastCV, configv1.Update{Payload: payloadImage1, Version: "0.0.1"}, 3)
+	verifyReleasePayload(t, kc, ns, "0.0.1", payloadImage1)
+}
+
+// waitForAvailableUpdates checks invariants during an upgrade process. versions is a list of the expected versions that
+// should be seen during update, with the last version being the one we wait to see.
+func waitForAvailableUpdate(t *testing.T, client clientset.Interface, ns string, allowIncrementalFailure bool, versions ...string) (*configv1.ClusterVersion, error) {
+	var lastCV *configv1.ClusterVersion
+	return lastCV, wait.PollImmediate(200*time.Millisecond, 60*time.Second, func() (bool, error) {
+		cv, err := client.Config().ClusterVersions().Get(ns, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		lastCV = cv
+
+		if !allowIncrementalFailure {
+			if failing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorFailing); failing != nil && failing.Status == configv1.ConditionTrue {
+				return false, fmt.Errorf("operator listed as failing (%s): %s", failing.Reason, failing.Message)
+			}
+		}
+
+		// just wait until the operator is available
+		if len(versions) == 0 {
+			available := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorAvailable)
+			return available != nil && available.Status == configv1.ConditionTrue, nil
+		}
+
+		if len(versions) == 1 {
+			if available := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorAvailable); available == nil || available.Status == configv1.ConditionFalse {
+				if progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); available != nil && (progressing == nil || progressing.Status != configv1.ConditionTrue) {
+					return false, fmt.Errorf("initializing operator should have progressing if available is false: %#v", progressing)
+				}
+				return false, nil
+			}
+			if len(cv.Status.History) == 0 {
+				return false, fmt.Errorf("initializing operator should have history after available goes true")
+			}
+			if cv.Status.History[0].Version != versions[len(versions)-1] {
+				return false, fmt.Errorf("initializing operator should report the target version in history once available")
+			}
+			if cv.Status.History[0].State != configv1.CompletedUpdate {
+				return false, fmt.Errorf("initializing operator should report history completed %#v", cv.Status.History[0])
+			}
+			if progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); progressing == nil || progressing.Status == configv1.ConditionTrue {
+				return false, fmt.Errorf("initializing operator should never be available and still progressing or lacking the condition: %#v", progressing)
+			}
+			return true, nil
+		}
+
+		if available := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorAvailable); available == nil || available.Status == configv1.ConditionFalse {
+			return false, fmt.Errorf("upgrading operator should remain available: %#v", available)
+		}
+		if !stringInSlice(versions, cv.Status.Desired.Version) {
+			return false, fmt.Errorf("upgrading operator status reported desired version %s which is not in the allowed set %v", cv.Status.Desired.Version, versions)
+		}
+		if len(cv.Status.History) == 0 {
+			return false, fmt.Errorf("upgrading operator should have at least once history entry")
+		}
+		if !stringInSlice(versions, cv.Status.History[0].Version) {
+			return false, fmt.Errorf("upgrading operator should have a valid history[0] version %s: %v", cv.Status.Desired.Version, versions)
+		}
+
+		if cv.Status.History[0].Version != versions[len(versions)-1] {
+			return false, nil
+		}
+
+		if failing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorFailing); failing != nil && failing.Status == configv1.ConditionTrue {
+			return false, fmt.Errorf("operator listed as failing (%s): %s", failing.Reason, failing.Message)
+		}
+
+		progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing)
+		if cv.Status.History[0].State != configv1.CompletedUpdate {
+			if progressing == nil || progressing.Status != configv1.ConditionTrue {
+				return false, fmt.Errorf("upgrading operator should have progressing true: %#v", progressing)
+			}
+			return false, nil
+		}
+
+		if progressing == nil || progressing.Status != configv1.ConditionFalse {
+			return false, fmt.Errorf("upgraded operator should have progressing condition false: %#v", progressing)
+		}
+		return true, nil
+	})
+}
+
+// waitUntilUpgradeFails checks invariants during an upgrade process. versions is a list of the expected versions that
+// should be seen during update, with the last version being the one we wait to see.
+func waitUntilUpgradeFails(t *testing.T, client clientset.Interface, ns string, failingReason, failingMessage, progressingMessage string, versions ...string) (*configv1.ClusterVersion, error) {
+	var lastCV *configv1.ClusterVersion
+	return lastCV, wait.PollImmediate(200*time.Millisecond, 60*time.Second, func() (bool, error) {
+		cv, err := client.Config().ClusterVersions().Get(ns, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		lastCV = cv
+
+		if c := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorAvailable); c == nil || c.Status != configv1.ConditionTrue {
+			return false, fmt.Errorf("operator should remain available: %#v", c)
+		}
+
+		// just wait until the operator is failing
+		if len(versions) == 0 {
+			c := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorFailing)
+			return c != nil && c.Status == configv1.ConditionTrue, nil
+		}
+
+		// TODO: add a test for initializing to an error state
+		// if len(versions) == 1 {
+		// 	if available := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorAvailable); available == nil || available.Status == configv1.ConditionFalse {
+		// 		if progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); available != nil && (progressing == nil || progressing.Status != configv1.ConditionTrue) {
+		// 			return false, fmt.Errorf("initializing operator should have progressing if available is false: %#v", progressing)
+		// 		}
+		// 		return false, nil
+		// 	}
+		// 	if len(cv.Status.History) == 0 {
+		// 		return false, fmt.Errorf("initializing operator should have history after available goes true")
+		// 	}
+		// 	if cv.Status.History[0].Version != versions[len(versions)-1] {
+		// 		return false, fmt.Errorf("initializing operator should report the target version in history once available")
+		// 	}
+		// 	if cv.Status.History[0].State != configv1.CompletedUpdate {
+		// 		return false, fmt.Errorf("initializing operator should report history completed %#v", cv.Status.History[0])
+		// 	}
+		// 	if progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); progressing == nil || progressing.Status == configv1.ConditionTrue {
+		// 		return false, fmt.Errorf("initializing operator should never be available and still progressing or lacking the condition: %#v", progressing)
+		// 	}
+		// 	return true, nil
+		// }
+		if len(versions) == 1 {
+			return false, fmt.Errorf("unimplemented")
+		}
+
+		if !stringInSlice(versions, cv.Status.Desired.Version) {
+			return false, fmt.Errorf("upgrading operator status reported desired version %s which is not in the allowed set %v", cv.Status.Desired.Version, versions)
+		}
+		if len(cv.Status.History) == 0 {
+			return false, fmt.Errorf("upgrading operator should have at least once history entry")
+		}
+		if !stringInSlice(versions, cv.Status.History[0].Version) {
+			return false, fmt.Errorf("upgrading operator should have a valid history[0] version %s: %v", cv.Status.Desired.Version, versions)
+		}
+
+		if cv.Status.History[0].Version != versions[len(versions)-1] {
+			return false, nil
+		}
+		if cv.Status.History[0].State == configv1.CompletedUpdate {
+			return false, fmt.Errorf("upgrading operator to failed payload should remain partial: %#v", cv.Status.History)
+		}
+
+		failing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorFailing)
+		if failing == nil || failing.Status != configv1.ConditionTrue {
+			return false, nil
+		}
+		progressing := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing)
+		if progressing == nil || progressing.Status != configv1.ConditionTrue {
+			return false, fmt.Errorf("upgrading operator to failed payload should have progressing true: %#v", progressing)
+		}
+		if !strings.Contains(failing.Message, failingMessage) {
+			return false, fmt.Errorf("failure message mismatch: %s", failing.Message)
+		}
+		if failing.Reason != failingReason {
+			return false, fmt.Errorf("failure reason mismatch: %s", failing.Reason)
+		}
+		if progressing.Reason != failing.Reason {
+			return false, fmt.Errorf("failure reason and progressing reason don't match: %s", progressing.Reason)
+		}
+		if !strings.Contains(progressing.Message, progressingMessage) {
+			return false, fmt.Errorf("progressing message mismatch: %s", progressing.Message)
+		}
+
+		return true, nil
+	})
+}
+
+func stringInSlice(slice []string, s string) bool {
+	for _, item := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyClusterVersionStatus(t *testing.T, cv *configv1.ClusterVersion, expectedUpdate configv1.Update, expectHistory int) {
+	t.Helper()
+	if cv.Status.Desired != expectedUpdate {
+		t.Fatalf("unexpected: %#v", cv.Status.Desired)
+	}
+	if len(cv.Status.History) != expectHistory {
+		t.Fatalf("unexpected: %#v", cv.Status.History)
+	}
+	actual := cv.Status.History[0]
+	if actual.StartedTime.Time.IsZero() || actual.CompletionTime == nil || actual.CompletionTime.Time.IsZero() || actual.CompletionTime.Time.Before(actual.StartedTime.Time) {
+		t.Fatalf("unexpected: %s -> %s", actual.StartedTime, actual.CompletionTime)
+	}
+	expect := configv1.UpdateHistory{
+		State:          configv1.CompletedUpdate,
+		Version:        expectedUpdate.Version,
+		Payload:        expectedUpdate.Payload,
+		StartedTime:    actual.StartedTime,
+		CompletionTime: actual.CompletionTime,
+	}
+	if !reflect.DeepEqual(expect, actual) {
+		t.Fatalf("unexpected history: %s", diff.ObjectReflectDiff(expect, actual))
+	}
+	if len(cv.Status.VersionHash) == 0 {
+		t.Fatalf("unexpected version hash: %#v", cv.Status.VersionHash)
+	}
+	if cv.Status.Generation != cv.Generation {
+		t.Fatalf("unexpected generation: %#v", cv.Status.Generation)
+	}
+}
+
+func verifyReleasePayload(t *testing.T, kc kubernetes.Interface, ns, version, payload string) {
+	t.Helper()
+	verifyReleasePayloadConfigMap1(t, kc, ns, version, payload)
+	verifyReleasePayloadConfigMap2(t, kc, ns, version, payload)
+}
+
+func verifyReleasePayloadConfigMap1(t *testing.T, kc kubernetes.Interface, ns, version, payload string) {
+	t.Helper()
+	cm, err := kc.CoreV1().ConfigMaps(ns).Get("config1", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unable to find cm/config1 in ns %s: %v", ns, err)
+	}
+	if cm.Data["version"] != version || cm.Data["releaseImage"] != payload {
+		t.Fatalf("unexpected cm/config1 contents: %#v", cm.Data)
+	}
+}
+
+func verifyReleasePayloadConfigMap2(t *testing.T, kc kubernetes.Interface, ns, version, payload string) {
+	t.Helper()
+	cm, err := kc.CoreV1().ConfigMaps(ns).Get("config2", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unable to find cm/config2 in ns %s: %v", ns, err)
+	}
+	if cm.Data["version"] != version || cm.Data["releaseImage"] != "{{.ReleaseImage}}" {
+		t.Fatalf("unexpected cm/config2 contents: %#v", cm.Data)
+	}
+}
+
+func printCV(cv *configv1.ClusterVersion) string {
+	data, err := json.MarshalIndent(cv, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("<error: %v>", err)
+	}
+	return string(data)
+}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1,0 +1,708 @@
+package cvo
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/uuid"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/cluster-version-operator/lib"
+)
+
+func setupCVOTest() (*Operator, map[string]runtime.Object, *fake.Clientset, *dynamicfake.FakeDynamicClient, func()) {
+	client := &fake.Clientset{}
+	client.AddReactor("*", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return false, nil, fmt.Errorf("unexpected client action: %#v", action)
+	})
+	cvs := make(map[string]runtime.Object)
+	client.AddReactor("*", "clusterversions", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch a := action.(type) {
+		case clientgotesting.GetAction:
+			obj, ok := cvs[a.GetName()]
+			if !ok {
+				return true, nil, errors.NewNotFound(schema.GroupResource{Resource: "clusterversions"}, a.GetName())
+			}
+			return true, obj.DeepCopyObject(), nil
+		case clientgotesting.CreateAction:
+			obj := a.GetObject().DeepCopyObject()
+			m := obj.(metav1.Object)
+			cvs[m.GetName()] = obj
+			return true, obj, nil
+		case clientgotesting.UpdateAction:
+			obj := a.GetObject().DeepCopyObject().(*configv1.ClusterVersion)
+			existing := cvs[obj.Name].DeepCopyObject().(*configv1.ClusterVersion)
+			rv, _ := strconv.Atoi(existing.ResourceVersion)
+			nextRV := strconv.Itoa(rv + 1)
+			if a.GetSubresource() == "status" {
+				existing.Status = obj.Status
+			} else {
+				existing.Spec = obj.Spec
+				existing.ObjectMeta = obj.ObjectMeta
+			}
+			existing.ResourceVersion = nextRV
+			cvs[existing.Name] = existing
+			return true, existing, nil
+		}
+		return false, nil, fmt.Errorf("unexpected client action: %#v", action)
+	})
+
+	o := &Operator{
+		namespace: "test",
+		name:      "version",
+		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
+		client:    client,
+		cvLister:  &clientCVLister{client: client},
+	}
+
+	dynamicScheme := runtime.NewScheme()
+	//dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, &unstructured.Unstructured{})
+	dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, &unstructured.Unstructured{})
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
+
+	worker := NewSyncWorker(
+		&fakeDirectoryRetriever{Path: "testdata/payloadtest"},
+		&testResourceBuilder{client: dynamicClient},
+		time.Second/2,
+		wait.Backoff{
+			Steps: 1,
+		},
+	)
+	o.configSync = worker
+
+	return o, cvs, client, dynamicClient, func() { o.queue.ShutDown() }
+}
+
+func TestCVO_StartupAndSync(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	defer shutdownFn()
+	worker := o.configSync.(*SyncWorker)
+	go worker.Start(stopCh)
+
+	// Step 1: Verify the CVO creates the initial Cluster Version object
+	//
+	client.ClearActions()
+	err := o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	if len(actions) != 3 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	// read from lister
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	// read before create
+	expectGet(t, actions[1], "clusterversions", "", "version")
+	// create initial version
+	actual := cvs["version"].(*configv1.ClusterVersion)
+	expectCreate(t, actions[2], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: actual.Spec.ClusterID,
+			Channel:   "fast",
+		},
+	})
+	verifyAllStatus(t, worker.StatusCh())
+
+	// Step 2: Ensure the CVO reports a status error if it has nothing to sync
+	//
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	actual = cvs["version"].(*configv1.ClusterVersion)
+	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: actual.Spec.ClusterID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				// empty because the operator release image is not set, so we have no input
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+				// report back to the user that we don't have enough info to proceed
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Message: "No configured operator version, unable to update cluster"},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Unable to apply <unknown>: an error occurred"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	})
+	verifyAllStatus(t, worker.StatusCh())
+
+	// Step 3: Given an operator payload, begin synchronizing
+	//
+	o.releaseImage = "payload/image:1"
+	o.releaseVersion = "4.0.1"
+	desired := configv1.Update{Version: "4.0.1", Payload: "payload/image:1"}
+	//
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	actual = cvs["version"].(*configv1.ClusterVersion)
+	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: actual.Spec.ClusterID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: desired,
+			History: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Payload: "payload/image:1", Version: "4.0.1", StartedTime: defaultStartedTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+				// cleared failing status and set progressing
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Working towards 4.0.1"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	})
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Step: "RetrievePayload",
+			// the desired version is briefly incorrect (user provided) until we retrieve the payload
+			Actual: configv1.Update{Version: "4.0.1", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Fraction:    float32(1) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Fraction:    float32(2) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Completed:   1,
+			Fraction:    1,
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+
+	// Step 4: Now that sync is complete, verify status is updated to represent payload contents
+	//
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	// update the status to indicate we are synced, available, and report versions
+	actual = cvs["version"].(*configv1.ClusterVersion)
+	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: actual.Spec.ClusterID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the payload version over the operator's version (although in general they will remain in sync)
+			Desired:     configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				// Because payload and operator had mismatched versions, we get two entries (which shouldn't happen unless there is a bug in the CVO)
+				{State: configv1.CompletedUpdate, Payload: "payload/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.PartialUpdate, Payload: "payload/image:1", Version: "4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	})
+
+	// Step 5: Wait for the SyncWorker to trigger a reconcile (500ms after the first)
+	//
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(1) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(2) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Completed:   2,
+			Fraction:    1,
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+
+	// Step 6: After a reconciliation, there should be no status change because the state is the same
+	//
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+}
+
+func TestCVO_RestartAndReconcile(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	defer shutdownFn()
+	worker := o.configSync.(*SyncWorker)
+
+	// Setup: a successful sync from a previous run, and the operator at the same payload as before
+	//
+	o.releaseImage = "payload/image:1"
+	o.releaseVersion = "1.0.0-abc"
+	desired := configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: clusterUID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the payload version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				// TODO: this is wrong, should be single partial entry
+				{State: configv1.CompletedUpdate, Payload: "payload/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.PartialUpdate, Payload: "payload/image:1", Version: "4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.PartialUpdate, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.PartialUpdate, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	// Step 1: The sync loop starts and triggers a sync, but does not update status
+	//
+	client.ClearActions()
+	err := o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+
+	// check the worker status is initially set to reconciling
+	if status := worker.Status(); !status.Reconciling || status.Completed != 0 {
+		t.Fatalf("The worker should be reconciling from the beginning: %#v", status)
+	}
+
+	// Step 2: Start the sync worker and verify the sequence of events, and then verify
+	//         the status does not change
+	//
+	go worker.Start(stopCh)
+	//
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "RetrievePayload",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(1) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(2) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Completed:   1,
+			Fraction:    1,
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+
+	// Step 3: Wait until the next resync is triggered, and then verify that status does
+	//         not change
+	//
+	verifyAllStatus(t, worker.StatusCh(),
+		// note that the payload is not retrieved a second time
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(1) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(2) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Completed:   2,
+			Fraction:    1,
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+}
+
+func TestCVO_ErrorDuringReconcile(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	defer shutdownFn()
+	worker := o.configSync.(*SyncWorker)
+	b := newBlockingResourceBuilder()
+	worker.builder = b
+
+	// Setup: a successful sync from a previous run, and the operator at the same payload as before
+	//
+	o.releaseImage = "payload/image:1"
+	o.releaseVersion = "1.0.0-abc"
+	desired := configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: clusterUID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the payload version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Payload: "payload/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	// Step 1: The sync loop starts and triggers a sync, but does not update status
+	//
+	client.ClearActions()
+	err := o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+
+	// check the worker status is initially set to reconciling
+	if status := worker.Status(); !status.Reconciling || status.Completed != 0 {
+		t.Fatalf("The worker should be reconciling from the beginning: %#v", status)
+	}
+
+	// Step 2: Start the sync worker and verify the sequence of events
+	//
+	go worker.Start(stopCh)
+	//
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "RetrievePayload",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	// verify we haven't observed any other events
+	verifyAllStatus(t, worker.StatusCh())
+
+	// Step 3: Simulate a sync being triggered while we are partway through our first
+	//         reconcile sync and verify status is not updated
+	//
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+
+	// Step 4: Unblock the first item from being applied
+	//
+	b.Send(nil)
+	//
+	// verify we observe the remaining changes in the first sync
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(1) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	verifyAllStatus(t, worker.StatusCh())
+
+	// Step 5: Unblock the first item from being applied
+	//
+	b.Send(nil)
+	//
+	// verify we observe the remaining changes in the first sync
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Fraction:    float32(2) / 3,
+			Step:        "ApplyResources",
+			VersionHash: "6GC9TkkG9PA=",
+			Actual:      configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	verifyAllStatus(t, worker.StatusCh())
+
+	// Step 6: Send an error, then verify it shows up in status
+	//
+	b.Send(fmt.Errorf("unable to proceed"))
+	//
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Reconciling: true,
+			Step:        "ApplyResources",
+			Fraction:    float32(2) / 3,
+			VersionHash: "6GC9TkkG9PA=",
+			Failure: &updateError{
+				cause:   fmt.Errorf("unable to proceed"),
+				Reason:  "UpdatePayloadFailed",
+				Message: "Could not update test \"file-yml\" (v1, 3 of 3)",
+			},
+			Actual: configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+		},
+	)
+	client.ClearActions()
+	err = o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions = client.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: clusterUID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the payload version over the operator's version (although in general they will remain in sync)
+			Desired:     configv1.Update{Version: "1.0.0-abc", Payload: "payload/image:1"},
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				// Because payload and operator had mismatched versions, we get two entries (which shouldn't happen unless there is a bug in the CVO)
+				{State: configv1.CompletedUpdate, Payload: "payload/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadFailed", Message: "Could not update test \"file-yml\" (v1, 3 of 3)"},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadFailed", Message: "Error while reconciling 1.0.0-abc: the update could not be applied"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	})
+}
+
+func verifyAllStatus(t *testing.T, ch <-chan SyncWorkerStatus, items ...SyncWorkerStatus) {
+	t.Helper()
+	if len(items) == 0 {
+		if len(ch) > 0 {
+			t.Fatalf("expected status to empty, got %#v", <-ch)
+		}
+		return
+	}
+	for i, expect := range items {
+		actual, ok := <-ch
+		if !ok {
+			t.Fatalf("channel closed after reading only %d items", i)
+		}
+		if !reflect.DeepEqual(expect, actual) {
+			t.Fatalf("unexpected status item %d: %s", i, diff.ObjectReflectDiff(expect, actual))
+		}
+	}
+}
+
+func waitFor(t *testing.T, fn func() bool) {
+	t.Helper()
+	err := wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		return fn(), nil
+	})
+	if err == wait.ErrWaitTimeout {
+		t.Fatalf("Worker condition was not reached within timeout")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// blockingResourceBuilder controls how quickly Apply() is executed and allows error
+// injection.
+type blockingResourceBuilder struct {
+	ch chan error
+}
+
+func newBlockingResourceBuilder() *blockingResourceBuilder {
+	return &blockingResourceBuilder{
+		ch: make(chan error),
+	}
+}
+
+func (b *blockingResourceBuilder) Send(err error) {
+	b.ch <- err
+}
+
+func (b *blockingResourceBuilder) Apply(m *lib.Manifest) error {
+	return <-b.ch
+}

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -11,12 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 
 	"github.com/openshift/client-go/config/clientset/versioned/scheme"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
-	"github.com/openshift/cluster-version-operator/pkg/cvo/internal/dynamicclient"
 )
 
 // readUnstructuredV1OrDie reads operatorstatus object from bytes. Panics on error.
@@ -67,11 +65,7 @@ type genericBuilder struct {
 
 // NewGenericBuilder returns an implentation of resourcebuilder.Interface that
 // uses dynamic clients for applying.
-func NewGenericBuilder(config *rest.Config, m lib.Manifest) (resourcebuilder.Interface, error) {
-	client, err := dynamicclient.New(config, m.GVK, m.Object().GetNamespace())
-	if err != nil {
-		return nil, err
-	}
+func NewGenericBuilder(client dynamic.ResourceInterface, m lib.Manifest) (resourcebuilder.Interface, error) {
 	return &genericBuilder{
 		client: client,
 		raw:    m.Raw,

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -1,21 +1,29 @@
 package cvo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
+	clientgotesting "k8s.io/client-go/testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
+	"github.com/openshift/cluster-version-operator/pkg/cvo/internal"
 )
 
 func TestHasRequeueOnErrorAnnotation(t *testing.T) {
@@ -191,12 +199,13 @@ func TestShouldRequeueOnErr(t *testing.T) {
 	}
 }
 
-func TestSyncUpdatePayload(t *testing.T) {
+func Test_SyncWorker_apply(t *testing.T) {
 	tests := []struct {
 		manifests []string
 		reactors  map[action]error
 
-		check func(*testing.T, []action)
+		check   func(*testing.T, []action)
+		wantErr bool
 	}{{
 		manifests: []string{
 			`{
@@ -220,13 +229,13 @@ func TestSyncUpdatePayload(t *testing.T) {
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 2 {
 				spew.Dump(actions)
-				t.Fatal("expected only 2 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[1], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[1], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -250,15 +259,16 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 3 {
 				spew.Dump(actions)
-				t.Fatal("expected only 3 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -285,21 +295,22 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 7 {
 				spew.Dump(actions)
-				t.Fatal("expected only 7 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[3], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[3], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[4], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[4], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -329,22 +340,23 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}: &meta.NoResourceMatchError{},
-			action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}: &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"): &meta.NoResourceMatchError{},
 		},
+		wantErr: true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 9 {
 				spew.Dump(actions)
-				t.Fatal("expected only 12 actions")
+				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[3], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[3], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
-			if got, exp := actions[6], (action{schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"}); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[6], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
 			}
 		},
@@ -361,29 +373,199 @@ func TestSyncUpdatePayload(t *testing.T) {
 			}
 
 			up := &updatePayload{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
-			op := &Operator{}
-			op.syncBackoff = wait.Backoff{Steps: 3}
-			config := &configv1.ClusterVersion{}
 			r := &recorder{}
 			testMapper := resourcebuilder.NewResourceMapper()
 			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, newTestBuilder(r, test.reactors))
 			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, newTestBuilder(r, test.reactors))
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
-			op.syncUpdatePayload(config, up)
+			worker := &SyncWorker{}
+			worker.backoff.Steps = 3
+			worker.builder = (&Operator{}).defaultResourceBuilder()
+			ctx := context.Background()
+			worker.apply(ctx, up, &SyncWork{}, &statusWrapper{w: worker, previousStatus: worker.Status()})
 			test.check(t, r.actions)
+		})
+	}
+}
+
+func Test_SyncWorker_apply_generic(t *testing.T) {
+	tests := []struct {
+		manifests []string
+		modifiers []resourcebuilder.MetaV1ObjectModifierFunc
+
+		check func(t *testing.T, client *dynamicfake.FakeDynamicClient)
+	}{
+		{
+			manifests: []string{
+				`{
+				"apiVersion": "test.cvo.io/v1",
+				"kind": "TestA",
+				"metadata": {
+					"namespace": "default",
+					"name": "testa"
+				}
+			}`,
+				`{
+				"apiVersion": "test.cvo.io/v1",
+				"kind": "TestB",
+				"metadata": {
+					"namespace": "default",
+					"name": "testb"
+				}
+			}`,
+			},
+			check: func(t *testing.T, client *dynamicfake.FakeDynamicClient) {
+				actions := client.Actions()
+				if len(actions) != 4 {
+					spew.Dump(actions)
+					t.Fatal("expected only 4 actions")
+				}
+
+				got := actions[1].(clientgotesting.CreateAction).GetObject()
+				exp := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestA",
+						"metadata": map[string]interface{}{
+							"name":      "testa",
+							"namespace": "default",
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+
+				got = actions[3].(clientgotesting.CreateAction).GetObject()
+				exp = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestB",
+						"metadata": map[string]interface{}{
+							"name":      "testb",
+							"namespace": "default",
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+			},
+		},
+		{
+			modifiers: []resourcebuilder.MetaV1ObjectModifierFunc{
+				func(obj metav1.Object) {
+					m := obj.GetLabels()
+					if m == nil {
+						m = make(map[string]string)
+					}
+					m["test/label"] = "a"
+					obj.SetLabels(m)
+				},
+			},
+			manifests: []string{
+				`{
+					"apiVersion": "test.cvo.io/v1",
+					"kind": "TestA",
+					"metadata": {
+						"namespace": "default",
+						"name": "testa"
+					}
+				}`,
+				`{
+					"apiVersion": "test.cvo.io/v1",
+					"kind": "TestB",
+					"metadata": {
+						"namespace": "default",
+						"name": "testb"
+					}
+				}`,
+			},
+			check: func(t *testing.T, client *dynamicfake.FakeDynamicClient) {
+				actions := client.Actions()
+				if len(actions) != 4 {
+					spew.Dump(actions)
+					t.Fatalf("got %d actions", len(actions))
+				}
+
+				got := actions[1].(clientgotesting.CreateAction).GetObject()
+				exp := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestA",
+						"metadata": map[string]interface{}{
+							"name":      "testa",
+							"namespace": "default",
+							"labels":    map[string]interface{}{"test/label": "a"},
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+
+				got = actions[3].(clientgotesting.CreateAction).GetObject()
+				exp = &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "test.cvo.io/v1",
+						"kind":       "TestB",
+						"metadata": map[string]interface{}{
+							"name":      "testb",
+							"namespace": "default",
+							"labels":    map[string]interface{}{"test/label": "a"},
+						},
+					},
+				}
+				if !reflect.DeepEqual(got, exp) {
+					t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				}
+			},
+		},
+	}
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
+			var manifests []lib.Manifest
+			for _, s := range test.manifests {
+				m := lib.Manifest{}
+				if err := json.Unmarshal([]byte(s), &m); err != nil {
+					t.Fatal(err)
+				}
+				manifests = append(manifests, m)
+			}
+
+			dynamicScheme := runtime.NewScheme()
+			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, &unstructured.Unstructured{})
+			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, &unstructured.Unstructured{})
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
+
+			up := &updatePayload{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
+			worker := &SyncWorker{}
+			worker.backoff.Steps = 1
+			worker.builder = &testResourceBuilder{
+				client:    dynamicClient,
+				modifiers: test.modifiers,
+			}
+			ctx := context.Background()
+			err := worker.apply(ctx, up, &SyncWork{}, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.check(t, dynamicClient)
 		})
 	}
 }
 
 type testBuilder struct {
 	*recorder
-	reactors map[action]error
+	reactors  map[action]error
+	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
 
 	m *lib.Manifest
 }
 
-func (t *testBuilder) WithModifier(_ resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
+func (t *testBuilder) WithModifier(m resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
+	t.modifiers = append(t.modifiers, m)
 	return t
 }
 
@@ -412,4 +594,74 @@ type action struct {
 	GVK       schema.GroupVersionKind
 	Namespace string
 	Name      string
+}
+
+func newAction(gvk schema.GroupVersionKind, namespace, name string) action {
+	return action{GVK: gvk, Namespace: namespace, Name: name}
+}
+
+type fakeSyncRecorder struct {
+	Returns *SyncWorkerStatus
+	Updates []configv1.Update
+}
+
+func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
+	ch := make(chan SyncWorkerStatus)
+	close(ch)
+	return ch
+}
+
+func (r *fakeSyncRecorder) Start(stopCh <-chan struct{}) {}
+
+func (r *fakeSyncRecorder) Update(desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus {
+	r.Updates = append(r.Updates, desired)
+	return r.Returns
+}
+
+type fakeResourceBuilder struct {
+	M   []*lib.Manifest
+	Err error
+}
+
+func (b *fakeResourceBuilder) Apply(m *lib.Manifest) error {
+	b.M = append(b.M, m)
+	return b.Err
+}
+
+type fakeDirectoryRetriever struct {
+	Path string
+	Err  error
+}
+
+func (r *fakeDirectoryRetriever) RetrievePayload(ctx context.Context, update configv1.Update) (string, error) {
+	return r.Path, r.Err
+}
+
+type fakePayloadRetriever struct {
+	Dir string
+	Err error
+}
+
+func (r *fakePayloadRetriever) RetrievePayload(ctx context.Context, desired configv1.Update) (string, error) {
+	return r.Dir, r.Err
+}
+
+// testResourceBuilder uses a fake dynamic client to exercise the generic builder in tests.
+type testResourceBuilder struct {
+	client    *dynamicfake.FakeDynamicClient
+	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
+}
+
+func (b *testResourceBuilder) Apply(m *lib.Manifest) error {
+	ns := m.Object().GetNamespace()
+	fakeGVR := schema.GroupVersionResource{Group: m.GVK.Group, Version: m.GVK.Version, Resource: strings.ToLower(m.GVK.Kind)}
+	client := b.client.Resource(fakeGVR).Namespace(ns)
+	builder, err := internal.NewGenericBuilder(client, *m)
+	if err != nil {
+		return err
+	}
+	for _, m := range b.modifiers {
+		builder = builder.WithModifier(m)
+	}
+	return builder.Do()
 }

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -1,0 +1,497 @@
+package cvo
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-version-operator/lib"
+)
+
+// ConfigSyncWorker abstracts how the payload is synchronized to the server. Introduced for testing.
+type ConfigSyncWorker interface {
+	Start(stopCh <-chan struct{})
+	Update(desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus
+	StatusCh() <-chan SyncWorkerStatus
+}
+
+// PayloadRetriever abstracts how a desired version is extracted to disk. Introduced for testing.
+type PayloadRetriever interface {
+	RetrievePayload(ctx context.Context, desired configv1.Update) (string, error)
+}
+
+// ResourceBuilder abstracts how a manifest is created on the server. Introduced for testing.
+type ResourceBuilder interface {
+	Apply(*lib.Manifest) error
+}
+
+// StatusReporter abstracts how status is reported by the worker run method. Introduced for testing.
+type StatusReporter interface {
+	Report(status SyncWorkerStatus)
+}
+
+// SyncWork represents the work that should be done in a sync iteration.
+type SyncWork struct {
+	Desired     configv1.Update
+	Overrides   []configv1.ComponentOverride
+	Reconciling bool
+	Completed   int
+}
+
+// Empty returns true if the payload is empty for this work.
+func (w SyncWork) Empty() bool {
+	return len(w.Desired.Payload) == 0
+}
+
+// SyncWorkerStatus is the status of the sync worker at a given time.
+type SyncWorkerStatus struct {
+	Step    string
+	Failure error
+
+	Fraction float32
+
+	Completed   int
+	Reconciling bool
+	VersionHash string
+
+	Actual configv1.Update
+}
+
+// DeepCopy copies the worker status.
+func (w SyncWorkerStatus) DeepCopy() *SyncWorkerStatus {
+	return &w
+}
+
+// SyncWorker retrieves and applies the desired payload, tracking the status for the parent to
+// monitor. The worker accepts a desired state via Update() and works to keep that state in
+// sync. Once a particular payload version is synced, it will be updated no more often than
+// minimumReconcileInterval.
+//
+// State transitions:
+//
+//   Initial: wait for valid Update(), report empty status
+//     Update() -> Sync
+//   Sync: attempt to invoke the syncOnce() method
+//     syncOnce() returns an error -> Error
+//     syncOnce() returns nil -> Reconciling
+//   Reconciling: invoke syncOnce() no more often than reconcileInterval
+//     Update() with different values -> Sync
+//     syncOnce() returns an error -> Error
+//     syncOnce() returns nil -> Reconciling
+//   Error: backoff until we are attempting every reconcileInterval
+//     syncOnce() returns an error -> Error
+//     syncOnce() returns nil -> Reconciling
+//
+type SyncWorker struct {
+	backoff     wait.Backoff
+	retriever   PayloadRetriever
+	builder     ResourceBuilder
+	reconciling bool
+
+	// minimumReconcileInterval is the minimum time between reconcile attempts, and is
+	// used to define the maximum backoff interval when syncOnce() returns an error.
+	minimumReconcileInterval time.Duration
+
+	// coordination between the sync loop and external callers
+	notify chan struct{}
+	report chan SyncWorkerStatus
+
+	// lock guards changes to these fields
+	lock     sync.Mutex
+	work     *SyncWork
+	cancelFn func()
+	status   SyncWorkerStatus
+
+	// updated by the run method only
+	payload *updatePayload
+}
+
+// NewSyncWorker initializes a ConfigSyncWorker that will retrieve payloads to disk, apply them via builder
+// to a server, and obey limits about how often to reconcile or retry on errors.
+func NewSyncWorker(retriever PayloadRetriever, builder ResourceBuilder, reconcileInterval time.Duration, backoff wait.Backoff) ConfigSyncWorker {
+	return &SyncWorker{
+		retriever: retriever,
+		builder:   builder,
+		backoff:   backoff,
+
+		minimumReconcileInterval: reconcileInterval,
+
+		notify: make(chan struct{}, 1),
+		// report is a large buffered channel to improve local testing - most consumers should invoke
+		// Status() or use the result of calling Update() instead because the channel can be out of date
+		// if the reader is not fast enough.
+		report: make(chan SyncWorkerStatus, 500),
+	}
+}
+
+// StatusCh returns a channel that reports status from the worker. The channel is buffered and events
+// can be lost, so this is best used as a trigger to read the latest status.
+func (w *SyncWorker) StatusCh() <-chan SyncWorkerStatus {
+	return w.report
+}
+
+// Update instructs the sync worker to start synchronizing the desired update. The reconciling boolean is
+// ignored unless this is the first time that Update has been called. The returned status represents either
+// the initial state or whatever the last recorded status was.
+// TODO: in the future it may be desirable for changes that alter desired to wait briefly before returning,
+//   giving the sync loop the opportunity to observe our change and begin working towards it.
+func (w *SyncWorker) Update(desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	work := &SyncWork{
+		Desired:   desired,
+		Overrides: overrides,
+	}
+
+	if work.Empty() || equalSyncWork(w.work, work) {
+		return w.status.DeepCopy()
+	}
+
+	// initialize the reconciliation flag and the status the first time
+	// update is invoked
+	if w.work == nil {
+		if reconciling {
+			work.Reconciling = true
+		}
+		w.status = SyncWorkerStatus{Reconciling: work.Reconciling, Actual: work.Desired}
+	}
+
+	// notify the sync loop that we changed config
+	w.work = work
+	if w.cancelFn != nil {
+		w.cancelFn()
+		w.cancelFn = nil
+	}
+	select {
+	case w.notify <- struct{}{}:
+	default:
+	}
+
+	return w.status.DeepCopy()
+}
+
+// Start periodically invokes run, detecting whether content has changed.
+// It is edge-triggered when Update() is invoked and level-driven after the
+// syncOnce() has succeeded for a given input (we are said to be "reconciling").
+func (w *SyncWorker) Start(stopCh <-chan struct{}) {
+	glog.V(5).Infof("Starting sync worker")
+
+	work := &SyncWork{}
+
+	wait.Until(func() {
+		consecutiveErrors := 0
+		errorInterval := w.minimumReconcileInterval / 16
+
+		var next <-chan time.Time
+		for {
+			waitingToReconcile := work.Reconciling
+			select {
+			case <-stopCh:
+				glog.V(5).Infof("Stopped worker")
+				return
+			case <-next:
+				waitingToReconcile = false
+				glog.V(5).Infof("Wait finished")
+			case <-w.notify:
+				glog.V(5).Infof("Work updated")
+			}
+
+			// determine whether we need to do work
+			changed := w.calculateNext(work)
+			if !changed && waitingToReconcile {
+				glog.V(5).Infof("No change, waiting")
+				continue
+			}
+
+			// until Update() has been called at least once, we do nothing
+			if work.Empty() {
+				next = time.After(w.minimumReconcileInterval)
+				glog.V(5).Infof("No work, waiting")
+				continue
+			}
+
+			// actually apply the payload, allowing for calls to be cancelled
+			err := func() error {
+				ctx, cancelFn := context.WithCancel(context.Background())
+				w.lock.Lock()
+				w.cancelFn = cancelFn
+				w.lock.Unlock()
+				defer cancelFn()
+
+				// reporter hides status updates that occur earlier than the previous failure,
+				// so that we don't fail, then immediately start reporting an earlier status
+				reporter := &statusWrapper{w: w, previousStatus: w.Status()}
+				glog.V(5).Infof("Previous sync status: %#v", reporter.previousStatus)
+				return w.syncOnce(ctx, work, reporter)
+			}()
+			if err != nil {
+				// backoff wait
+				// TODO: replace with wait.Backoff when 1.13 client-go is available
+				consecutiveErrors++
+				interval := w.minimumReconcileInterval
+				if consecutiveErrors < 4 {
+					interval = errorInterval
+					for i := 0; i < consecutiveErrors; i++ {
+						interval *= 2
+					}
+				}
+				next = time.After(wait.Jitter(interval, 0.2))
+
+				utilruntime.HandleError(fmt.Errorf("unable to synchronize payload (waiting %s): %v", interval, err))
+				continue
+			}
+			glog.V(5).Infof("Sync succeeded, reconciling")
+
+			work.Reconciling = true
+			next = time.After(w.minimumReconcileInterval)
+		}
+	}, 10*time.Millisecond, stopCh)
+
+	glog.V(5).Infof("Worker shut down")
+}
+
+// statusWrapper prevents a newer status update from overwriting a previous
+// failure from later in the sync process.
+type statusWrapper struct {
+	w              *SyncWorker
+	previousStatus *SyncWorkerStatus
+}
+
+func (w *statusWrapper) Report(status SyncWorkerStatus) {
+	p := w.previousStatus
+	if p.Failure != nil && status.Failure == nil {
+		if p.Actual == status.Actual {
+			if status.Fraction < p.Fraction {
+				glog.V(5).Infof("Dropping status report from earlier in sync loop")
+				return
+			}
+		}
+	}
+	w.w.updateStatus(status)
+}
+
+// calculateNext updates the passed work object with the desired next state and
+// returns true if any changes were made. The reconciling flag is set the first
+// time work transitions from empty to not empty (as a result of someone invoking
+// Update).
+func (w *SyncWorker) calculateNext(work *SyncWork) bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	changed := !equalSyncWork(w.work, work)
+
+	// if this is the first time through the loop, initialize reconciling to
+	// the state Update() calculated (to allow us to start in reconciling)
+	if work.Empty() {
+		work.Reconciling = w.work.Reconciling
+	} else {
+		if changed {
+			work.Reconciling = false
+		}
+	}
+	// always clear the completed variable if we are not reconciling
+	if !work.Reconciling {
+		work.Completed = 0
+	}
+
+	if w.work != nil {
+		work.Desired = w.work.Desired
+		work.Overrides = w.work.Overrides
+	}
+
+	return changed
+}
+
+// equalUpdate returns true if two updates have the same payload.
+func equalUpdate(a, b configv1.Update) bool {
+	return a.Payload == b.Payload
+}
+
+// equalSyncWork returns true if a and b are equal.
+func equalSyncWork(a, b *SyncWork) bool {
+	if a == b {
+		return true
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	return equalUpdate(a.Desired, b.Desired) && reflect.DeepEqual(a.Overrides, b.Overrides)
+}
+
+// updateStatus records the current status of the sync action for observation
+// by others. It sends a copy of the update to the report channel for improved
+// testability.
+func (w *SyncWorker) updateStatus(update SyncWorkerStatus) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	glog.V(5).Infof("Status change %#v", update)
+	w.status = update
+	select {
+	case w.report <- update:
+	default:
+		if glog.V(5) {
+			glog.Infof("Status report channel was full %#v", update)
+		}
+	}
+}
+
+// Desired returns the state the SyncWorker is trying to achieve.
+func (w *SyncWorker) Desired() configv1.Update {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if w.work == nil {
+		return configv1.Update{}
+	}
+	return w.work.Desired
+}
+
+// Status returns a copy of the current worker status.
+func (w *SyncWorker) Status() *SyncWorkerStatus {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	return w.status.DeepCopy()
+}
+
+// sync retrieves the payload and applies it to the server, returning an error if
+// the update could not be completely applied. The status is updated as we progress.
+// Cancelling the context will abort the execution of the sync.
+func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, reporter StatusReporter) error {
+	glog.V(4).Infof("Running sync %s", versionString(work.Desired))
+	update := work.Desired
+
+	// cache the payload until the release image changes
+	payload := w.payload
+	if payload == nil || !equalUpdate(configv1.Update{Payload: payload.ReleaseImage}, update) {
+		glog.V(4).Infof("Loading payload")
+		reporter.Report(SyncWorkerStatus{Step: "RetrievePayload", Reconciling: work.Reconciling, Actual: update})
+		payloadDir, err := w.retriever.RetrievePayload(ctx, update)
+		if err != nil {
+			reporter.Report(SyncWorkerStatus{Failure: err, Step: "RetrievePayload", Reconciling: work.Reconciling, Actual: update})
+			return err
+		}
+		payload, err := loadUpdatePayload(payloadDir, update.Payload)
+		if err != nil {
+			reporter.Report(SyncWorkerStatus{Failure: err, Step: "VerifyPayload", Reconciling: work.Reconciling, Actual: update})
+			return err
+		}
+		w.payload = payload
+		glog.V(4).Infof("Payload loaded from %s with hash %s", payload.ReleaseImage, payload.ManifestHash)
+	}
+
+	return w.apply(ctx, w.payload, work, reporter)
+}
+
+// apply updates the server with the contents of the provided payload or returns an error.
+// Cancelling the context will abort the execution of the sync.
+func (w *SyncWorker) apply(ctx context.Context, payload *updatePayload, work *SyncWork, reporter StatusReporter) error {
+	update := configv1.Update{
+		Version: payload.ReleaseVersion,
+		Payload: payload.ReleaseImage,
+	}
+
+	// update each object
+	version := payload.ReleaseVersion
+	total := len(payload.Manifests)
+	done := 0
+	var tasks []*syncTask
+	for i := range payload.Manifests {
+		tasks = append(tasks, &syncTask{
+			index:    i + 1,
+			total:    total,
+			manifest: &payload.Manifests[i],
+			backoff:  w.backoff,
+		})
+	}
+
+	for i := 0; i < len(tasks); i++ {
+		task := tasks[i]
+		setAppliedAndPending(version, total, done)
+		fraction := float32(i) / float32(len(tasks))
+
+		reporter.Report(SyncWorkerStatus{Fraction: fraction, Step: "ApplyResources", Reconciling: work.Reconciling, VersionHash: payload.ManifestHash, Actual: update})
+
+		glog.V(4).Infof("Running sync for %s", task)
+		glog.V(5).Infof("Manifest: %s", string(task.manifest.Raw))
+
+		if contextIsCancelled(ctx) {
+			err := fmt.Errorf("update was cancelled at %d/%d", i, len(tasks))
+			reporter.Report(SyncWorkerStatus{Failure: err, Fraction: fraction, Step: "ApplyResources", Reconciling: work.Reconciling, VersionHash: payload.ManifestHash, Actual: update})
+			return err
+		}
+
+		ov, ok := getOverrideForManifest(work.Overrides, task.manifest)
+		if ok && ov.Unmanaged {
+			glog.V(4).Infof("Skipping %s as unmanaged", task)
+			continue
+		}
+
+		if err := task.Run(version, w.builder); err != nil {
+			reporter.Report(SyncWorkerStatus{Failure: err, Fraction: fraction, Step: "ApplyResources", Reconciling: work.Reconciling, VersionHash: payload.ManifestHash, Actual: update})
+			cause := errors.Cause(err)
+			if task.requeued == 0 && shouldRequeueOnErr(cause, task.manifest) {
+				task.requeued++
+				tasks = append(tasks, task)
+				continue
+			}
+			return err
+		}
+		done++
+		glog.V(4).Infof("Done syncing for %s", task)
+	}
+
+	setAppliedAndPending(version, total, done)
+	work.Completed++
+	reporter.Report(SyncWorkerStatus{Fraction: 1, Completed: work.Completed, Reconciling: true, VersionHash: payload.ManifestHash, Actual: update})
+
+	return nil
+}
+
+// contextIsCancelled returns true if the provided context is cancelled.
+func contextIsCancelled(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// runThrottledStatusNotifier invokes fn every time ch is updated, but no more often than once
+// every interval. If bucket is non-zero then the channel is throttled like a rate limiter bucket.
+func runThrottledStatusNotifier(stopCh <-chan struct{}, interval time.Duration, bucket int, ch <-chan SyncWorkerStatus, fn func()) {
+	// notify the status change function fairly infrequently to avoid updating
+	// the caller status more frequently than is needed
+	throttle := rate.NewLimiter(rate.Every(interval), bucket)
+	wait.Until(func() {
+		ctx := context.Background()
+		var last SyncWorkerStatus
+		for {
+			select {
+			case <-stopCh:
+				return
+			case next := <-ch:
+				// only throttle if we aren't on an edge
+				if next.Actual == last.Actual && next.Reconciling == last.Reconciling && (next.Failure != nil) == (last.Failure != nil) {
+					if err := throttle.Wait(ctx); err != nil {
+						utilruntime.HandleError(fmt.Errorf("unable to throttle status notification: %v", err))
+					}
+				}
+				last = next
+
+				fn()
+			}
+		}
+	}, 1*time.Second, stopCh)
+}

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -1,0 +1,131 @@
+package cvo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func Test_statusWrapper_Report(t *testing.T) {
+	tests := []struct {
+		name     string
+		previous SyncWorkerStatus
+		next     SyncWorkerStatus
+		want     bool
+	}{
+		{
+			name:     "skip updates that clear an error and are at an earlier fraction",
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			next:     SyncWorkerStatus{Actual: configv1.Update{Payload: "testing"}},
+			want:     false,
+		},
+		{
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			next:     SyncWorkerStatus{Actual: configv1.Update{Payload: "testing2"}},
+			want:     true,
+		},
+		{
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}},
+			next:     SyncWorkerStatus{Actual: configv1.Update{Payload: "testing"}},
+			want:     true,
+		},
+		{
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			next:     SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}},
+			want:     true,
+		},
+		{
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			next:     SyncWorkerStatus{Failure: fmt.Errorf("b"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			want:     true,
+		},
+		{
+			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.1},
+			next:     SyncWorkerStatus{Failure: fmt.Errorf("b"), Actual: configv1.Update{Payload: "testing"}, Fraction: 0.2},
+			want:     true,
+		},
+		{
+			previous: SyncWorkerStatus{Actual: configv1.Update{Payload: "testing"}},
+			next:     SyncWorkerStatus{Actual: configv1.Update{Payload: "testing"}},
+			want:     true,
+		},
+		{
+			next: SyncWorkerStatus{Actual: configv1.Update{Payload: "testing"}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &statusWrapper{
+				previousStatus: &tt.previous,
+			}
+			w.w = &SyncWorker{report: make(chan SyncWorkerStatus, 1)}
+			w.Report(tt.next)
+			close(w.w.report)
+			if tt.want {
+				select {
+				case evt, ok := <-w.w.report:
+					if !ok {
+						t.Fatalf("no event")
+					}
+					if evt != tt.next {
+						t.Fatalf("unexpected: %#v", evt)
+					}
+				}
+			} else {
+				select {
+				case evt, ok := <-w.w.report:
+					if ok {
+						t.Fatalf("unexpected event: %#v", evt)
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_runThrottledStatusNotifier(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	in := make(chan SyncWorkerStatus)
+	out := make(chan struct{}, 100)
+
+	go runThrottledStatusNotifier(stopCh, 30*time.Second, 1, in, func() { out <- struct{}{} })
+
+	in <- SyncWorkerStatus{Actual: configv1.Update{Payload: "test"}}
+	select {
+	case <-out:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("should have not throttled")
+	}
+
+	in <- SyncWorkerStatus{Reconciling: true, Actual: configv1.Update{Payload: "test"}}
+	select {
+	case <-out:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("should have not throttled")
+	}
+
+	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Update{Payload: "test"}}
+	select {
+	case <-out:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("should have not throttled")
+	}
+
+	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Update{Payload: "test"}}
+	select {
+	case <-out:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("should have not throttled")
+	}
+
+	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Update{Payload: "test"}}
+	select {
+	case <-out:
+		t.Fatalf("should have throttled")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+var _ dynamic.Interface = &FakeDynamicClient{}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Version: "v1", Kind: "List"}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	for _, item := range entireList.Items {
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}


### PR DESCRIPTION
Implement #77

* Refactor payload syncing into its own loop, and the main loop tells it what to do and gathers status on where it is
   * Take subtle behavior of syncing and put it into the worker, not the sync loop (retries, timeouts, remembering status)
* Writing CV status is much simpler and is based only on inputs (what the sync loop is doing + available updates + validation errors)
* Add integration and more extensive core testing