### PR TITLE
Bug 1670727: install/0000_00_cluster-version-operator_03_deployment: Set 'strategy: Recreate'

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -46,6 +46,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
+      strategy: Recreate
       tolerations:
         - operator: Exists
       volumes:


### PR DESCRIPTION
Address [rhbz#1670727][1]:

```
F0129 08:54:04.971868       1 start.go:144] Unable to start metrics server: listen tcp 0.0.0.0:9099: bind: address already in use
```

when the new CVO pod is scheduled on the same node as the old one.  From [the Kubernetes docs][2] the default strategy (which we override with this commit) was `RollingUpdate`.  The `Recreate` strategy avoids the port conflict [because][3]:

> All existing Pods are killed before new ones are created when `.spec.strategy.type==Recreate`.

That leaves a (hopefully brief) window when there is no CVO pod, but since our only API is serving those metrics, that's probably not a big deal.  The new pod should be able to pick up reconciling ClusterVersion changes when it comes up, even if changes were made during the no-CVO-pod gap.

CC @abhinavdahiya, @smarterclayton

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1670727
[2]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
[3]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment