### PR TITLE
test: Fix flake when retrieving payloads

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -140,7 +140,7 @@ func calculateAvailableUpdatesStatus(clusterID, upstream, channel, version strin
 	for _, update := range updates {
 		cvoUpdates = append(cvoUpdates, configv1.Update{
 			Version: update.Version.String(),
-			Image: update.Image,
+			Image:   update.Image,
 		})
 	}
 

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -156,7 +156,7 @@ func New(
 		kubeClient:    kubeClient,
 		eventRecorder: eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: namespace}),
 
-		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterversion"),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterversion"),
 		availableUpdatesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "availableupdates"),
 	}
 

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -217,6 +217,11 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 				message = fmt.Sprintf("Reconciling %s: the cluster version is invalid", version)
 			case status.Fraction > 0:
 				message = fmt.Sprintf("Working towards %s: %.0f%% complete", version, status.Fraction*100)
+			case status.Step == "RetrievePayload":
+				if len(reason) == 0 {
+					reason = "DownloadingUpdate"
+				}
+				message = fmt.Sprintf("Working towards %s: downloading update", version)
 			default:
 				message = fmt.Sprintf("Working towards %s", version)
 			}

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -727,11 +727,18 @@ func waitUntilUpgradeFails(t *testing.T, client clientset.Interface, ns string, 
 			}
 		}
 
-		if !stringInSlice(versions, cv.Status.Desired.Version) {
-			return false, fmt.Errorf("upgrading operator status reported desired version %s which is not in the allowed set %v", cv.Status.Desired.Version, versions)
-		}
 		if len(cv.Status.History) == 0 {
 			return false, fmt.Errorf("upgrading operator should have at least once history entry")
+		}
+		if len(cv.Status.Desired.Version) == 0 {
+			// if we are downloading the next update, we're allowed to have an empty desired version because we
+			// haven't been able to load the payload
+			if c := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue && strings.Contains(c.Message, "downloading update") && c.Reason == "DownloadingUpdate" {
+				return false, nil
+			}
+		}
+		if !stringInSlice(versions, cv.Status.Desired.Version) {
+			return false, fmt.Errorf("upgrading operator status reported desired version %s which is not in the allowed set %v", cv.Status.Desired.Version, versions)
 		}
 		if !stringInSlice(versions, cv.Status.History[0].Version) {
 			return false, fmt.Errorf("upgrading operator should have a valid history[0] version %s: %v", cv.Status.Desired.Version, versions)


### PR DESCRIPTION
When a payload is retrieved the version may be empty, and if the
status is updated it'll have an empty version. This caused an
integration flake.

Since retrieving the payload can take a certain amount of time,
reflect that in the progressing message and give a unique reason.
The test should then verify the state.