### PR TITLE
lib: ensureClusterOperatorStatus tracks RelatedObjects

### DIFF
--- a/lib/resourcemerge/os.go
+++ b/lib/resourcemerge/os.go
@@ -32,6 +32,10 @@ func ensureClusterOperatorStatus(modified *bool, existing *configv1.ClusterOpera
 		*modified = true
 		existing.Extension.Object = required.Extension.Object
 	}
+	if !equality.Semantic.DeepEqual(existing.RelatedObjects, required.RelatedObjects) {
+		*modified = true
+		existing.RelatedObjects = required.RelatedObjects
+	}
 }
 
 func SetOperatorStatusCondition(conditions *[]configv1.ClusterOperatorStatusCondition, newCondition configv1.ClusterOperatorStatusCondition) {


### PR DESCRIPTION
The relatedObjects reported in status is used by must-gather tool to help get diagnostic information about an operator.  Missing from the existing library that handles cluster operator status.