### PR TITLE
status: Report a percentage when performing the initial sync

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -879,9 +879,10 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "after desired update is cancelled, go to reconciling",
+			name: "after desired update is cancelled, revert to progressing",
 			syncStatus: &SyncWorkerStatus{
-				Actual: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
+				Actual:   configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
+				Fraction: 0.334,
 			},
 			optr: Operator{
 				releaseImage:   "image/image:v4.0.1",
@@ -978,7 +979,7 @@ func TestOperator_sync(t *testing.T) {
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 							{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
 							// we correct the message that was incorrect from the previous state
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Working towards 4.0.1"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Working towards 4.0.1: 33% complete"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -211,9 +211,14 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 				LastTransitionTime: now,
 			})
 		} else {
-			message := fmt.Sprintf("Working towards %s", version)
-			if len(validationErrs) > 0 {
+			var message string
+			switch {
+			case len(validationErrs) > 0:
 				message = fmt.Sprintf("Reconciling %s: the cluster version is invalid", version)
+			case status.Fraction > 0:
+				message = fmt.Sprintf("Working towards %s: %.0f%% complete", version, status.Fraction*100)
+			default:
+				message = fmt.Sprintf("Working towards %s", version)
 			}
 			resourcemerge.SetOperatorStatusCondition(&config.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:               configv1.OperatorProgressing,


### PR DESCRIPTION
During both initial cluster init and upgrade it is valuable to show
the user how far we have gotten. Use the fraction reported by status
to show an approximate percentage of our progress through the payload.

During reconcilation, we show nothing.