### PR TITLE
Bug 1670727: install/0000_00_cluster-version-operator_03_deployment: Fix Recreate strategy

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: cluster-version-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       name: cluster-version-operator
@@ -46,7 +48,6 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
-      strategy: Recreate
       tolerations:
         - operator: Exists
       volumes:


### PR DESCRIPTION
I'd added this in 078686d73b (#140), but apparently [got the wrong place][1]:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.0/6412/artifacts/e2e-aws/deployments.json.gz | gunzip | jq '.items[] | select(.metadata.name == "cluster-version-operator").spec.strategy'
{
  "rollingUpdate": {
    "maxSurge": "25%",
    "maxUnavailable": "25%"
  },
  "type": "RollingUpdate"
}
```

I'm not actually sure how I arrived at the previous position.  Anyway, hopefully this commit puts the setting in the right place.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1670727#c14