### PR TITLE
sync: Report a specific cluster operator error when not available

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -615,7 +615,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			Failure: &payload.UpdateError{
 				Nested:  fmt.Errorf("unable to proceed"),
 				Reason:  "UpdatePayloadFailed",
-				Message: "Could not update test \"file-yml\" (v1, 3 of 3)",
+				Message: "Could not update test \"file-yml\" (3 of 3)",
 			},
 			Actual: configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 		},
@@ -649,7 +649,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
-				{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadFailed", Message: "Could not update test \"file-yml\" (v1, 3 of 3)"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadFailed", Message: "Could not update test \"file-yml\" (3 of 3)"},
 				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadFailed", Message: "Error while reconciling 1.0.0-abc: the update could not be applied"},
 				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 			},

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -14,8 +15,11 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
+	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
+	"github.com/openshift/cluster-version-operator/pkg/payload"
 )
 
 var (
@@ -75,14 +79,17 @@ const (
 	osPollTimeout  = 1 * time.Minute
 )
 
-func waitForOperatorStatusToBeDone(client configclientv1.ClusterOperatorsGetter, os *configv1.ClusterOperator) error {
-	return wait.Poll(osPollInternal, osPollTimeout, func() (bool, error) {
-		eos, err := client.ClusterOperators().Get(os.Name, metav1.GetOptions{})
+func waitForOperatorStatusToBeDone(client configclientv1.ClusterOperatorsGetter, co *configv1.ClusterOperator) error {
+	var lastCO *configv1.ClusterOperator
+	err := wait.Poll(osPollInternal, osPollTimeout, func() (bool, error) {
+		eos, err := client.ClusterOperators().Get(co.Name, metav1.GetOptions{})
 		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
 			return false, err
 		}
-		glog.V(4).Infof("ClusterOperator %s/%s is reporting %v",
-			eos.Namespace, eos.Name, spew.Sdump(eos.Status))
+		lastCO = eos
 
 		// TODO: temporarily disabled while the design for version tracking is finalized
 		// if eos.Status.Version != os.Status.Version {
@@ -102,14 +109,50 @@ func waitForOperatorStatusToBeDone(client configclientv1.ClusterOperatorsGetter,
 				failing = false
 			}
 		}
-
 		// if we're at the correct version, and available, not progressing, and not failing, we are done
 		if available && !progressing && !failing {
 			return true, nil
 		}
-		glog.V(3).Infof("ClusterOperator %s/%s is not done; it is available=%v, progressing=%v, failing=%v",
-			eos.Namespace, eos.Name, available, progressing, failing)
-
 		return false, nil
 	})
+
+	if err != wait.ErrWaitTimeout {
+		return err
+	}
+
+	if lastCO == nil {
+		return &payload.UpdateError{
+			Reason:  "ClusterOperatorNotAvailable",
+			Message: fmt.Sprintf("Cluster operator %s has not yet reported success", co.Name),
+			Name:    co.Name,
+		}
+	}
+	co = lastCO
+
+	glog.V(3).Infof("ClusterOperator %s is not done; it is available=%v, progressing=%v, failing=%v",
+		co.Name,
+		resourcemerge.IsOperatorStatusConditionTrue(co.Status.Conditions, configv1.OperatorAvailable),
+		resourcemerge.IsOperatorStatusConditionTrue(co.Status.Conditions, configv1.OperatorProgressing),
+		resourcemerge.IsOperatorStatusConditionTrue(co.Status.Conditions, configv1.OperatorFailing),
+	)
+
+	if c := resourcemerge.FindOperatorStatusCondition(co.Status.Conditions, configv1.OperatorFailing); c != nil && c.Status == configv1.ConditionTrue {
+		if len(c.Message) > 0 {
+			return &payload.UpdateError{
+				Reason:  "ClusterOperatorFailing",
+				Message: fmt.Sprintf("Cluster operator %s is reporting a failure: %s", co.Name, c.Message),
+				Name:    co.Name,
+			}
+		}
+		return &payload.UpdateError{
+			Reason:  "ClusterOperatorFailing",
+			Message: fmt.Sprintf("Cluster operator %s is reporting a failure", co.Name),
+			Name:    co.Name,
+		}
+	}
+	return &payload.UpdateError{
+		Reason:  "ClusterOperatorNotAvailable",
+		Message: fmt.Sprintf("Cluster operator %s has not yet reported success", co.Name),
+		Name:    co.Name,
+	}
 }

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -162,7 +162,7 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 		msg := "an error occurred"
 		if uErr, ok := err.(*payload.UpdateError); ok {
 			reason = uErr.Reason
-			msg = payload.SummaryForReason(reason)
+			msg = payload.SummaryForReason(reason, uErr.Name)
 		}
 
 		// set the failing condition

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -410,7 +410,7 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 		t, client, ns,
 		"UpdatePayloadResourceInvalid",
 		fmt.Sprintf(
-			`Could not update configmap "%s/config2" (v1, 2 of 2): the object is invalid, possibly due to local cluster configuration`,
+			`Could not update configmap "%s/config2" (2 of 2): the object is invalid, possibly due to local cluster configuration`,
 			ns,
 		),
 		"Unable to apply 0.0.2: some cluster configuration is invalid",


### PR DESCRIPTION
Cluster operators block most of upgrade, so we should report the information the cluster operator has available back to the CV status object via an UpdateError.

Reduce the amount of debug info printed by cluster operator status waiting to simplify the logs.

While reviewing CV logs from startup, we run the resync loop more frequently waiting for the CO to be created because we exit the poll loop on any error. When we see "CO not found", continue the loop to avoid triggering the top level sync worker backoff loop.  Shaves a few tens of seconds of startup time.

Finally, remove the apiVersion info from the status log message, it didn't make much sense and the end user is going to have to look at the payload anyway if we get into a wierd error case where it matters (the apiVersion was put in in case we had to debug a typo in a version, which really shouldn't happen).