### PR TITLE
sync: Double max parallelism of sync worker

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -219,7 +219,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 
 	// start the config sync loop, and have it notify the queue when new status is detected
 	go runThrottledStatusNotifier(stopCh, optr.statusInterval, 2, optr.configSync.StatusCh(), func() { optr.queue.Add(optr.queueKey()) })
-	go optr.configSync.Start(8, stopCh)
+	go optr.configSync.Start(16, stopCh)
 
 	go wait.Until(func() { optr.worker(optr.queue, optr.sync) }, time.Second, stopCh)
 	go wait.Until(func() { optr.worker(optr.availableUpdatesQueue, optr.availableUpdatesSync) }, time.Second, stopCh)


### PR DESCRIPTION
The 0000_70 run level has ~13 operators. It appears we can afford
to go a bit broader (although the ideal solution is to pause a task
group when we hit a CO, flush out the others, then wait).

A subsequent change will alter how the rate limiter works so that we
can be a little slower during reconcile but faster during initial install.

Extracted from #134