### PR TITLE
manifests: operator should have cluster-critical-priority

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -45,6 +45,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
         - operator: Exists
       volumes:


### PR DESCRIPTION
specifies system-cluster-critical priority for operator.

blocks passing smoke tests for ensuring control plane pods always schedule.

see: https://github.com/openshift/origin/pull/22217