### PR TITLE
metrics: Report the age of the current payload for alerting

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -2,13 +2,23 @@
 
 The Cluster Version Operator reports the following metrics:
 
-Core metrics for the version
+Core metrics for the version. Types:
+
+* `current` - the version the operator is applying right now (the running CVO version)
+* `failure` - if the failure condition is set, reported for desired and current versions
+* `desired` - reported if different from current
+* `completed` - returns 1 and the info of the most recent `Completed` entry in the history, or 0 otherwise
+
+`current` has the `age` label set to the unix timestamp of the payload age, `completed` has the `age` label
+set to the time at which the update was completed. All other variants have empty age labels.
 
 ```
 # HELP cluster_version Reports the version of the cluster.
 # TYPE cluster_version gauge
-cluster_version{payload="test/image:1",type="current",version="4.0.2"} 1
-cluster_version{payload="test/image:1",type="failure",version="4.0.2"} 1
+cluster_version{age="132049356",payload="test/image:1",type="current",version="4.0.2"} 1
+cluster_version{age="",payload="test/image:1",type="failure",version="4.0.2"} 1
+cluster_version{age="",payload="test/image:2",type="desired",version="4.0.3"} 1
+cluster_version{age="132064396",payload="test/image:1",type="completed",version="4.0.2"} 1
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge
 cluster_version_available_updates{channel="fast",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -70,12 +70,15 @@ type Operator struct {
 	// namespace and name are used to find the ClusterVersion, OperatorStatus.
 	namespace, name string
 
-	// releaseImage allows templating CVO deployment manifest.
+	// releaseImage is the image the current operator points to and allows
+	// templating of the CVO deployment manifest.
 	releaseImage string
 	// releaseVersion is a string identifier for the current version, read
 	// from the payload of the operator. It may be empty if no version exists, in
 	// which case no available updates will be returned.
 	releaseVersion string
+	// releaseCreated, if set, is the timestamp of the current update.
+	releaseCreated time.Time
 
 	// restConfig is used to create resourcebuilder.
 	restConfig *rest.Config
@@ -184,6 +187,7 @@ func New(
 	if meta, _, err := loadUpdatePayloadMetadata(optr.defaultPayloadDir(), releaseImage); err != nil {
 		glog.Warningf("The local payload is invalid - no current version can be determined from disk: %v", err)
 	} else {
+		optr.releaseCreated = meta.ImageRef.CreationTimestamp.Time
 		// XXX: set this to the cincinnati version in preference
 		if _, err := semver.Parse(meta.ImageRef.Name); err != nil {
 			glog.Warningf("The local payload name %q is not a valid semantic version - no current version will be reported: %v", meta.ImageRef.Name, err)

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -1,6 +1,8 @@
 package cvo
 
 import (
+	"strconv"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,8 +46,15 @@ func newOperatorMetrics(optr *Operator) *operatorMetrics {
 
 		version: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_version",
-			Help: "Reports the version of the cluster.",
-		}, []string{"type", "version", "payload"}),
+			Help: `Reports the version of the cluster. The type is 'current' for
+what is being actively applied, 'desired' if a different
+update will be applied, 'failure' if either current or
+desired cannot be applied, and 'completed' as the last update
+that reached a conclusion. The age label is seconds since the
+epoch and for 'current' is the payload creation timestamp and
+for 'completed' is the time the update was first successfully
+applied.`,
+		}, []string{"type", "version", "payload", "age"}),
 		availableUpdates: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_version_available_updates",
 			Help: "Report the count of available versions for an upstream and channel.",
@@ -62,32 +71,53 @@ func newOperatorMetrics(optr *Operator) *operatorMetrics {
 }
 
 func (m *operatorMetrics) Describe(ch chan<- *prometheus.Desc) {
-	ch <- m.version.WithLabelValues("", "", "").Desc()
+	ch <- m.version.WithLabelValues("", "", "", "").Desc()
 }
 
 func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 	current := m.optr.currentVersion()
-	g := m.version.WithLabelValues("current", current.Version, current.Payload)
+	currentAge := ""
+	if !m.optr.releaseCreated.IsZero() {
+		currentAge = strconv.FormatInt(m.optr.releaseCreated.Unix(), 10)
+	}
+	g := m.version.WithLabelValues("current", current.Version, current.Payload, currentAge)
 	g.Set(1)
 	ch <- g
 	if cv, err := m.optr.cvLister.Get(m.optr.name); err == nil {
 		// output cluster version
 		failing := resourcemerge.IsOperatorStatusConditionTrue(cv.Status.Conditions, configv1.OperatorFailing)
 		if update := cv.Spec.DesiredUpdate; update != nil && update.Payload != current.Payload {
-			g := m.version.WithLabelValues("update", update.Version, update.Payload)
+			g := m.version.WithLabelValues("desired", update.Version, update.Payload, "")
 			g.Set(1)
 			ch <- g
 			if failing {
-				g = m.version.WithLabelValues("failure", update.Version, update.Payload)
+				g = m.version.WithLabelValues("failure", update.Version, update.Payload, "")
 				g.Set(1)
 				ch <- g
 			}
 		}
 		if failing {
-			g := m.version.WithLabelValues("failure", current.Version, current.Payload)
+			g := m.version.WithLabelValues("failure", current.Version, current.Payload, currentAge)
 			g.Set(1)
 			ch <- g
 		}
+
+		// record the last completed update is completed at least once (1) or no completed update has been applied (0)
+		var completedUpdate configv1.Update
+		completed := float64(0)
+		completedAge := ""
+		for _, history := range cv.Status.History {
+			if history.State == configv1.CompletedUpdate {
+				completedUpdate.Payload = history.Payload
+				completedUpdate.Version = history.Version
+				completed = 1
+				completedAge = strconv.FormatInt(history.CompletionTime.Time.Unix(), 10)
+				break
+			}
+		}
+		g := m.version.WithLabelValues("completed", completedUpdate.Version, completedUpdate.Payload, completedAge)
+		g.Set(completed)
+		ch <- g
 
 		if len(cv.Spec.Upstream) > 0 || len(cv.Status.AvailableUpdates) > 0 || resourcemerge.IsOperatorStatusConditionTrue(cv.Status.Conditions, configv1.RetrievedUpdates) {
 			upstream := "<default>"

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -2,7 +2,9 @@ package cvo
 
 import (
 	"testing"
+	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -20,12 +22,87 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			optr: &Operator{
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
+				releaseCreated: time.Unix(3, 0),
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
 				if len(metrics) != 1 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1"})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": "3"})
+			},
+		},
+		{
+			name: "collects current version with no age",
+			optr: &Operator{
+				releaseVersion: "0.0.2",
+				releaseImage:   "test/image:1",
+			},
+			wants: func(t *testing.T, metrics []prometheus.Metric) {
+				if len(metrics) != 1 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
+				}
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+			},
+		},
+		{
+			name: "collects completed history",
+			optr: &Operator{
+				name:           "test",
+				releaseVersion: "0.0.2",
+				releaseImage:   "test/image:1",
+				releaseCreated: time.Unix(3, 0),
+				cvLister: &cvLister{
+					Items: []*configv1.ClusterVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+							Status: configv1.ClusterVersionStatus{
+								History: []configv1.UpdateHistory{
+									{State: configv1.PartialUpdate, CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
+									{State: configv1.CompletedUpdate, Version: "0.0.1", Payload: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
+								},
+							},
+						},
+					},
+				},
+			},
+			wants: func(t *testing.T, metrics []prometheus.Metric) {
+				if len(metrics) != 2 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
+				}
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": "3"})
+				expectMetric(t, metrics[1], 1, map[string]string{"type": "completed", "version": "0.0.1", "payload": "test/image:0", "age": "4"})
+			},
+		},
+		{
+			name: "ignores partial history",
+			optr: &Operator{
+				name:           "test",
+				releaseVersion: "0.0.2",
+				releaseImage:   "test/image:1",
+				releaseCreated: time.Unix(3, 0),
+				cvLister: &cvLister{
+					Items: []*configv1.ClusterVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test",
+							},
+							Status: configv1.ClusterVersionStatus{
+								History: []configv1.UpdateHistory{
+									{State: configv1.PartialUpdate, CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
+								},
+							},
+						},
+					},
+				},
+			},
+			wants: func(t *testing.T, metrics []prometheus.Metric) {
+				if len(metrics) != 2 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
+				}
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": "3"})
+				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
 			},
 		},
 		{
@@ -50,9 +127,9 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
 				if len(metrics) != 4 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": ""})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": "", "age": ""})
 				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1", "namespace": ""})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": ""})
 				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Failing", "namespace": ""})
@@ -81,9 +158,9 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
 				if len(metrics) != 4 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": ""})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": "", "age": ""})
 				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": "", "namespace": "default"})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": "default"})
 				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "condition": "Custom", "namespace": "default"})
@@ -110,11 +187,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+				if len(metrics) != 3 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": ""})
-				expectMetric(t, metrics[1], 2, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": "", "age": ""})
+				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
+				expectMetric(t, metrics[2], 2, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -137,11 +215,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+				if len(metrics) != 3 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "payload": "", "age": ""})
+				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -164,11 +243,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+				if len(metrics) != 3 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "update", "version": "1.0.0", "payload": "test/image:2"})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+				expectMetric(t, metrics[1], 1, map[string]string{"type": "desired", "version": "1.0.0", "payload": "test/image:2", "age": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
 			},
 		},
 		{
@@ -196,13 +276,14 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+				if len(metrics) != 5 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "update", "version": "1.0.0", "payload": "test/image:2"})
-				expectMetric(t, metrics[2], 1, map[string]string{"type": "failure", "version": "1.0.0", "payload": "test/image:2"})
-				expectMetric(t, metrics[3], 1, map[string]string{"type": "failure", "version": "0.0.2", "payload": "test/image:1"})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+				expectMetric(t, metrics[1], 1, map[string]string{"type": "desired", "version": "1.0.0", "payload": "test/image:2", "age": ""})
+				expectMetric(t, metrics[2], 1, map[string]string{"type": "failure", "version": "1.0.0", "payload": "test/image:2", "age": ""})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "failure", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+				expectMetric(t, metrics[4], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
 			},
 		},
 		{
@@ -227,11 +308,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
-					t.Fatalf("Unexpected metrics %#v", metrics)
+				if len(metrics) != 3 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "failure", "version": "0.0.2", "payload": "test/image:1"})
+				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+				expectMetric(t, metrics[1], 1, map[string]string{"type": "failure", "version": "0.0.2", "payload": "test/image:1", "age": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "payload": "", "age": ""})
 			},
 		},
 	}


### PR DESCRIPTION
One attack vector for clusters is to deny access to new updates or
to deliberately send an older update with vulnerabilities. This commit ensures the date the
payload was created is reported back through metrics and up via
telemetry. It also adds a new `completed` type for the cluster_version
metric that reports the last successfully applied cluster version and
the date it was successfully applied the first time (from the new
status history field). Finally, we correct the naming for the update
type to match the name of the status field to `desired`.