### PR TITLE
metrics: Report cluster_version as seconds since the epoch per type

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -2,23 +2,23 @@
 
 The Cluster Version Operator reports the following metrics:
 
-Core metrics for the version. Types:
+The cluster version is reported as seconds since the epoch with labels for `version` and
+`image`. The `type` label reports which value is reported:
 
-* `current` - the version the operator is applying right now (the running CVO version)
-* `failure` - if the failure condition is set, reported for desired and current versions
-* `desired` - reported if different from current
-* `completed` - returns 1 and the info of the most recent `Completed` entry in the history, or 0 otherwise
-
-`current` has the `age` label set to the unix timestamp of the image age, `completed` has the `age` label
-set to the time at which the update was completed. All other variants have empty age labels.
+* `current` - the version the operator is applying right now (the running CVO version) and the age of the payload
+* `cluster` - the same as current, but the value is the creation timestamp of the cluster version (cluster age)
+* `failure` - if the failure condition is set, reports the last transition time for both desired and current versions.
+* `desired` - reported if different from current as the most recent timestamp on the cluster version
+* `completed` - the time the most recent version was completely applied, or is zero.
 
 ```
 # HELP cluster_version Reports the version of the cluster.
 # TYPE cluster_version gauge
-cluster_version{age="132049356",image="test/image:1",type="current",version="4.0.2"} 1
-cluster_version{age="",image="test/image:1",type="failure",version="4.0.2"} 1
-cluster_version{age="",image="test/image:2",type="desired",version="4.0.3"} 1
-cluster_version{age="132064396",image="test/image:1",type="completed",version="4.0.2"} 1
+cluster_version{image="test/image:1",type="current",version="4.0.2"} 130000000
+cluster_version{image="test/image:1",type="failure",version="4.0.2"} 132000400
+cluster_version{image="test/image:2",type="desired",version="4.0.3"} 132000400
+cluster_version{image="test/image:1",type="completed",version="4.0.2"} 132000100
+cluster_version{image="test/image:1",type="cluster",version="4.0.2"} 131000000
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge
 cluster_version_available_updates{channel="fast",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -28,7 +28,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				if len(metrics) != 1 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": "3"})
+				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				if len(metrics) != 1 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 			},
 		},
 		{
@@ -55,7 +55,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
@@ -68,11 +69,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": "3"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "completed", "version": "0.0.1", "image": "test/image:0", "age": "4"})
+				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[2], 4, map[string]string{"type": "completed", "version": "0.0.1", "image": "test/image:0"})
 			},
 		},
 		{
@@ -86,7 +88,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
@@ -98,11 +101,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": "3"})
-				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -121,7 +125,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 								},
 								Conditions: []configv1.ClusterOperatorStatusCondition{
 									{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
-									{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue},
+									{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(5, 0)}},
 								},
 							},
 						},
@@ -132,7 +136,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1", "namespace": ""})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": ""})
 				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Failing", "namespace": ""})
@@ -163,7 +167,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": "", "namespace": "default"})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": "default"})
 				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "condition": "Custom", "namespace": "default"})
@@ -177,7 +181,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Status: configv1.ClusterVersionStatus{
 								AvailableUpdates: []configv1.Update{
@@ -190,12 +195,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "image": "", "age": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
-				expectMetric(t, metrics[2], 2, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
+				expectMetric(t, metrics[3], 2, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -206,7 +212,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Status: configv1.ClusterVersionStatus{
 								Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -218,12 +225,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "", "image": "", "age": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
+				expectMetric(t, metrics[3], 0, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -236,22 +244,29 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Spec: configv1.ClusterVersionSpec{
 								DesiredUpdate: &configv1.Update{Version: "1.0.0", Image: "test/image:2"},
+							},
+							Status: configv1.ClusterVersionStatus{
+								Conditions: []configv1.ClusterOperatorStatusCondition{
+									{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(5, 0)}},
+								},
 							},
 						},
 					},
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2", "age": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
+				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -260,18 +275,20 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
 				name:           "test",
+				releaseCreated: time.Unix(6, 0),
 				cvLister: &cvLister{
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(5, 0)},
 							},
 							Spec: configv1.ClusterVersionSpec{
 								DesiredUpdate: &configv1.Update{Version: "1.0.0", Image: "test/image:2"},
 							},
 							Status: configv1.ClusterVersionStatus{
 								Conditions: []configv1.ClusterOperatorStatusCondition{
-									{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue},
+									{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(4, 0)}},
 								},
 							},
 						},
@@ -279,14 +296,15 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 5 {
+				if len(metrics) != 6 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2", "age": ""})
-				expectMetric(t, metrics[2], 1, map[string]string{"type": "failure", "version": "1.0.0", "image": "test/image:2", "age": ""})
-				expectMetric(t, metrics[3], 1, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1", "age": ""})
-				expectMetric(t, metrics[4], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 6, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[1], 5, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
+				expectMetric(t, metrics[3], 4, map[string]string{"type": "failure", "version": "1.0.0", "image": "test/image:2"})
+				expectMetric(t, metrics[4], 4, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[5], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -299,7 +317,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					Items: []*configv1.ClusterVersion{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test",
+								Name:              "test",
+								CreationTimestamp: metav1.Time{Time: time.Unix(2, 0)},
 							},
 							Status: configv1.ClusterVersionStatus{
 								Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -311,12 +330,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 1, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "age": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1", "age": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": "", "age": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 	}


### PR DESCRIPTION
Building on feedback from the first round, report `cluster_version`
for each type as seconds since the epoch. The value allows relevant
data to be extracted such as the age of the cluster, the age of the
current payload, when the most recent successful update was applied,
and when the most recent failure started occurring.

Example queries:

    # the oldest clusters and what versions they are running
    sort(cluster_version{type="cluster"})

    # the most recently successfully updated clusters
    sort_desc(cluster_version{type="completed"})

    # the 20 clusters that recently started failing
    topk(20, cluster_version{type="failure"})

    # the clusters running the oldest payloads
    sort(cluster_version{type="current"})