### PR TITLE
docs: Add obligation to create ClusterOperator

### DIFF
--- a/docs/dev/clusteroperator.md
+++ b/docs/dev/clusteroperator.md
@@ -22,7 +22,7 @@ When ClusterVersionOperator encounters a ClusterOperator Custom Resource,
 
 ClusterVersionOperator will only deploy files with `.yaml`, `.yml`, or `.json` extensions, like `kubectl create -f DIR`.
 
-**NOTE**: ClusterVersionOperator sweeps the manifests in the release payload in alphabetical order, therefore if the ClusterOperator Custom Resource exists before the deployment for the operator that is supposed to report the Custom Resource, ClusterVersionOperator will be stuck waiting and cannot proceed.
+**NOTE**: ClusterVersionOperator sweeps the manifests in the release payload in alphabetical order, therefore if the ClusterOperator Custom Resource exists before the deployment for the operator that is supposed to report the Custom Resource, ClusterVersionOperator will be stuck waiting and cannot proceed. Also note that the ClusterOperator resource in `/manifests` is only a communication mechanism, to tell the ClusterVersionOperator, which ClusterOperator resource to wait for. The ClusterVersionOperator does not create the ClusterOperator resource, this and updating it is the responsibility of the respective operator.
 
 ### What should be the contents of ClusterOperator Custom Resource in /manifests
 


### PR DESCRIPTION
This wasn't quite clear enough in the docs. I had to have a discussion with @abhinavdahiya to understand whose responsibility it was to create the object.