### PR TITLE
pkg/cincinnati: scope HTTP request to a context

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -1,6 +1,7 @@
 package cincinnati
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -38,7 +39,7 @@ type Update node
 // finding all of the children. These children are the available updates for
 // the current version and their payloads indicate from where the actual update
 // image can be downloaded.
-func (c Client) GetUpdates(upstream string, channel string, version semver.Version) ([]Update, error) {
+func (c Client) GetUpdates(ctx context.Context, upstream string, channel string, version semver.Version) ([]Update, error) {
 	// Prepare parametrized cincinnati query.
 	cincinnatiURL, err := url.Parse(upstream)
 	if err != nil {
@@ -58,7 +59,7 @@ func (c Client) GetUpdates(upstream string, channel string, version semver.Versi
 	req.Header.Add("Accept", GraphMediaType)
 
 	client := http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -1,6 +1,7 @@
 package cincinnati
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -123,7 +124,7 @@ func TestGetUpdates(t *testing.T) {
 
 			c := NewClient(clientID)
 
-			updates, err := c.GetUpdates(ts.URL, channelName, semver.MustParse(test.version))
+			updates, err := c.GetUpdates(context.TODO(), ts.URL, channelName, semver.MustParse(test.version))
 			if test.err == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -361,8 +362,8 @@ func (optr *Operator) availableUpdatesSync(key string) error {
 	if errs := validation.ValidateClusterVersion(config); len(errs) > 0 {
 		return nil
 	}
-
-	return optr.syncAvailableUpdates(config)
+	ctx := context.TODO()
+	return optr.syncAvailableUpdates(ctx, config)
 }
 
 // isOlderThanLastUpdate returns true if the cluster version is older than


### PR DESCRIPTION
This adds a context to remote cincinnati calls. The topmost context is
left floating as the caller is not context-aware at the moment.