### PR TITLE
manifest: switch pull policy to ifnotpresent

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: cluster-version-operator
         image: {{.ReleaseImage}}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
           - "start"
           - "--release-image={{.ReleaseImage}}"


### PR DESCRIPTION
If the registry goes down, we want to continue to be able to run new replicas
of this image over time.

This matches other operators and our general guidance

/assign @abhinavdahiya 