### PR TITLE
cininnati: fix unknown version fetch

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -69,11 +69,16 @@ func (c Client) GetUpdates(upstream string, channel string, version semver.Versi
 
 	// Find the current version within the graph.
 	var currentIdx int
+	found := false
 	for i, node := range graph.Nodes {
 		if version.EQ(node.Version) {
 			currentIdx = i
+			found = true
 			break
 		}
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown version %s", version)
 	}
 
 	// Find the children of the current version.

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -1,0 +1,120 @@
+package cincinnati
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/google/uuid"
+)
+
+func TestGetUpdates(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		mtype := r.Header.Get("Accept")
+		if mtype != GraphMediaType {
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return
+		}
+
+		_, err := w.Write([]byte(`{
+			"nodes": [
+			  {
+				"version": "4.0.0-4",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-4",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-5",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-6",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-6",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-6+2",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-0.okd-0",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-0.2",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2",
+				"metadata": {}
+			  },
+			  {
+				"version": "4.0.0-0.3",
+				"image": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3",
+				"metadata": {}
+			  }
+			],
+			"edges": [[0,1],[1,2],[1,3],[5,6]]
+		  }`))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	tests := []struct {
+		name    string
+		version string
+
+		available []Update
+		err       string
+	}{{
+		name:    "one update available",
+		version: "4.0.0-4",
+		available: []Update{
+			{semver.MustParse("4.0.0-5"), "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
+		},
+	}, {
+		name:    "two updates available",
+		version: "4.0.0-5",
+		available: []Update{
+			{semver.MustParse("4.0.0-6"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
+			{semver.MustParse("4.0.0-6+2"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"},
+		},
+	}, {
+		name:    "no updates available",
+		version: "4.0.0-0.okd-0",
+	}, {
+		name:    "unknown version",
+		version: "4.0.0-3",
+		err:     "unknown version 4.0.0-3",
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(handler))
+			c := NewClient(uuid.New())
+
+			updates, err := c.GetUpdates(ts.URL, "", semver.MustParse(test.version))
+			if test.err == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got: %v", err)
+				}
+				if !reflect.DeepEqual(updates, test.available) {
+					t.Fatalf("expected %v, got: %v", test.available, updates)
+				}
+			} else {
+				if err == nil || err.Error() != test.err {
+					t.Fatalf("expected err to be %s, got: %v", test.err, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-
+	_ "github.com/golang/glog" // integration tests set glog flags.
 	"github.com/google/uuid"
 )
 

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2138,7 +2138,14 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		{
 			name: "set available updates and clear error state when success and empty",
 			handler: func(w http.ResponseWriter, req *http.Request) {
-				fmt.Fprintf(w, "{}")
+				fmt.Fprintf(w, `
+				{
+					"nodes": [
+						{"version":"4.0.1",            "image": "image/image:v4.0.1"}
+					],
+					"edges": []
+				}
+				`)
 			},
 			optr: Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",


### PR DESCRIPTION
currently if the current version does not exist in the reponse returned from cincinnati, we use the `0`th node as our version
and return the available updates for that version.
example,

If the response from cincinnati is following:
```console
$ curl --silent --header 'Accept:application/json' https://api.openshift.com/api/upgrades_info/v1/graph | jq .
{
  "nodes": [
    {
      "version": "4.0.0-5",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
      "metadata": {}
    },
    {
      "version": "4.0.0-4",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-4",
      "metadata": {}
    },
    {
      "version": "4.0.0-6",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-6",
      "metadata": {}
    },
    {
      "version": "4.0.0-7",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-7",
      "metadata": {}
    },
    {
      "version": "4.0.0-8",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-8",
      "metadata": {}
    },
    {
      "version": "4.0.0-9",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-9",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.1",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
      "metadata": {
        "description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build"
      }
    },
    {
      "version": "4.0.0-0.okd-0",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.okd-0",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.2",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.2",
      "metadata": {}
    },
    {
      "version": "4.0.0-0.3",
      "payload": "quay.io/openshift-release-dev/ocp-release:4.0.0-0.3",
      "metadata": {}
    }
  ],
  "edges": [
    [
      1,
      0
    ],
    [
      0,
      2
    ],
    [
      2,
      3
    ],
    [
      3,
      4
    ],
    [
      4,
      5
    ],
    [
      6,
      8
    ],
    [
      8,
      9
    ]
  ]
}
```

For a cusotm release image generated locally
```console
$ oc get clusterversion -oyaml
apiVersion: v1
items:
- apiVersion: config.openshift.io/v1
  kind: ClusterVersion
  metadata:
    creationTimestamp: 2019-02-06T00:51:12Z
    generation: 1
    name: version
    namespace: ""
    resourceVersion: "956"
    selfLink: /apis/config.openshift.io/v1/clusterversions/version
    uid: 4cbc79c7-29a9-11e9-b85c-664f163f5f0f
  spec:
    channel: fast
    clusterID: a7d11204-7193-41ca-ad4a-337a540a5dac
    upstream: https://api.openshift.com/api/upgrades_info/v1/graph
  status:

    availableUpdates:
    - image: quay.io/openshift-release-dev/ocp-release:4.0.0-6
      version: 4.0.0-6

    conditions:
    - lastTransitionTime: 2019-02-06T00:51:21Z
      status: "False"
      type: Available
    - lastTransitionTime: 2019-02-06T00:53:21Z
      status: "False"
      type: Failing
    - lastTransitionTime: 2019-02-06T00:51:21Z
      message: 'Working towards 0.0.1-2019-02-06-003220: 22% complete'
      status: "True"
      type: Progressing
    - lastTransitionTime: 2019-02-06T00:51:21Z
      status: "True"
      type: RetrievedUpdates
    desired:
      image: quay.io/abhinavdahiya/origin-release@sha256:4e9f3686380d26566e9112fdd53262068004a22a85f93111a0f10d0b3dfdc3a9
      version: 0.0.1-2019-02-06-003220
    history:
    - completionTime: null
      image: quay.io/abhinavdahiya/origin-release@sha256:4e9f3686380d26566e9112fdd53262068004a22a85f93111a0f10d0b3dfdc3a9
      startedTime: 2019-02-06T00:51:21Z
      state: Partial
      version: 0.0.1-2019-02-06-003220
    observedGeneration: 1
    versionHash: G0evldCtMHI=
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
The current version is `0.0.1-2019-02-06-003220` and since this is version is not present in the response from cincinnati with use the `0`th node ie `4.0.0-5` and returns available update to `4.0.0-6`

This returns error when current version is not found in response from cincinnati.

/cc @crawford @smarterclayton 