### PR TITLE
Increase the QPS limits on clients slightly and use protobuf for sync

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -24,7 +24,7 @@ type crdBuilder struct {
 
 func newCRDBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &crdBuilder{
-		client: apiextclientv1beta1.NewForConfigOrDie(config),
+		client: apiextclientv1beta1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -25,7 +25,7 @@ type deploymentBuilder struct {
 
 func newDeploymentBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &deploymentBuilder{
-		client: appsclientv1.NewForConfigOrDie(config),
+		client: appsclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -89,7 +89,7 @@ type daemonsetBuilder struct {
 
 func newDaemonsetBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &daemonsetBuilder{
-		client: appsclientv1.NewForConfigOrDie(config),
+		client: appsclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -24,7 +24,7 @@ type jobBuilder struct {
 
 func newJobBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &jobBuilder{
-		client: batchclientv1.NewForConfigOrDie(config),
+		client: batchclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/lib/resourcebuilder/core.go
+++ b/lib/resourcebuilder/core.go
@@ -16,7 +16,7 @@ type serviceAccountBuilder struct {
 
 func newServiceAccountBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &serviceAccountBuilder{
-		client: coreclientv1.NewForConfigOrDie(config),
+		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -43,7 +43,7 @@ type configMapBuilder struct {
 
 func newConfigMapBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &configMapBuilder{
-		client: coreclientv1.NewForConfigOrDie(config),
+		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -70,7 +70,7 @@ type namespaceBuilder struct {
 
 func newNamespaceBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &namespaceBuilder{
-		client: coreclientv1.NewForConfigOrDie(config),
+		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -97,7 +97,7 @@ type serviceBuilder struct {
 
 func newServiceBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &serviceBuilder{
-		client: coreclientv1.NewForConfigOrDie(config),
+		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/lib/resourcebuilder/helper.go
+++ b/lib/resourcebuilder/helper.go
@@ -1,0 +1,11 @@
+package resourcebuilder
+
+import "k8s.io/client-go/rest"
+
+// withProtobuf makes a client use protobuf.
+func withProtobuf(config *rest.Config) *rest.Config {
+	config = rest.CopyConfig(config)
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+	return config
+}

--- a/lib/resourcebuilder/rbac.go
+++ b/lib/resourcebuilder/rbac.go
@@ -16,7 +16,7 @@ type clusterRoleBuilder struct {
 
 func newClusterRoleBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &clusterRoleBuilder{
-		client: rbacclientv1.NewForConfigOrDie(config),
+		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -43,7 +43,7 @@ type clusterRoleBindingBuilder struct {
 
 func newClusterRoleBindingBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &clusterRoleBindingBuilder{
-		client: rbacclientv1.NewForConfigOrDie(config),
+		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -70,7 +70,7 @@ type roleBuilder struct {
 
 func newRoleBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &roleBuilder{
-		client: rbacclientv1.NewForConfigOrDie(config),
+		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }
@@ -97,7 +97,7 @@ type roleBindingBuilder struct {
 
 func newRoleBindingBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &roleBindingBuilder{
-		client: rbacclientv1.NewForConfigOrDie(config),
+		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/lib/resourcebuilder/security.go
+++ b/lib/resourcebuilder/security.go
@@ -16,7 +16,7 @@ type securityBuilder struct {
 
 func newSecurityBuilder(config *rest.Config, m lib.Manifest) Interface {
 	return &securityBuilder{
-		client: securityclientv1.NewForConfigOrDie(config),
+		client: securityclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
 }

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -154,7 +154,7 @@ func New(
 		client:        client,
 		kubeClient:    kubeClient,
 		apiExtClient:  apiExtClient,
-		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "clusterversionoperator"}),
+		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: namespace}),
 
 		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterversion"),
 		availableUpdatesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "availableupdates"),

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
-	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -83,7 +82,6 @@ type Operator struct {
 
 	client        clientset.Interface
 	kubeClient    kubernetes.Interface
-	apiExtClient  apiextclientset.Interface
 	eventRecorder record.EventRecorder
 
 	// minimumUpdateCheckInterval is the minimum duration to check for updates from
@@ -132,7 +130,6 @@ func New(
 	restConfig *rest.Config,
 	client clientset.Interface,
 	kubeClient kubernetes.Interface,
-	apiExtClient apiextclientset.Interface,
 	enableMetrics bool,
 ) *Operator {
 	eventBroadcaster := record.NewBroadcaster()
@@ -153,7 +150,6 @@ func New(
 		restConfig:    restConfig,
 		client:        client,
 		kubeClient:    kubeClient,
-		apiExtClient:  apiExtClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: namespace}),
 
 		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterversion"),


### PR DESCRIPTION
For the kube apis, protobuf is more efficient on both client and server
side which reduces the base load of the cluster. We can't set protobuf for
custom resource clients or unstructured at the current time.

We are getting a fair amount of throttling during deployment and updates.
Increase QPS and Burst to be 4x the default. Refactor the start client
slightly to allow modifying the client in case we need to do this in the
future.