### PR TITLE
Ensure channel isn't empty on update check

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -118,6 +118,13 @@ func calculateAvailableUpdatesStatus(clusterID, upstream, channel, version strin
 		}
 	}
 
+	if len(channel) == 0 {
+		return nil, configv1.ClusterOperatorStatusCondition{
+			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "NoChannel",
+			Message: "The update channel has not been configured.",
+		}
+	}
+
 	currentVersion, err := semver.Parse(version)
 	if err != nil {
 		glog.V(2).Infof("Unable to parse current semantic version %q: %v", version, err)


### PR DESCRIPTION
Checking for an empty channel locally prevents unnecessary calls to the
upstream update server.

Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1679901.