### PR TITLE
metrics: Report a gauge for when cluster operator conditions change

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -1864,7 +1864,7 @@ func TestOperator_sync(t *testing.T) {
 				tt.init(optr)
 			}
 			optr.cvLister = &clientCVLister{client: optr.client}
-			optr.clusterOperatorLister = &clientCOLister{client: optr.client}
+			optr.coLister = &clientCOLister{client: optr.client}
 			if optr.configSync == nil {
 				expectStatus := tt.syncStatus
 				if expectStatus == nil {
@@ -2190,7 +2190,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			optr := tt.optr
 			optr.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-			optr.clusterOperatorLister = &clientCOLister{client: optr.client}
+			optr.coLister = &clientCOLister{client: optr.client}
 			optr.cvLister = &clientCVLister{client: optr.client}
 
 			if tt.handler != nil {

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -114,7 +115,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 		{
 			name: "collects cluster operator status failure",
 			optr: &Operator{
-				clusterOperatorLister: &coLister{
+				coLister: &coLister{
 					Items: []*configv1.ClusterOperator{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -139,15 +140,15 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1", "namespace": ""})
-				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": ""})
-				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Failing", "namespace": ""})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1"})
+				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available"})
+				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Failing"})
 			},
 		},
 		{
 			name: "collects cluster operator status custom",
 			optr: &Operator{
-				clusterOperatorLister: &coLister{
+				coLister: &coLister{
 					Items: []*configv1.ClusterOperator{
 						{
 							ObjectMeta: metav1.ObjectMeta{
@@ -170,9 +171,9 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": "", "namespace": "default"})
-				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "namespace": "default"})
-				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "condition": "Custom", "namespace": "default"})
+				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": ""})
+				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available"})
+				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "condition": "Custom"})
 			},
 		},
 		{
@@ -347,10 +348,116 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			if tt.optr.cvLister == nil {
 				tt.optr.cvLister = &cvLister{}
 			}
-			if tt.optr.clusterOperatorLister == nil {
-				tt.optr.clusterOperatorLister = &coLister{}
+			if tt.optr.coLister == nil {
+				tt.optr.coLister = &coLister{}
 			}
 			m := newOperatorMetrics(tt.optr)
+			descCh := make(chan *prometheus.Desc)
+			go func() {
+				for range descCh {
+				}
+			}()
+			m.Describe(descCh)
+			close(descCh)
+			ch := make(chan prometheus.Metric)
+			go func() {
+				m.Collect(ch)
+				close(ch)
+			}()
+			var collected []prometheus.Metric
+			for sample := range ch {
+				collected = append(collected, sample)
+			}
+			tt.wants(t, collected)
+		})
+	}
+}
+
+func Test_operatorMetrics_CollectTransitions(t *testing.T) {
+	tests := []struct {
+		name    string
+		optr    *Operator
+		changes []interface{}
+		wants   func(*testing.T, []prometheus.Metric)
+	}{
+		{
+			changes: []interface{}{
+				&configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{},
+					},
+				},
+				&configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+							{Type: configv1.ClusterStatusConditionType("Custom"), Status: configv1.ConditionFalse},
+						},
+					},
+				},
+				&configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+							{Type: configv1.ClusterStatusConditionType("Custom"), Status: configv1.ConditionFalse},
+							{Type: configv1.ClusterStatusConditionType("Unknown"), Status: configv1.ConditionUnknown},
+						},
+					},
+				},
+				&configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Status: configv1.ClusterOperatorStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Type: configv1.ClusterStatusConditionType("Custom"), Status: configv1.ConditionTrue},
+							{Type: configv1.ClusterStatusConditionType("Unknown"), Status: configv1.ConditionTrue},
+						},
+					},
+				},
+			},
+			optr: &Operator{
+				coLister: &coLister{},
+			},
+			wants: func(t *testing.T, metrics []prometheus.Metric) {
+				if len(metrics) != 4 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
+				}
+				sort.Slice(metrics, func(i, j int) bool {
+					a, b := metricParts(t, metrics[i]), metricParts(t, metrics[j])
+					for i := range a {
+						if a[i] < b[i] {
+							return true
+						}
+						if a[i] != b[i] {
+							return false
+						}
+					}
+					return false
+				})
+				expectMetric(t, metrics[0], 3, map[string]string{"name": "test", "condition": "Available"})
+				expectMetric(t, metrics[1], 2, map[string]string{"name": "test", "condition": "Custom"})
+				expectMetric(t, metrics[2], 2, map[string]string{"name": "test", "condition": "Unknown"})
+				expectMetric(t, metrics[3], 0, map[string]string{"type": "current", "version": "", "image": ""})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.optr.cvLister == nil {
+				tt.optr.cvLister = &cvLister{}
+			}
+			if tt.optr.coLister == nil {
+				tt.optr.coLister = &coLister{}
+			}
+			m := newOperatorMetrics(tt.optr)
+			for i := range tt.changes {
+				if i == 0 {
+					continue
+				}
+				m.clusterOperatorChanged(tt.changes[i-1], tt.changes[i])
+			}
 			ch := make(chan prometheus.Metric)
 			go func() {
 				m.Collect(ch)
@@ -385,4 +492,28 @@ func expectMetric(t *testing.T, metric prometheus.Metric, value float64, labels 
 	if len(labels) > 0 {
 		t.Fatalf("missing labels: %v", labels)
 	}
+}
+
+func metricParts(t *testing.T, metric prometheus.Metric, labels ...string) []string {
+	t.Helper()
+	var d dto.Metric
+	if err := metric.Write(&d); err != nil {
+		t.Fatalf("unable to write metrics: %v", err)
+	}
+	var parts []string
+	parts = append(parts, metric.Desc().String())
+	for _, name := range labels {
+		var found bool
+		for _, label := range d.Label {
+			if *label.Name == name {
+				found = true
+				parts = append(parts, *label.Value)
+				break
+			}
+		}
+		if !found {
+			parts = append(parts, "")
+		}
+	}
+	return parts
 }


### PR DESCRIPTION
Cluster operators may "flap" - have conditions that periodically
move from true to false (or appear and disappear). The CVO can record
all transitions as they occur and report it to prometheus, allowing
us to get fine grained reports of transitions. Since most operators
should be stable, treat Unknown -> False and <missing> -> Unknown
as just as valid, on the assumption that transitions are important.

Will allow us to identify flapping operators and fix them.