### PR TITLE
docs: Fix example to match https://github.com/openshift/api/pull/153

### DIFF
--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -8,7 +8,7 @@ This object is used by the administrator to declare their target cluster state, 
 You can extract the current update image from the `ClusterVersion` object:
 
 ```console
-$ oc get clusterversion -o jsonpath='{.status.current.image}{"\n"}' version
+$ oc get clusterversion -o jsonpath='{.status.desired.image}{"\n"}' version
 registry.svc.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833
 ```
 


### PR DESCRIPTION
Fixing example command that extracts the current update image from the
ClusterVersion object to match chnages to the api <https://github.com/openshift/api/pull/153>