### PR TITLE
lib/resourcebuilder: update interface to include context when doing work

### DIFF
--- a/lib/resourcebuilder/apireg.go
+++ b/lib/resourcebuilder/apireg.go
@@ -1,6 +1,8 @@
 package resourcebuilder
 
 import (
+	"context"
+
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
 	"github.com/openshift/cluster-version-operator/lib/resourceread"
@@ -26,7 +28,7 @@ func (b *apiServiceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *apiServiceBuilder) Do() error {
+func (b *apiServiceBuilder) Do(_ context.Context) error {
 	apiService := resourceread.ReadAPIServiceV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(apiService)

--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -1,6 +1,7 @@
 package resourcebuilder
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ func (b *deploymentBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *deploymentBuilder) Do() error {
+func (b *deploymentBuilder) Do(ctx context.Context) error {
 	deployment := resourceread.ReadDeploymentV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(deployment)
@@ -45,18 +46,14 @@ func (b *deploymentBuilder) Do() error {
 		return err
 	}
 	if updated && actual.Generation > 1 {
-		return waitForDeploymentCompletion(b.client, deployment)
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		return waitForDeploymentCompletion(ctxWithTimeout, 1*time.Second, b.client, deployment)
 	}
 	return nil
 }
-
-const (
-	deploymentPollInterval = 1 * time.Second
-	deploymentPollTimeout  = 5 * time.Minute
-)
-
-func waitForDeploymentCompletion(client appsclientv1.DeploymentsGetter, deployment *appsv1.Deployment) error {
-	return wait.Poll(deploymentPollInterval, deploymentPollTimeout, func() (bool, error) {
+func waitForDeploymentCompletion(ctx context.Context, interval time.Duration, client appsclientv1.DeploymentsGetter, deployment *appsv1.Deployment) error {
+	return wait.PollImmediateUntil(interval, func() (bool, error) {
 		d, err := client.Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			// exit early to recreate the deployment.
@@ -78,7 +75,7 @@ func waitForDeploymentCompletion(client appsclientv1.DeploymentsGetter, deployme
 		}
 		glog.V(4).Infof("Deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
 		return false, nil
-	})
+	}, ctx.Done())
 }
 
 type daemonsetBuilder struct {
@@ -99,7 +96,7 @@ func (b *daemonsetBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *daemonsetBuilder) Do() error {
+func (b *daemonsetBuilder) Do(ctx context.Context) error {
 	daemonset := resourceread.ReadDaemonSetV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(daemonset)
@@ -109,7 +106,9 @@ func (b *daemonsetBuilder) Do() error {
 		return err
 	}
 	if updated && actual.Generation > 1 {
-		return waitForDaemonsetRollout(b.client, daemonset)
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		return waitForDaemonsetRollout(ctxWithTimeout, 1*time.Second, b.client, daemonset)
 	}
 	return nil
 }
@@ -119,8 +118,8 @@ const (
 	daemonsetPollTimeout  = 5 * time.Minute
 )
 
-func waitForDaemonsetRollout(client appsclientv1.DaemonSetsGetter, daemonset *appsv1.DaemonSet) error {
-	return wait.Poll(daemonsetPollInterval, daemonsetPollTimeout, func() (bool, error) {
+func waitForDaemonsetRollout(ctx context.Context, interval time.Duration, client appsclientv1.DaemonSetsGetter, daemonset *appsv1.DaemonSet) error {
+	return wait.PollImmediateUntil(interval, func() (bool, error) {
 		d, err := client.DaemonSets(daemonset.Namespace).Get(daemonset.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			// exit early to recreate the daemonset.
@@ -142,5 +141,5 @@ func waitForDaemonsetRollout(client appsclientv1.DaemonSetsGetter, daemonset *ap
 		}
 		glog.V(4).Infof("Daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberAvailable)
 		return false, nil
-	})
+	}, ctx.Done())
 }

--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -1,6 +1,7 @@
 package resourcebuilder
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -34,7 +35,7 @@ func (b *jobBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *jobBuilder) Do() error {
+func (b *jobBuilder) Do(_ context.Context) error {
 	job := resourceread.ReadJobV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(job)

--- a/lib/resourcebuilder/core.go
+++ b/lib/resourcebuilder/core.go
@@ -1,6 +1,8 @@
 package resourcebuilder
 
 import (
+	"context"
+
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
 	"github.com/openshift/cluster-version-operator/lib/resourceread"
@@ -26,7 +28,7 @@ func (b *serviceAccountBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interfa
 	return b
 }
 
-func (b *serviceAccountBuilder) Do() error {
+func (b *serviceAccountBuilder) Do(_ context.Context) error {
 	serviceAccount := resourceread.ReadServiceAccountV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(serviceAccount)
@@ -53,7 +55,7 @@ func (b *configMapBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *configMapBuilder) Do() error {
+func (b *configMapBuilder) Do(_ context.Context) error {
 	configMap := resourceread.ReadConfigMapV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(configMap)
@@ -80,7 +82,7 @@ func (b *namespaceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *namespaceBuilder) Do() error {
+func (b *namespaceBuilder) Do(_ context.Context) error {
 	namespace := resourceread.ReadNamespaceV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(namespace)
@@ -107,7 +109,7 @@ func (b *serviceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *serviceBuilder) Do() error {
+func (b *serviceBuilder) Do(_ context.Context) error {
 	service := resourceread.ReadServiceV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(service)

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -1,6 +1,7 @@
 package resourcebuilder
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -64,7 +65,7 @@ type NewInteraceFunc func(rest *rest.Config, m lib.Manifest) Interface
 
 type Interface interface {
 	WithModifier(MetaV1ObjectModifierFunc) Interface
-	Do() error
+	Do(context.Context) error
 }
 
 // New returns Interface using the mapping stored in mapper for m Manifest.

--- a/lib/resourcebuilder/rbac.go
+++ b/lib/resourcebuilder/rbac.go
@@ -1,6 +1,8 @@
 package resourcebuilder
 
 import (
+	"context"
+
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
 	"github.com/openshift/cluster-version-operator/lib/resourceread"
@@ -26,7 +28,7 @@ func (b *clusterRoleBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface 
 	return b
 }
 
-func (b *clusterRoleBuilder) Do() error {
+func (b *clusterRoleBuilder) Do(_ context.Context) error {
 	clusterRole := resourceread.ReadClusterRoleV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(clusterRole)
@@ -53,7 +55,7 @@ func (b *clusterRoleBindingBuilder) WithModifier(f MetaV1ObjectModifierFunc) Int
 	return b
 }
 
-func (b *clusterRoleBindingBuilder) Do() error {
+func (b *clusterRoleBindingBuilder) Do(_ context.Context) error {
 	clusterRoleBinding := resourceread.ReadClusterRoleBindingV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(clusterRoleBinding)
@@ -80,7 +82,7 @@ func (b *roleBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *roleBuilder) Do() error {
+func (b *roleBuilder) Do(_ context.Context) error {
 	role := resourceread.ReadRoleV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(role)
@@ -107,7 +109,7 @@ func (b *roleBindingBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface 
 	return b
 }
 
-func (b *roleBindingBuilder) Do() error {
+func (b *roleBindingBuilder) Do(_ context.Context) error {
 	roleBinding := resourceread.ReadRoleBindingV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(roleBinding)

--- a/lib/resourcebuilder/security.go
+++ b/lib/resourcebuilder/security.go
@@ -1,6 +1,8 @@
 package resourcebuilder
 
 import (
+	"context"
+
 	securityclientv1 "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
@@ -26,7 +28,7 @@ func (b *securityBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	return b
 }
 
-func (b *securityBuilder) Do() error {
+func (b *securityBuilder) Do(_ context.Context) error {
 	scc := resourceread.ReadSecurityContextConstraintsV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(scc)

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -464,7 +465,7 @@ type resourceBuilder struct {
 }
 
 // NewResourceBuilder creates the default resource builder implementation.
-func NewResourceBuilder(config *rest.Config) ResourceBuilder {
+func NewResourceBuilder(config *rest.Config) payload.ResourceBuilder {
 	return &resourceBuilder{config: config}
 }
 
@@ -479,7 +480,7 @@ func (b *resourceBuilder) BuilderFor(m *lib.Manifest) (resourcebuilder.Interface
 	return internal.NewGenericBuilder(client, *m)
 }
 
-func (b *resourceBuilder) Apply(m *lib.Manifest) error {
+func (b *resourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
 	builder, err := b.BuilderFor(m)
 	if err != nil {
 		return err
@@ -487,5 +488,5 @@ func (b *resourceBuilder) Apply(m *lib.Manifest) error {
 	if b.modifier != nil {
 		builder = builder.WithModifier(b.modifier)
 	}
-	return builder.Do()
+	return builder.Do(ctx)
 }

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -705,6 +706,6 @@ func (b *blockingResourceBuilder) Send(err error) {
 	b.ch <- err
 }
 
-func (b *blockingResourceBuilder) Apply(m *lib.Manifest) error {
+func (b *blockingResourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
 	return <-b.ch
 }

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -77,7 +78,7 @@ func (b *genericBuilder) WithModifier(f resourcebuilder.MetaV1ObjectModifierFunc
 	return b
 }
 
-func (b *genericBuilder) Do() error {
+func (b *genericBuilder) Do(_ context.Context) error {
 	ud := readUnstructuredV1OrDie(b.raw)
 	if b.modifier != nil {
 		b.modifier(ud)

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -475,7 +476,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				return false, nil, fmt.Errorf("unexpected client action: %#v", action)
 			})
 
-			err := waitForOperatorStatusToBeDone(1*time.Millisecond, time.Microsecond, client.ConfigV1(), test.exp)
+			ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), 1*time.Millisecond)
+			defer cancel()
+			err := waitForOperatorStatusToBeDone(ctxWithTimeout, 1*time.Millisecond, client.ConfigV1(), test.exp)
 			if test.expErr == nil {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -309,7 +309,7 @@ func (t *testBuilder) WithModifier(m resourcebuilder.MetaV1ObjectModifierFunc) r
 	return t
 }
 
-func (t *testBuilder) Do() error {
+func (t *testBuilder) Do(_ context.Context) error {
 	a := t.recorder.Invoke(t.m.GVK, t.m.Object().GetNamespace(), t.m.Object().GetName())
 	return t.reactors[a]
 }
@@ -392,7 +392,7 @@ type testResourceBuilder struct {
 	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
 }
 
-func (b *testResourceBuilder) Apply(m *lib.Manifest) error {
+func (b *testResourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
 	ns := m.Object().GetNamespace()
 	fakeGVR := schema.GroupVersionResource{Group: m.GVK.Group, Version: m.GVK.Version, Resource: strings.ToLower(m.GVK.Kind)}
 	client := b.client.Resource(fakeGVR).Namespace(ns)
@@ -403,5 +403,5 @@ func (b *testResourceBuilder) Apply(m *lib.Manifest) error {
 	for _, m := range b.modifiers {
 		builder = builder.WithModifier(m)
 	}
-	return builder.Do()
+	return builder.Do(ctx)
 }


### PR DESCRIPTION
all resourcebuilders must respect the context when doing work. This allows slow resource builders to
cancel their task mid-way.

/cc @smarterclayton 