### PR TITLE
hack: change override env for version

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -14,12 +14,12 @@ GOARCH=${GOACH:-${GOHOSTARCH}}
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"
 
-if [ -z ${VERSION+a} ]; then
+if [ -z ${VERSION_OVERRIDE+a} ]; then
 	echo "Using version from git..."
-	VERSION=$(git describe --abbrev=8 --dirty --always)
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
-GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION}"
+GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
 
 eval $(go env)
 
@@ -29,5 +29,5 @@ fi
 
 mkdir -p ${BIN_PATH}
 
-echo "Building ${REPO} (${VERSION})"
+echo "Building ${REPO} (${VERSION_OVERRIDE})"
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/cluster-version-operator ${REPO}/cmd/...

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -16,10 +16,10 @@ if [ `id --user` -ne 0 ]; then
 	print_error "Note: Building unprivileged may fail due to permissions"
 fi
 
-if [ -z ${VERSION+a} ]; then
+if [ -z ${VERSION_OVERRIDE+a} ]; then
         print_info "Using version from git..."
-        VERSION=$(git describe --abbrev=8 --dirty --always)
+        VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
 set -x
-podman build -t "cluster-version-operator:${VERSION}" -f Dockerfile --no-cache
+podman build -t "cluster-version-operator:${VERSION_OVERRIDE}" -f Dockerfile --no-cache

--- a/hack/push-image.sh
+++ b/hack/push-image.sh
@@ -9,11 +9,11 @@ function print_info {
 
 REPO=${REPO:-"openshift"}
 
-if [ -z ${VERSION+a} ]; then
+if [ -z ${VERSION_OVERRIDE+a} ]; then
         print_info "Using version from git..."
-        VERSION=$(git describe --abbrev=8 --dirty --always)
+        VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
 set -x
-podman push "cluster-version-operator:${VERSION}" "${REPO}/origin-cluster-version-operator:${VERSION}"
-podman push "cluster-version-operator:${VERSION}" "${REPO}/origin-cluster-version-operator:latest"
+podman push "cluster-version-operator:${VERSION_OVERRIDE}" "${REPO}/origin-cluster-version-operator:${VERSION_OVERRIDE}"
+podman push "cluster-version-operator:${VERSION_OVERRIDE}" "${REPO}/origin-cluster-version-operator:latest"


### PR DESCRIPTION
Similar to https://github.com/openshift/machine-config-operator/pull/191.
Turns out `registry.svc.ci.openshift.org/openshift/release:golang-1.10` has `VERSION` env set to golang's version.
So switching to `VERSION_OVERRIDE` prevents conflicts.

/cc @crawford