### PR TITLE
docs/dev/clusteroperator: Fix "it's" -> "its" typo

### DIFF
--- a/docs/dev/clusteroperator.md
+++ b/docs/dev/clusteroperator.md
@@ -124,7 +124,7 @@ If this is false, it means the operator is not trying to apply any new state.
 If it remains true for an extended period of time, it suggests something is wrong in the cluster.  It can probably wait until Monday.
 * `Available` must be true if the operand is functional and available in the cluster at the level in status.
 If this is false, it means there is an outage.  Someone is probably getting paged.
-* `Failing` should be true if the operator has encountered an error that is preventing it or it's operand from working properly.
+* `Failing` should be true if the operator has encountered an error that is preventing it or its operand from working properly.
 The operand may still be available, but intent may not have been fulfilled.
 If this is true, it means that the operand is at risk of an outage or improper configuration.  It can probably wait until the morning, but someone needs to look at it.
 


### PR DESCRIPTION
We want the possessive her, not the "it is" contraction.