### PR TITLE
pkg/cvo: Report current tasks

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -259,7 +260,11 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 			case len(validationErrs) > 0:
 				message = fmt.Sprintf("Reconciling %s: the cluster version is invalid", version)
 			case status.Fraction > 0:
-				message = fmt.Sprintf("Working towards %s: %.0f%% complete", version, status.Fraction*100)
+				tasks := make([]string, 0, len(status.Current))
+				for _, task := range status.Current {
+					tasks = append(tasks, task.KindName())
+				}
+				message = fmt.Sprintf("Working towards %s: %.0f%% complete (%s)", version, status.Fraction*100, strings.Join(tasks, ", "))
 			case status.Step == "RetrievePayload":
 				if len(reason) == 0 {
 					reason = "DownloadingUpdate"

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -2,6 +2,7 @@ package cvo
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -70,7 +71,7 @@ func Test_statusWrapper_Report(t *testing.T) {
 					if !ok {
 						t.Fatalf("no event")
 					}
-					if evt != tt.next {
+					if !reflect.DeepEqual(evt, tt.next) {
 						t.Fatalf("unexpected: %#v", evt)
 					}
 				}

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -51,6 +51,15 @@ func (st *Task) String() string {
 	return fmt.Sprintf("%s \"%s/%s\" (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), ns, st.Manifest.Object().GetName(), st.Index, st.Total)
 }
 
+// KindName returns the kind, namespace (if set), and name of the task.
+func (st *Task) KindName() string {
+	ns := st.Manifest.Object().GetNamespace()
+	if len(ns) == 0 {
+		return fmt.Sprintf("%s %s", st.Manifest.GVK.Kind, st.Manifest.Object().GetName())
+	}
+	return fmt.Sprintf("%s %s/%s", st.Manifest.GVK.Kind, ns, st.Manifest.Object().GetName())
+}
+
 // Run attempts to create the provided object until it succeeds or context is cancelled. It returns the
 // last error if context is cancelled.
 func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder, state State) error {


### PR DESCRIPTION
When the CVO reports "98% complete" and similar, that's nice, but it would be useful to [know what it was still working on][1].  For example, this would provide at least a starting point for figuring out what component(s) were blocking an upgrade or install.

The delete-pointer-while-preserving-order lines in `FinishTask()` are from [here][2].

The `reflect.DeepEqual` addition avoids:

```
./sync_worker_test.go:73:13: invalid operation: evt != tt.next (struct containing []*payload.Task cannot be compared)
```

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1691513#c17
[2]: https://github.com/golang/go/wiki/SliceTricks