### PR TITLE
pkg/cincinnati: Soften unknown-version message

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -90,7 +90,7 @@ func (c Client) GetUpdates(upstream string, channel string, version semver.Versi
 		}
 	}
 	if !found {
-		return nil, fmt.Errorf("unknown version %s", version)
+		return nil, fmt.Errorf("currently installed version %s not found in the %q channel", version, channel)
 	}
 
 	// Find the children of the current version.

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -47,7 +47,7 @@ func TestGetUpdates(t *testing.T) {
 		name:          "unknown version",
 		version:       "4.0.0-3",
 		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
-		err:           "unknown version 4.0.0-3",
+		err:           "currently installed version 4.0.0-3 not found in the \"test-channel\" channel",
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Maybe having the current version not in the desired channel's graph is a problem, but maybe you know what you're doing.  And Cincinnati might *know* about your version, and just consider it to be outside your
channel, in which case the solution may be "switch channels" and not "switch versions".  This change hopefully makes it a bit easier for an admin in this condition to figure out the appropriate next step for their cluster.

CC @smarterclayton, @steveeJ