### PR TITLE
sync: Distinguish between reconcile, initial, and sync states

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -30,6 +30,10 @@ func newCRDBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *crdBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *crdBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b

--- a/lib/resourcebuilder/apireg.go
+++ b/lib/resourcebuilder/apireg.go
@@ -23,6 +23,10 @@ func newAPIServiceBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *apiServiceBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *apiServiceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b

--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -31,6 +31,10 @@ func newDeploymentBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *deploymentBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *deploymentBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b
@@ -89,6 +93,10 @@ func newDaemonsetBuilder(config *rest.Config, m lib.Manifest) Interface {
 		client: appsclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
+}
+
+func (b *daemonsetBuilder) WithMode(m Mode) Interface {
+	return b
 }
 
 func (b *daemonsetBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {

--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -30,6 +30,10 @@ func newJobBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *jobBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *jobBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b

--- a/lib/resourcebuilder/core.go
+++ b/lib/resourcebuilder/core.go
@@ -23,6 +23,10 @@ func newServiceAccountBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *serviceAccountBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *serviceAccountBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b
@@ -48,6 +52,10 @@ func newConfigMapBuilder(config *rest.Config, m lib.Manifest) Interface {
 		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
+}
+
+func (b *configMapBuilder) WithMode(m Mode) Interface {
+	return b
 }
 
 func (b *configMapBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
@@ -77,6 +85,10 @@ func newNamespaceBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *namespaceBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *namespaceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b
@@ -102,6 +114,10 @@ func newServiceBuilder(config *rest.Config, m lib.Manifest) Interface {
 		client: coreclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
+}
+
+func (b *serviceBuilder) WithMode(m Mode) Interface {
+	return b
 }
 
 func (b *serviceBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -63,8 +63,18 @@ type MetaV1ObjectModifierFunc func(metav1.Object)
 // and the Manifest.
 type NewInteraceFunc func(rest *rest.Config, m lib.Manifest) Interface
 
+// Mode is how this builder is being used.
+type Mode int
+
+const (
+	UpdatingMode Mode = iota
+	ReconcilingMode
+	InitializingMode
+)
+
 type Interface interface {
 	WithModifier(MetaV1ObjectModifierFunc) Interface
+	WithMode(Mode) Interface
 	Do(context.Context) error
 }
 

--- a/lib/resourcebuilder/rbac.go
+++ b/lib/resourcebuilder/rbac.go
@@ -23,6 +23,10 @@ func newClusterRoleBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *clusterRoleBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *clusterRoleBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b
@@ -48,6 +52,10 @@ func newClusterRoleBindingBuilder(config *rest.Config, m lib.Manifest) Interface
 		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
+}
+
+func (b *clusterRoleBindingBuilder) WithMode(m Mode) Interface {
+	return b
 }
 
 func (b *clusterRoleBindingBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
@@ -77,6 +85,10 @@ func newRoleBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *roleBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *roleBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b
@@ -102,6 +114,10 @@ func newRoleBindingBuilder(config *rest.Config, m lib.Manifest) Interface {
 		client: rbacclientv1.NewForConfigOrDie(withProtobuf(config)),
 		raw:    m.Raw,
 	}
+}
+
+func (b *roleBindingBuilder) WithMode(m Mode) Interface {
+	return b
 }
 
 func (b *roleBindingBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {

--- a/lib/resourcebuilder/security.go
+++ b/lib/resourcebuilder/security.go
@@ -23,6 +23,10 @@ func newSecurityBuilder(config *rest.Config, m lib.Manifest) Interface {
 	}
 }
 
+func (b *securityBuilder) WithMode(m Mode) Interface {
+	return b
+}
+
 func (b *securityBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 	b.modifier = f
 	return b

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -493,7 +493,7 @@ func (b *resourceBuilder) BuilderFor(m *lib.Manifest) (resourcebuilder.Interface
 	return internal.NewGenericBuilder(client, *m)
 }
 
-func (b *resourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
+func (b *resourceBuilder) Apply(ctx context.Context, m *lib.Manifest, state payload.State) error {
 	builder, err := b.BuilderFor(m)
 	if err != nil {
 		return err
@@ -501,7 +501,20 @@ func (b *resourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
 	if b.modifier != nil {
 		builder = builder.WithModifier(b.modifier)
 	}
-	return builder.Do(ctx)
+	return builder.WithMode(stateToMode(state)).Do(ctx)
+}
+
+func stateToMode(state payload.State) resourcebuilder.Mode {
+	switch state {
+	case payload.InitializingPayload:
+		return resourcebuilder.InitializingMode
+	case payload.UpdatingPayload:
+		return resourcebuilder.UpdatingMode
+	case payload.ReconcilingPayload:
+		return resourcebuilder.ReconcilingMode
+	default:
+		panic(fmt.Sprintf("unexpected payload state %d", int(state)))
+	}
 }
 
 func hasNeverReachedLevel(cv *configv1.ClusterVersion) bool {

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -833,6 +833,6 @@ func (b *blockingResourceBuilder) Send(err error) {
 	b.ch <- err
 }
 
-func (b *blockingResourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
+func (b *blockingResourceBuilder) Apply(ctx context.Context, m *lib.Manifest, state payload.State) error {
 	return <-b.ch
 }

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -206,23 +206,27 @@ func TestCVO_StartupAndSync(t *testing.T) {
 	})
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Step: "RetrievePayload",
+			Step:    "RetrievePayload",
+			Initial: true,
 			// the desired version is briefly incorrect (user provided) until we retrieve the image
 			Actual: configv1.Update{Version: "4.0.1", Image: "image/image:1"},
 		},
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
+			Initial:     true,
 			VersionHash: "6GC9TkkG9PA=",
 			Actual:      configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 		},
 		SyncWorkerStatus{
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
+			Initial:     true,
 			VersionHash: "6GC9TkkG9PA=",
 			Actual:      configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 		},
 		SyncWorkerStatus{
 			Fraction:    float32(2) / 3,
+			Initial:     true,
 			Step:        "ApplyResources",
 			VersionHash: "6GC9TkkG9PA=",
 			Actual:      configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
@@ -382,6 +386,9 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 	if status := worker.Status(); !status.Reconciling || status.Completed != 0 {
 		t.Fatalf("The worker should be reconciling from the beginning: %#v", status)
 	}
+	if worker.work.State != payload.ReconcilingPayload {
+		t.Fatalf("The worker should be reconciling: %v", worker.work)
+	}
 
 	// Step 2: Start the sync worker and verify the sequence of events, and then verify
 	//         the status does not change
@@ -536,6 +543,9 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 	if status := worker.Status(); !status.Reconciling || status.Completed != 0 {
 		t.Fatalf("The worker should be reconciling from the beginning: %#v", status)
 	}
+	if worker.work.State != payload.ReconcilingPayload {
+		t.Fatalf("The worker should be reconciling: %v", worker.work)
+	}
 
 	// Step 2: Start the sync worker and verify the sequence of events
 	//
@@ -656,6 +666,123 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestCVO_VerifyInitializingPayloadState(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	defer shutdownFn()
+	worker := o.configSync.(*SyncWorker)
+	b := newBlockingResourceBuilder()
+	worker.builder = b
+
+	// Setup: a successful sync from a previous run, and the operator at the same image as before
+	//
+	o.releaseImage = "image/image:1"
+	o.releaseVersion = "1.0.0-abc"
+	desired := configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: clusterUID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the image version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	// Step 1: The sync loop starts and triggers a sync, but does not update status
+	//
+	client.ClearActions()
+	err := o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the worker status is initially set to reconciling
+	if status := worker.Status(); status.Reconciling || status.Completed != 0 {
+		t.Fatalf("The worker should be initializing from the beginning: %#v", status)
+	}
+	if worker.work.State != payload.InitializingPayload {
+		t.Fatalf("The worker should be initializing: %v", worker.work)
+	}
+}
+
+func TestCVO_VerifyUpdatingPayloadState(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	defer shutdownFn()
+	worker := o.configSync.(*SyncWorker)
+	b := newBlockingResourceBuilder()
+	worker.builder = b
+
+	// Setup: a successful sync from a previous run, and the operator at the same image as before
+	//
+	o.releaseImage = "image/image:1"
+	o.releaseVersion = "1.0.0-abc"
+	desired := configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: clusterUID,
+			Channel:   "fast",
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the image version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "6GC9TkkG9PA=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
+				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc.0", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: configv1.OperatorFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	// Step 1: The sync loop starts and triggers a sync, but does not update status
+	//
+	client.ClearActions()
+	err := o.sync(o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check the worker status is initially set to reconciling
+	if status := worker.Status(); status.Reconciling || status.Completed != 0 {
+		t.Fatalf("The worker should be updating from the beginning: %#v", status)
+	}
+	if worker.work.State != payload.UpdatingPayload {
+		t.Fatalf("The worker should be updating: %v", worker.work)
+	}
 }
 
 func verifyAllStatus(t *testing.T, ch <-chan SyncWorkerStatus, items ...SyncWorkerStatus) {

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -73,6 +73,10 @@ func NewGenericBuilder(client dynamic.ResourceInterface, m lib.Manifest) (resour
 	}, nil
 }
 
+func (b *genericBuilder) WithMode(m resourcebuilder.Mode) resourcebuilder.Interface {
+	return b
+}
+
 func (b *genericBuilder) WithModifier(f resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
 	b.modifier = f
 	return b

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -16,6 +16,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
 	"github.com/openshift/cluster-version-operator/pkg/payload"
 )
 
@@ -23,7 +24,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 	tests := []struct {
 		name   string
 		actual *configv1.ClusterOperator
-
+		mode   resourcebuilder.Mode
 		exp    *configv1.ClusterOperator
 		expErr error
 	}{{
@@ -478,7 +479,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 
 			ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), 1*time.Millisecond)
 			defer cancel()
-			err := waitForOperatorStatusToBeDone(ctxWithTimeout, 1*time.Millisecond, clientClusterOperatorsGetter{getter: client.ConfigV1().ClusterOperators()}, test.exp)
+			err := waitForOperatorStatusToBeDone(ctxWithTimeout, 1*time.Millisecond, clientClusterOperatorsGetter{getter: client.ConfigV1().ClusterOperators()}, test.exp, test.mode)
 			if (test.expErr == nil) != (err == nil) {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -1,9 +1,11 @@
 package cvo
 
 import (
+	"reflect"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func Test_mergeEqualVersions(t *testing.T) {
@@ -35,6 +37,85 @@ func Test_mergeEqualVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := mergeEqualVersions(tt.current, tt.desired); got != tt.want {
 				t.Errorf("%v != %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_pruneStatusHistory(t *testing.T) {
+	obj := &configv1.ClusterVersion{
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.PartialUpdate, Version: "0.0.9"},
+				{State: configv1.PartialUpdate, Version: "0.0.8"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpdate, Version: "0.0.6"},
+			},
+		},
+	}
+	tests := []struct {
+		name       string
+		config     *configv1.ClusterVersion
+		maxHistory int
+		want       []configv1.UpdateHistory
+	}{
+		{
+			config:     obj.DeepCopy(),
+			maxHistory: 2,
+			want: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+			},
+		},
+		{
+			config:     obj.DeepCopy(),
+			maxHistory: 3,
+			want: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.PartialUpdate, Version: "0.0.9"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+			},
+		},
+		{
+			config:     obj.DeepCopy(),
+			maxHistory: 4,
+			want: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.PartialUpdate, Version: "0.0.9"},
+				{State: configv1.PartialUpdate, Version: "0.0.8"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+			},
+		},
+		{
+			config:     obj.DeepCopy(),
+			maxHistory: 5,
+			want: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.PartialUpdate, Version: "0.0.9"},
+				{State: configv1.PartialUpdate, Version: "0.0.8"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpdate, Version: "0.0.6"},
+			},
+		},
+		{
+			config:     obj.DeepCopy(),
+			maxHistory: 6,
+			want: []configv1.UpdateHistory{
+				{State: configv1.PartialUpdate, Version: "0.0.10"},
+				{State: configv1.PartialUpdate, Version: "0.0.9"},
+				{State: configv1.PartialUpdate, Version: "0.0.8"},
+				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpdate, Version: "0.0.6"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.config.DeepCopy()
+			pruneStatusHistory(config, tt.maxHistory)
+			if !reflect.DeepEqual(tt.want, config.Status.History) {
+				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, config.Status.History))
 			}
 		})
 	}

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -300,8 +300,14 @@ type testBuilder struct {
 	*recorder
 	reactors  map[action]error
 	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
+	mode      resourcebuilder.Mode
 
 	m *lib.Manifest
+}
+
+func (t *testBuilder) WithMode(m resourcebuilder.Mode) resourcebuilder.Interface {
+	t.mode = m
+	return t
 }
 
 func (t *testBuilder) WithModifier(m resourcebuilder.MetaV1ObjectModifierFunc) resourcebuilder.Interface {
@@ -392,7 +398,7 @@ type testResourceBuilder struct {
 	modifiers []resourcebuilder.MetaV1ObjectModifierFunc
 }
 
-func (b *testResourceBuilder) Apply(ctx context.Context, m *lib.Manifest) error {
+func (b *testResourceBuilder) Apply(ctx context.Context, m *lib.Manifest, state payload.State) error {
 	ns := m.Object().GetNamespace()
 	fakeGVR := schema.GroupVersionResource{Group: m.GVK.Group, Version: m.GVK.Version, Resource: strings.ToLower(m.GVK.Kind)}
 	client := b.client.Resource(fakeGVR).Namespace(ns)

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -353,7 +353,7 @@ func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
 
 func (r *fakeSyncRecorder) Start(maxWorkers int, stopCh <-chan struct{}) {}
 
-func (r *fakeSyncRecorder) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus {
+func (r *fakeSyncRecorder) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
 	r.Updates = append(r.Updates, desired)
 	return r.Returns
 }

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -458,7 +458,7 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 				continue
 			}
 
-			if err := task.Run(ctx, version, w.builder); err != nil {
+			if err := task.Run(ctx, version, w.builder, work.State); err != nil {
 				return err
 			}
 			cr.Inc()

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -25,7 +25,7 @@ import (
 // ConfigSyncWorker abstracts how the image is synchronized to the server. Introduced for testing.
 type ConfigSyncWorker interface {
 	Start(maxWorkers int, stopCh <-chan struct{})
-	Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus
+	Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus
 	StatusCh() <-chan SyncWorkerStatus
 }
 
@@ -41,11 +41,11 @@ type StatusReporter interface {
 
 // SyncWork represents the work that should be done in a sync iteration.
 type SyncWork struct {
-	Generation  int64
-	Desired     configv1.Update
-	Overrides   []configv1.ComponentOverride
-	Reconciling bool
-	Completed   int
+	Generation int64
+	Desired    configv1.Update
+	Overrides  []configv1.ComponentOverride
+	State      payload.State
+	Completed  int
 }
 
 // Empty returns true if the image is empty for this work.
@@ -64,6 +64,7 @@ type SyncWorkerStatus struct {
 
 	Completed   int
 	Reconciling bool
+	Initial     bool
 	VersionHash string
 
 	Actual configv1.Update
@@ -147,7 +148,7 @@ func (w *SyncWorker) StatusCh() <-chan SyncWorkerStatus {
 // the initial state or whatever the last recorded status was.
 // TODO: in the future it may be desirable for changes that alter desired to wait briefly before returning,
 //   giving the sync loop the opportunity to observe our change and begin working towards it.
-func (w *SyncWorker) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, reconciling bool) *SyncWorkerStatus {
+func (w *SyncWorker) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
@@ -164,12 +165,10 @@ func (w *SyncWorker) Update(generation int64, desired configv1.Update, overrides
 	// initialize the reconciliation flag and the status the first time
 	// update is invoked
 	if w.work == nil {
-		if reconciling {
-			work.Reconciling = true
-		}
+		work.State = state
 		w.status = SyncWorkerStatus{
 			Generation:  generation,
-			Reconciling: work.Reconciling,
+			Reconciling: state.Reconciling(),
 			Actual:      work.Desired,
 		}
 	}
@@ -202,7 +201,7 @@ func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
 
 		var next <-chan time.Time
 		for {
-			waitingToReconcile := work.Reconciling
+			waitingToReconcile := work.State == payload.ReconcilingPayload
 			select {
 			case <-stopCh:
 				glog.V(5).Infof("Stopped worker")
@@ -261,7 +260,7 @@ func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
 			glog.V(5).Infof("Sync succeeded, reconciling")
 
 			work.Completed++
-			work.Reconciling = true
+			work.State = payload.ReconcilingPayload
 			next = time.After(w.minimumReconcileInterval)
 		}
 	}, 10*time.Millisecond, stopCh)
@@ -302,14 +301,14 @@ func (w *SyncWorker) calculateNext(work *SyncWork) bool {
 	// if this is the first time through the loop, initialize reconciling to
 	// the state Update() calculated (to allow us to start in reconciling)
 	if work.Empty() {
-		work.Reconciling = w.work.Reconciling
+		work.State = w.work.State
 	} else {
 		if changed {
-			work.Reconciling = false
+			work.State = payload.UpdatingPayload
 		}
 	}
 	// always clear the completed variable if we are not reconciling
-	if !work.Reconciling {
+	if work.State != payload.ReconcilingPayload {
 		work.Completed = 0
 	}
 
@@ -378,22 +377,22 @@ func (w *SyncWorker) Status() *SyncWorkerStatus {
 // the update could not be completely applied. The status is updated as we progress.
 // Cancelling the context will abort the execution of the sync.
 func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers int, reporter StatusReporter) error {
-	glog.V(4).Infof("Running sync %s on generation %d", versionString(work.Desired), work.Generation)
+	glog.V(4).Infof("Running sync %s on generation %d in state %s", versionString(work.Desired), work.Generation, work.State)
 	update := work.Desired
 
 	// cache the payload until the release image changes
 	validPayload := w.payload
 	if validPayload == nil || !equalUpdate(configv1.Update{Image: validPayload.ReleaseImage}, update) {
 		glog.V(4).Infof("Loading payload")
-		reporter.Report(SyncWorkerStatus{Step: "RetrievePayload", Reconciling: work.Reconciling, Actual: update})
+		reporter.Report(SyncWorkerStatus{Step: "RetrievePayload", Initial: work.State.Initializing(), Reconciling: work.State.Reconciling(), Actual: update})
 		payloadDir, err := w.retriever.RetrievePayload(ctx, update)
 		if err != nil {
-			reporter.Report(SyncWorkerStatus{Failure: err, Step: "RetrievePayload", Reconciling: work.Reconciling, Actual: update})
+			reporter.Report(SyncWorkerStatus{Failure: err, Step: "RetrievePayload", Initial: work.State.Initializing(), Reconciling: work.State.Reconciling(), Actual: update})
 			return err
 		}
 		payloadUpdate, err := payload.LoadUpdate(payloadDir, update.Image)
 		if err != nil {
-			reporter.Report(SyncWorkerStatus{Failure: err, Step: "VerifyPayload", Reconciling: work.Reconciling, Actual: update})
+			reporter.Report(SyncWorkerStatus{Failure: err, Step: "VerifyPayload", Initial: work.State.Initializing(), Reconciling: work.State.Reconciling(), Actual: update})
 			return err
 		}
 		w.payload = payloadUpdate
@@ -418,7 +417,8 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 	cr := &consistentReporter{
 		status: SyncWorkerStatus{
 			Generation:  work.Generation,
-			Reconciling: work.Reconciling,
+			Initial:     work.State.Initializing(),
+			Reconciling: work.State.Reconciling(),
 			VersionHash: payloadUpdate.ManifestHash,
 			Actual:      update,
 		},
@@ -471,7 +471,7 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 		return err
 	}
 
-	// update the
+	// update the status
 	cr.Complete()
 	return nil
 }
@@ -541,6 +541,7 @@ func (r *consistentReporter) Complete() {
 	metricPayload.WithLabelValues(r.version, "applied").Set(float64(r.done))
 	copied := r.status
 	copied.Completed = r.completed + 1
+	copied.Initial = false
 	copied.Reconciling = true
 	copied.Fraction = 1
 	r.reporter.Report(copied)

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -31,7 +31,7 @@ func init() {
 
 // ResourceBuilder abstracts how a manifest is created on the server. Introduced for testing.
 type ResourceBuilder interface {
-	Apply(context.Context, *lib.Manifest) error
+	Apply(context.Context, *lib.Manifest, State) error
 }
 
 type Task struct {
@@ -50,11 +50,11 @@ func (st *Task) String() string {
 	return fmt.Sprintf("%s \"%s/%s\" (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), ns, st.Manifest.Object().GetName(), st.Index, st.Total)
 }
 
-func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder) error {
+func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder, state State) error {
 	var lastErr error
 	if err := wait.ExponentialBackoff(st.Backoff, func() (bool, error) {
 		// run builder for the manifest
-		if err := builder.Apply(ctx, st.Manifest); err != nil {
+		if err := builder.Apply(ctx, st.Manifest, state); err != nil {
 			utilruntime.HandleError(errors.Wrapf(err, "error running apply for %s", st))
 			lastErr = err
 			metricPayloadErrors.WithLabelValues(version).Inc()


### PR DESCRIPTION
Identify what sort of change we are making to the cluster in order
to better handle the different states. Does not change status reporting
or the internal sync which will be in a follow up commit.

The three states are:

* Initializing - we haven't yet completed a payload
* Updating - we're moving between two payloads of different versions
* Reconciling - we're level on a completed payload

The states will allow us to more efficiently reconcile, start faster,
and be safer during upgrades.

Extracted from #131