### PR TITLE
pkg/cincinnati: fix media-type

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	// ContentTypeGraphV1 is the MIME type specified in the HTTP Accept header
-	// of requests sent to the Cincinnati Graph API.
-	ContentTypeGraphV1 = "application/vnd.redhat.cincinnati.graph+json; version=1.0"
+	// GraphMediaType is the media-type specified in the HTTP Accept header
+	// of requests sent to the Cincinnati-v1 Graph API.
+	GraphMediaType = "application/json"
 )
 
 // Client is a Cincinnati client which can be used to fetch update graphs from
@@ -43,7 +43,7 @@ func (c Client) GetUpdates(upstream string, channel string, version semver.Versi
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", ContentTypeGraphV1)
+	req.Header.Add("Accept", GraphMediaType)
 
 	client := http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
This aligns client-accepted media type to cincinnati spec.

Ref: https://github.com/openshift/cincinnati/blob/06c9ce64367b55f453295b2765a9aab61791dc76/docs/design/cincinnati.md#request