### PR TITLE
cvo: Don't wake the CVO on a cluster operator change

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -172,7 +172,6 @@ func New(
 	)
 
 	cvInformer.Informer().AddEventHandler(optr.eventHandler())
-	clusterOperatorInformer.Informer().AddEventHandler(optr.eventHandler())
 
 	optr.clusterOperatorLister = clusterOperatorInformer.Lister()
 	optr.clusterOperatorSynced = clusterOperatorInformer.Informer().HasSynced


### PR DESCRIPTION
We don't actually react to cluster operator objects today. We can
safely ignore this edge since we already wait inside sync loop.