### PR TITLE
Bug 1691513: CVO should retry initialization until cancelled to avoid wedging because of failing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	hack/build-go.sh
+.PHONY: build
+
+test:
+	go test ./...
+.PHONY: test

--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -2,7 +2,6 @@ package resourcebuilder
 
 import (
 	"context"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -49,15 +48,13 @@ func (b *crdBuilder) Do(ctx context.Context) error {
 		return err
 	}
 	if updated {
-		ctxWithTimeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
-		defer cancel()
-		return waitForCustomResourceDefinitionCompletion(ctxWithTimeout, 1*time.Second, b.client, crd)
+		return waitForCustomResourceDefinitionCompletion(ctx, b.client, crd)
 	}
 	return nil
 }
 
-func waitForCustomResourceDefinitionCompletion(ctx context.Context, interval time.Duration, client apiextclientv1beta1.CustomResourceDefinitionsGetter, crd *apiextv1beta1.CustomResourceDefinition) error {
-	return wait.PollImmediateUntil(interval, func() (bool, error) {
+func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiextclientv1beta1.CustomResourceDefinitionsGetter, crd *apiextv1beta1.CustomResourceDefinition) error {
+	return wait.PollImmediateUntil(defaultObjectPollInterval, func() (bool, error) {
 		c, err := client.CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			// exit early to recreate the crd.

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -86,3 +87,7 @@ func New(mapper *ResourceMapper, rest *rest.Config, m lib.Manifest) (Interface, 
 	}
 	return f(rest, m), nil
 }
+
+// defaultObjectPollInterval is the default interval to poll the API to determine whether an object
+// is ready. Use this when a more specific interval is not necessary.
+const defaultObjectPollInterval = 3 * time.Second

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -622,7 +622,19 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 	// Step 6: Send an error, then verify it shows up in status
 	//
 	b.Send(fmt.Errorf("unable to proceed"))
+
+	go func() {
+		for len(b.ch) != 0 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+		for len(b.ch) == 0 || len(worker.StatusCh()) == 0 {
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
 	//
+	// verify we see the update after the context times out
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
 			Reconciling: true,

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -99,13 +99,7 @@ func (b *clusterOperatorBuilder) Do(ctx context.Context) error {
 	if b.modifier != nil {
 		b.modifier(os)
 	}
-	timeout := 1 * time.Minute
-	if b.mode == resourcebuilder.InitializingMode {
-		timeout = 6 * time.Minute
-	}
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	return waitForOperatorStatusToBeDone(ctxWithTimeout, 1*time.Second, b.client, os, b.mode)
+	return waitForOperatorStatusToBeDone(ctx, 1*time.Second, b.client, os, b.mode)
 }
 
 func waitForOperatorStatusToBeDone(ctx context.Context, interval time.Duration, client ClusterOperatorsGetter, expected *configv1.ClusterOperator, mode resourcebuilder.Mode) error {

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -357,7 +357,7 @@ func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
 	return ch
 }
 
-func (r *fakeSyncRecorder) Start(maxWorkers int, stopCh <-chan struct{}) {}
+func (r *fakeSyncRecorder) Start(ctx context.Context, maxWorkers int) {}
 
 func (r *fakeSyncRecorder) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
 	r.Updates = append(r.Updates, desired)

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
 	clientgotesting "k8s.io/client-go/testing"
@@ -29,8 +30,9 @@ import (
 
 func Test_SyncWorker_apply(t *testing.T) {
 	tests := []struct {
-		manifests []string
-		reactors  map[action]error
+		manifests   []string
+		reactors    map[action]error
+		cancelAfter int
 
 		check   func(*testing.T, []action)
 		wantErr bool
@@ -61,10 +63,10 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 
 			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
-				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 			if got, exp := actions[1], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
-				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
 	}, {
@@ -89,7 +91,8 @@ func Test_SyncWorker_apply(t *testing.T) {
 		reactors: map[action]error{
 			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
-		wantErr: true,
+		cancelAfter: 2,
+		wantErr:     true,
 		check: func(t *testing.T, actions []action) {
 			if len(actions) != 3 {
 				spew.Dump(actions)
@@ -97,7 +100,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 
 			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
-				t.Fatalf("expected: %s got: %s", spew.Sdump(exp), spew.Sdump(got))
+				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
 	}}
@@ -120,13 +123,38 @@ func Test_SyncWorker_apply(t *testing.T) {
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
 			worker := &SyncWorker{}
-			worker.backoff.Steps = 3
 			worker.builder = NewResourceBuilder(nil, nil, nil)
-			ctx := context.Background()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			worker.builder = &cancelAfterErrorBuilder{
+				builder:         worker.builder,
+				cancel:          cancel,
+				remainingErrors: test.cancelAfter,
+			}
+
 			worker.apply(ctx, up, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
 			test.check(t, r.actions)
 		})
 	}
+}
+
+type cancelAfterErrorBuilder struct {
+	builder         payload.ResourceBuilder
+	cancel          func()
+	remainingErrors int
+}
+
+func (b *cancelAfterErrorBuilder) Apply(ctx context.Context, m *lib.Manifest, state payload.State) error {
+	err := b.builder.Apply(ctx, m, state)
+	if err != nil {
+		if b.remainingErrors == 0 {
+			b.cancel()
+		} else {
+			b.remainingErrors--
+		}
+	}
+	return err
 }
 
 func Test_SyncWorker_apply_generic(t *testing.T) {

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -24,7 +24,7 @@ import (
 
 // ConfigSyncWorker abstracts how the image is synchronized to the server. Introduced for testing.
 type ConfigSyncWorker interface {
-	Start(maxWorkers int, stopCh <-chan struct{})
+	Start(ctx context.Context, maxWorkers int)
 	Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus
 	StatusCh() <-chan SyncWorkerStatus
 }
@@ -190,7 +190,7 @@ func (w *SyncWorker) Update(generation int64, desired configv1.Update, overrides
 // Start periodically invokes run, detecting whether content has changed.
 // It is edge-triggered when Update() is invoked and level-driven after the
 // syncOnce() has succeeded for a given input (we are said to be "reconciling").
-func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
+func (w *SyncWorker) Start(ctx context.Context, maxWorkers int) {
 	glog.V(5).Infof("Starting sync worker")
 
 	work := &SyncWork{}
@@ -203,7 +203,7 @@ func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
 		for {
 			waitingToReconcile := work.State == payload.ReconcilingPayload
 			select {
-			case <-stopCh:
+			case <-ctx.Done():
 				glog.V(5).Infof("Stopped worker")
 				return
 			case <-next:
@@ -229,7 +229,7 @@ func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
 
 			// actually apply the image, allowing for calls to be cancelled
 			err := func() error {
-				ctx, cancelFn := context.WithCancel(context.Background())
+				ctx, cancelFn := context.WithCancel(ctx)
 				w.lock.Lock()
 				w.cancelFn = cancelFn
 				w.lock.Unlock()
@@ -263,7 +263,7 @@ func (w *SyncWorker) Start(maxWorkers int, stopCh <-chan struct{}) {
 			work.State = payload.ReconcilingPayload
 			next = time.After(w.minimumReconcileInterval)
 		}
-	}, 10*time.Millisecond, stopCh)
+	}, 10*time.Millisecond, ctx.Done())
 
 	glog.V(5).Infof("Worker shut down")
 }

--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -159,7 +159,7 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 	if err != nil {
 		return err
 	}
-	return resourcebuilder.WaitForJobCompletion(r.kubeClient.BatchV1(), job)
+	return resourcebuilder.WaitForJobCompletion(ctx, r.kubeClient.BatchV1(), job)
 }
 
 // copyPayloadCmd returns command that copies cvo and release manifests from deafult location

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -379,9 +379,10 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	options.ReleaseImage = payloadImage1
 	options.PayloadOverride = filepath.Join(dir, "ignored")
 	options.EnableMetrics = false
+	options.ResyncInterval = 3 * time.Second
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}).(*cvo.SyncWorker)
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Duration: time.Second, Factor: 1.2}).(*cvo.SyncWorker)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -233,9 +233,9 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}).(*cvo.SyncWorker)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	controllers.Start(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	controllers.Start(ctx)
 
 	t.Logf("wait until we observe the cluster version become available")
 	lastCV, err := waitForUpdateAvailable(t, client, ns, false, "0.0.1")
@@ -384,9 +384,9 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}).(*cvo.SyncWorker)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	controllers.Start(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	controllers.Start(ctx)
 
 	t.Logf("wait until we observe the cluster version become available")
 	lastCV, err := waitForUpdateAvailable(t, client, ns, false, "0.0.1")
@@ -660,9 +660,9 @@ metadata:
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}).(*cvo.SyncWorker)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	controllers.Start(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	controllers.Start(ctx)
 
 	t.Logf("wait until we observe the cluster version become available")
 	lastCV, err := waitForUpdateAvailable(t, client, ns, false, "0.0.1")


### PR DESCRIPTION
The sync loop currently mixes a combination of:

1. Try forever (top level sync loop) 
2. Cancel sync when a timeout is reached 
3. Retry individual Apply actions in the sync workers up to a max
retry 
4. Retry within Apply actions

This led to bugs in initialization where transient errors cause a prereq
step to fail and never complete, leading to other operators never going
live.

This commit simplifies the structure of our retry logic to be:

1. Try to sync forever 
2. Cancel sync after a certain period of failure and go into backoff 
3. Retry individual Applies forever with capped backoff 
4. Retry applies as long as context is not cancelled

This implies all top level sync has a context with a deadline which is the
case today - some test cases are changed for it.

This should also reduce the lag between cancel (on user action, for 
instance) and the sync loop terminating, since everything is context gated.

Also adds a Makefile because I like consistency.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1691513