### PR TITLE
clusteroperator: Skip waiting for progressing when versions expected

### DIFF
--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -155,8 +155,10 @@ func waitForOperatorStatusToBeDone(interval, timeout time.Duration, client confi
 				failing = false
 			}
 		}
-		// if we're at the correct version, and available, not progressing, and not failing, we are done
-		if available && !progressing && !failing {
+		// if we're at the correct version, and available, and not failing, we are done
+		// if we're available, not failing, and not progressing, we're also done
+		// TODO: remove progressing once all cluster operators report expected versions
+		if available && (!progressing || len(expected.Status.Versions) > 0) && !failing {
 			return true, nil
 		}
 


### PR DESCRIPTION
As operators begin waiting for versions, we no longer need to wait for progressing status before continuing to the payload as long as we aren't failing or available. For operators not yet setting versions, continue to wait for progressing.

Allowing this will allow the core operators to complete faster even if they are restarting to process config changes.  This may cause other operators to be flaky, but that's ok because they need to tolerate those anyway, or the kube-apiserver needs to be better at mitigating, or likely, both.

@derekwaynecarr @abhinavdahiya @bparees as per discussion today as we were switching image-registry operator over.  There's no reason to hold for progressing once an operator has told us it's available at the version we requested.  Will allow kube-apiserver to declare done earlier.