### PR TITLE
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,12 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
-RUN hack/build-go.sh
+RUN hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-version-operator/_output/linux/amd64/cluster-version-operator /usr/bin/
+COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY bootstrap /bootstrap
 ENTRYPOINT ["/usr/bin/cluster-version-operator"]


### PR DESCRIPTION
Remove hardcoded 'amd64' from Dockerfile to support multi-arch builds.