### PR TITLE
SetOperatorStatusCondition update transition time for existing

### DIFF
--- a/lib/resourcemerge/os.go
+++ b/lib/resourcemerge/os.go
@@ -51,7 +51,7 @@ func SetOperatorStatusCondition(conditions *[]configv1.ClusterOperatorStatusCond
 
 	if existingCondition.Status != newCondition.Status {
 		existingCondition.Status = newCondition.Status
-		existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
 
 	existingCondition.Reason = newCondition.Reason


### PR DESCRIPTION
This commit ensures whenever there are differences between
existing and new status, we update the transition time with
current time.