### PR TITLE
metrics: Report when the CVO is transitioning a payload

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -7,9 +7,10 @@ The cluster version is reported as seconds since the epoch with labels for `vers
 
 * `current` - the version the operator is applying right now (the running CVO version) and the age of the payload
 * `cluster` - the same as current, but the value is the creation timestamp of the cluster version (cluster age)
-* `failure` - if the failure condition is set, reports the last transition time for both desired and current versions.
+* `failure` - if the failure condition is set, reports the last transition time for both desired and current versions
 * `desired` - reported if different from current as the most recent timestamp on the cluster version
-* `completed` - the time the most recent version was completely applied, or is zero.
+* `completed` - the time the most recent version was completely applied, or is zero
+* `updating` - if the operator is moving to a new version, the time the update started
 
 ```
 # HELP cluster_version Reports the version of the cluster.
@@ -19,6 +20,7 @@ cluster_version{image="test/image:1",type="failure",version="4.0.2"} 132000400
 cluster_version{image="test/image:2",type="desired",version="4.0.3"} 132000400
 cluster_version{image="test/image:1",type="completed",version="4.0.2"} 132000100
 cluster_version{image="test/image:1",type="cluster",version="4.0.2"} 131000000
+cluster_version{image="test/image:2",type="updating",version="4.0.3"} 132000400
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge
 cluster_version_available_updates{channel="fast",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -64,7 +64,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
-									{State: configv1.PartialUpdate, CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
+									{State: configv1.PartialUpdate, Version: "0.0.2", Image: "test/image:1", StartedTime: metav1.Time{Time: time.Unix(2, 0)}},
 									{State: configv1.CompletedUpdate, Version: "0.0.1", Image: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
 								},
 							},
@@ -73,12 +73,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 4, map[string]string{"type": "completed", "version": "0.0.1", "image": "test/image:0"})
+				expectMetric(t, metrics[3], 2, map[string]string{"type": "updating", "version": "0.0.2", "image": "test/image:1"})
 			},
 		},
 		{
@@ -105,12 +106,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
+				expectMetric(t, metrics[3], 0, map[string]string{"type": "updating", "version": "", "image": ""})
 			},
 		},
 		{


### PR DESCRIPTION
The current metric for 'desired' cluster_version reports the user's
input. However this metric doesn't discriminate between an invalid
update (where nothing will be happening) and when the operator is
attempting to converge, nor does it report the version number we
read from the release image.

Add a new 'updating' cluster_version type that is returned if and
only if the most recent history entry is in the Partial update state
(i.e., not reconciling), which covers both upgrade and rollback. The
image and version are reported from the history and should be
accurate to the payload's internal version. The value is the start
time in unix seconds of this current version and is a good proxy for
"how long have we been trying to upgrade".

Identified by the analysis team because 'desired' is imprecise.