### PR TITLE
test: Avoid collisions on namespace and lengthen shutdown timeout

### DIFF
--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -461,7 +461,7 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	kc := cb.KubeClientOrDie("integration-test")
 	client := cb.ClientOrDie("integration-test")
 
-	ns := fmt.Sprintf("e2e-cvo-%s", randutil.String(4))
+	ns := fmt.Sprintf("e2e-cvo-%s", randutil.String(6))
 
 	if _, err := kc.Core().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -533,7 +533,7 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	startTime := time.Now()
 	var endTime time.Time
 	// the lock should be deleted immediately
-	err = wait.PollImmediate(100*time.Millisecond, 3*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
 		_, err := kc.Core().ConfigMaps(ns).Get(ns, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			endTime = time.Now()


### PR DESCRIPTION
While testing in tight loops I was able to trigger collisions and
timeout errors.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/141/pull-ci-openshift-cluster-version-operator-master-integration/198

```
	start_integration_test.go:549: timed out waiting for the condition
	start_integration_test.go:476: failed to delete cluster version e2e-cvo-fqgh: clusterversions.config.openshift.io "e2e-cvo-fqgh" not found
```