### PR TITLE
pkg/cincinnati: update unamrshal to node to match the result from cincinnati

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -103,8 +103,8 @@ type graph struct {
 }
 
 type node struct {
-	Version semver.Version
-	Image   string
+	Version semver.Version `json:"version"`
+	Image   string         `json:"payload"`
 }
 
 type edge struct {

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -1,6 +1,8 @@
 package cincinnati
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -28,37 +30,37 @@ func TestGetUpdates(t *testing.T) {
 			"nodes": [
 			  {
 				"version": "4.0.0-4",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-4",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-5",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-6",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-6",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-6+2",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-0.okd-0",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-0.2",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2",
 				"metadata": {}
 			  },
 			  {
 				"version": "4.0.0-0.3",
-				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3",
+				"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3",
 				"metadata": {}
 			  }
 			],
@@ -113,6 +115,71 @@ func TestGetUpdates(t *testing.T) {
 			} else {
 				if err == nil || err.Error() != test.err {
 					t.Fatalf("expected err to be %s, got: %v", test.err, err)
+				}
+			}
+		})
+	}
+}
+
+func Test_nodeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		raw []byte
+
+		exp node
+		err string
+	}{{
+		raw: []byte(`{
+			"version": "4.0.0-5",
+			"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
+			"metadata": {}
+		  }`),
+
+		exp: node{semver.MustParse("4.0.0-5"), "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
+	}, {
+		raw: []byte(`{
+			"version": "4.0.0-0.1",
+			"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
+			"metadata": {
+			  "description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build"
+			}
+		  }`),
+		exp: node{semver.MustParse("4.0.0-0.1"), "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1"},
+	}, {
+		raw: []byte(`{
+			"version": "v4.0.0-0.1",
+			"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
+			"metadata": {
+			  "description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build"
+			}
+		  }`),
+		err: `Invalid character(s) found in major number "v4"`,
+	}, {
+		raw: []byte(`{
+			"version": "4-0-0+0.1",
+			"payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
+			"metadata": {
+			  "description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build"
+			}
+		  }
+	  `),
+
+		err: "No Major.Minor.Patch elements found",
+	}}
+
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("#%d", idx), func(t *testing.T) {
+			var n node
+			err := json.Unmarshal(test.raw, &n)
+			if test.err == "" {
+				if err != nil {
+					t.Fatalf("expecting nil error, got: %v", err)
+				}
+				if !reflect.DeepEqual(n, test.exp) {
+					t.Fatalf("expecting %v got %v", test.exp, n)
+				}
+			} else {
+				if err.Error() != test.err {
+					t.Fatalf("expecting %s error, got: %v", test.err, err)
 				}
 			}
 		})

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2141,7 +2141,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				fmt.Fprintf(w, `
 				{
 					"nodes": [
-						{"version":"4.0.1",            "image": "image/image:v4.0.1"}
+						{"version":"4.0.1",            "payload": "image/image:v4.0.1"}
 					],
 					"edges": []
 				}
@@ -2191,9 +2191,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				fmt.Fprintf(w, `
 				{
 					"nodes": [
-						{"version":"4.0.1",            "image": "image/image:v4.0.1"},
-						{"version":"4.0.2-prerelease", "image": "some.other.registry/image/image:v4.0.2"},
-						{"version":"4.0.2",            "image": "image/image:v4.0.2"}
+						{"version":"4.0.1",            "payload": "image/image:v4.0.1"},
+						{"version":"4.0.2-prerelease", "payload": "some.other.registry/image/image:v4.0.2"},
+						{"version":"4.0.2",            "payload": "image/image:v4.0.2"}
 					],
 					"edges": [
 						[0, 1],


### PR DESCRIPTION
Based on [cincinnati graph api Response][1] the fields for a node must be `version`, `image` and `metadata`. But response from current api:
```console
$ curl --silent --header 'Accept:application/json' https://api.openshift.com/api/upgrades_info/v1/graph | jq .
{
  "nodes": [
    {
      "version": "4.0.0-5",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
      "metadata": {}
    },
    {
      "version": "4.0.0-4",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4",
      "metadata": {}
    },
    {
      "version": "4.0.0-6",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6",
      "metadata": {}
    },
    {
      "version": "4.0.0-7",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-7",
      "metadata": {}
    },
    {
      "version": "4.0.0-8",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-8",
      "metadata": {}
    },
    {
      "version": "4.0.0-9",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-9",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.1",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
      "metadata": {
        "description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build"
      }
    },
    {
      "version": "4.0.0-0.okd-0",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.2",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.3",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3",
      "metadata": {}
    }
  ],
  "edges": [
    [
      1,
      0
    ],
    [
      0,
      2
    ],
    [
      2,
      3
    ],
    [
      3,
      4
    ],
    [
      4,
      5
    ],
    [
      6,
      8
    ],
    [
      8,
      9
    ]
  ]
}
```
has fields `version`, `payload` and `metadata` for a node.

[3956b76][2] changed the previouly `Payload` field to `Image` creating invalid node object.

With this PR, we are using the unmarshalling `version` and `payload` fields for a node.

[1]: https://github.com/openshift/cincinnati/blob/06c9ce64367b55f453295b2765a9aab61791dc76/docs/design/cincinnati.md#response
[2]: https://github.com/openshift/cluster-version-operator/commit/3956b767d634e7eab7dc1c322e7393330bd2d641


/cc @crawford @smarterclayton 