### PR TITLE
status: Correctly increment history and don't overwrite controller cache objects

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -278,7 +278,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
@@ -351,7 +351,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
@@ -425,7 +425,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
-							{Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
@@ -496,7 +496,7 @@ func TestOperator_sync(t *testing.T) {
 						Desired: configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						History: []configv1.UpdateHistory{
 							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{Time: time.Unix(0, 0)}, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{Time: time.Unix(0, 0)}, CompletionTime: &defaultCompletionTime},
 						},
 						VersionHash: "foo",
 						Conditions: []configv1.ClusterOperatorStatusCondition{

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
-
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1304,9 +1303,9 @@ func TestOperator_sync(t *testing.T) {
 				Actual:      configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
 			optr: Operator{
-				releaseImage: "image/image:v4.0.1",
-				namespace:    "test",
-				name:         "default",
+				releaseImage:          "image/image:v4.0.1",
+				namespace:             "test",
+				name:                  "default",
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				availableUpdates: &availableUpdates{
 					Upstream: "",

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -2,6 +2,7 @@ package cvo
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -21,6 +22,9 @@ import (
 
 func mergeEqualVersions(current *configv1.UpdateHistory, desired configv1.Update) bool {
 	if len(desired.Image) > 0 && desired.Image == current.Image {
+		if len(desired.Version) == 0 {
+			return true
+		}
 		if len(current.Version) == 0 || desired.Version == current.Version {
 			current.Version = desired.Version
 			return true
@@ -46,6 +50,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 	}
 
 	if len(config.Status.History) == 0 {
+		glog.V(5).Infof("initialize new history completed=%t desired=%#v", completed, desired)
 		config.Status.History = append(config.Status.History, configv1.UpdateHistory{
 			Version: desired.Version,
 			Image:   desired.Image,
@@ -57,31 +62,54 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 
 	last := &config.Status.History[0]
 
-	if !mergeEqualVersions(last, desired) {
-		last.CompletionTime = &now
-		config.Status.History = append([]configv1.UpdateHistory{
-			{
-				Version: desired.Version,
-				Image:   desired.Image,
-
-				State:       configv1.PartialUpdate,
-				StartedTime: now,
-			},
-		}, config.Status.History...)
-		last = &config.Status.History[0]
-	}
-
-	pruneStatusHistory(config, 10)
-
-	if completed {
-		last.State = configv1.CompletedUpdate
-		if last.CompletionTime == nil {
-			last.CompletionTime = &now
-		}
-	}
 	if len(last.State) == 0 {
 		last.State = configv1.PartialUpdate
 	}
+
+	if mergeEqualVersions(last, desired) {
+		glog.V(5).Infof("merge into existing history completed=%t desired=%#v last=%#v", completed, desired, last)
+		if completed {
+			last.State = configv1.CompletedUpdate
+			if last.CompletionTime == nil {
+				last.CompletionTime = &now
+			}
+		}
+	} else {
+		glog.V(5).Infof("must add a new history entry completed=%t desired=%#v != last=%#v", completed, desired, last)
+		last.CompletionTime = &now
+		if completed {
+			config.Status.History = append([]configv1.UpdateHistory{
+				{
+					Version: desired.Version,
+					Image:   desired.Image,
+
+					State:          configv1.CompletedUpdate,
+					StartedTime:    now,
+					CompletionTime: &now,
+				},
+			}, config.Status.History...)
+		} else {
+			config.Status.History = append([]configv1.UpdateHistory{
+				{
+					Version: desired.Version,
+					Image:   desired.Image,
+
+					State:       configv1.PartialUpdate,
+					StartedTime: now,
+				},
+			}, config.Status.History...)
+		}
+	}
+
+	// leave this here in case we find other future history bugs and need to debug it
+	if glog.V(5) && len(config.Status.History) > 1 {
+		if config.Status.History[0].Image == config.Status.History[1].Image && config.Status.History[0].Version == config.Status.History[1].Version {
+			data, _ := json.MarshalIndent(config.Status.History, "", "  ")
+			panic(fmt.Errorf("tried to update cluster version history to contain duplicate image entries: %s", string(data)))
+		}
+	}
+
+	pruneStatusHistory(config, 10)
 
 	config.Status.Desired = desired
 }

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -274,24 +274,24 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 // from the cache (instead of clearing the status).
 // if ierr is nil, return nil
 // if ierr is not nil, update OperatorStatus as Failing and return ierr
-func (optr *Operator) syncFailingStatus(config *configv1.ClusterVersion, ierr error) error {
+func (optr *Operator) syncFailingStatus(original *configv1.ClusterVersion, ierr error) error {
 	if ierr == nil {
 		return nil
 	}
 
 	// try to reuse the most recent status if available
-	if config == nil {
-		config, _ = optr.cvLister.Get(optr.name)
+	if original == nil {
+		original, _ = optr.cvLister.Get(optr.name)
 	}
-	if config == nil {
-		config = &configv1.ClusterVersion{
+	if original == nil {
+		original = &configv1.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: optr.name,
 			},
 		}
 	}
 
-	original := config.DeepCopy()
+	config := original.DeepCopy()
 
 	now := metav1.Now()
 	msg := fmt.Sprintf("Error ensuring the cluster version is up to date: %v", ierr)

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -34,6 +34,21 @@ func Test_mergeEqualVersions(t *testing.T) {
 		{
 			current: &configv1.UpdateHistory{Image: "test:1", Version: "0.0.1"},
 			desired: configv1.Update{Image: "test:1", Version: ""},
+			want:    true,
+		},
+		{
+			current: &configv1.UpdateHistory{Image: "test:1", Version: "0.0.1"},
+			desired: configv1.Update{Image: "", Version: "0.0.1"},
+			want:    false,
+		},
+		{
+			current: &configv1.UpdateHistory{Image: "test:1", Version: "0.0.1"},
+			desired: configv1.Update{Image: "test:2", Version: "0.0.1"},
+			want:    false,
+		},
+		{
+			current: &configv1.UpdateHistory{Image: "test:1", Version: "0.0.1"},
+			desired: configv1.Update{Image: "test:1", Version: "0.0.2"},
 			want:    false,
 		},
 	}

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -1,11 +1,15 @@
 package cvo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/client-go/config/clientset/versioned/fake"
 )
 
 func Test_mergeEqualVersions(t *testing.T) {
@@ -116,6 +120,123 @@ func Test_pruneStatusHistory(t *testing.T) {
 			pruneStatusHistory(config, tt.maxHistory)
 			if !reflect.DeepEqual(tt.want, config.Status.History) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, config.Status.History))
+			}
+		})
+	}
+}
+
+func TestOperator_syncFailingStatus(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name        string
+		optr        Operator
+		init        func(optr *Operator)
+		wantErr     func(*testing.T, error)
+		wantActions func(*testing.T, *Operator)
+		wantSync    []configv1.Update
+
+		original *configv1.ClusterVersion
+		ierr     error
+	}{
+		{
+			ierr: fmt.Errorf("bad"),
+			optr: Operator{
+				releaseVersion: "4.0.1",
+				releaseImage:   "image/image:v4.0.1",
+				namespace:      "test",
+				name:           "default",
+				client: fakeClientsetWithUpdates(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							Channel: "fast",
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							},
+							Desired:     configv1.Update{Version: "4.0.1", Image: "image/image:v4.0.1"},
+							VersionHash: "",
+							Conditions: []configv1.ClusterOperatorStatusCondition{
+								{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+								{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "unable to apply object"},
+								{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Working towards 4.0.1"},
+								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+							},
+						},
+					},
+				),
+			},
+			wantErr: func(t *testing.T, err error) {
+				if err == nil || err.Error() != "bad" {
+					t.Fatal(err)
+				}
+			},
+			wantActions: func(t *testing.T, optr *Operator) {
+				f := optr.client.(*fake.Clientset)
+				act := f.Actions()
+				if len(act) != 2 {
+					t.Fatalf("unknown actions: %d %#v", len(act), act)
+				}
+				expectGet(t, act[0], "clusterversions", "", "default")
+				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+					Spec: configv1.ClusterVersionSpec{
+						Channel: "fast",
+					},
+					Status: configv1.ClusterVersionStatus{
+						History: []configv1.UpdateHistory{
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+						},
+						Desired:     configv1.Update{Version: "4.0.1", Image: "image/image:v4.0.1"},
+						VersionHash: "",
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+							{Type: configv1.OperatorFailing, Status: configv1.ConditionTrue, Reason: "", Message: "bad"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "", Message: "Error ensuring the cluster version is up to date: bad"},
+							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+						},
+					},
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			optr := &tt.optr
+			if tt.init != nil {
+				tt.init(optr)
+			}
+			optr.cvLister = &clientCVLister{client: optr.client}
+			optr.coLister = &clientCOLister{client: optr.client}
+
+			var originalCopy *configv1.ClusterVersion
+			if tt.original != nil {
+				originalCopy = tt.original.DeepCopy()
+			}
+
+			err := optr.syncFailingStatus(tt.original, tt.ierr)
+
+			if !reflect.DeepEqual(originalCopy, tt.original) {
+				t.Fatalf("syncFailingStatus mutated input: %s", diff.ObjectReflectDiff(originalCopy, tt.original))
+			}
+
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("Operator.sync() unexpected error: %v", err)
+			}
+			if tt.wantErr != nil {
+				tt.wantErr(t, err)
+			}
+			if tt.wantActions != nil {
+				tt.wantActions(t, optr)
+			}
+			if err != nil {
+				return
 			}
 		})
 	}


### PR DESCRIPTION
When we refactored to the newer status style syncFailingStatus was
left updating the cached map, which can cause corruption of the
in memory state.

Also, we shouldn't add an entry to the history when images are equal but the new version is empty because we can get into that state if the CVO is rescheduled onto another node during an upgrade - while it's loading the payload the version will be empty.  We only add an entry if the version is set and has changed (indicating possibly that the tagged image changed).
