### PR TITLE
add 'co' as shortname for clusteroperators

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -30,6 +30,8 @@ spec:
     listKind: ClusterOperatorList
     plural: clusteroperators
     singular: clusteroperator
+    shortNames:
+    - co
   scope: Cluster
   subresources:
     status: {}


### PR DESCRIPTION
This seems like a natural shortname for a resource that I type very often.

/assign @smarterclayton @abhinavdahiya 