### PR TITLE
cvo: fix max_workers to number of nodes in graph

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -463,9 +463,9 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 	graph := payload.NewTaskGraph(tasks)
 	graph.Split(payload.SplitOnJobs)
 	if work.State == payload.InitializingPayload {
-		// get the payload out via brute force
-		maxWorkers = len(tasks)
 		graph.Parallelize(payload.FlattenByNumberAndComponent)
+		// get the payload out via brute force
+		maxWorkers = len(graph.Nodes)
 	} else {
 		graph.Parallelize(payload.ByNumberAndComponent)
 	}


### PR DESCRIPTION
from https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.0/735/artifacts/e2e-aws-upgrade/pods/openshift-cluster-version_cluster-version-operator-6d45bb77db-sv7h9_cluster-version-operator.log.gz
```
...
I0329 12:54:45.471460       1 task_graph.go:538] Canceled worker 222
I0329 12:54:45.471444       1 task_graph.go:538] Canceled worker 265
I0329 12:54:45.471468       1 task_graph.go:538] Canceled worker 221
I0329 12:54:45.471476       1 task_graph.go:538] Canceled worker 220
I0329 12:54:45.471475       1 task_graph.go:538] Canceled worker 218
I0329 12:54:45.471483       1 task_graph.go:538] Canceled worker 202
...
I0329 12:54:45.471551       1 task_graph.go:538] Canceled worker 238
I0329 12:54:45.471552       1 task_graph.go:538] Canceled worker 195
I0329 12:54:45.471556       1 task_graph.go:538] Canceled worker 193
I0329 12:54:45.471560       1 task_graph.go:538] Canceled worker 192
I0329 12:54:45.471561       1 task_graph.go:538] Canceled worker 191
I0329 12:54:45.471564       1 task_graph.go:538] Canceled worker 118
I0329 12:54:45.471568       1 task_graph.go:538] Canceled worker 148
I0329 12:54:45.471570       1 task_graph.go:538] Canceled worker 75
...
```
there shouldn't be that many workers ;) the max number of workers we need is the number of nodes in the graph.

/cc @smarterclayton 