### PR TITLE
pkg/payload/task: Include the Nested error in UpdateError.Error()

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -2488,7 +2488,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
-				{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadFailed", Message: "Could not update test \"file-yml\" (3 of 3)"},
+				{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadFailed", Message: "Could not update test \"file-yml\" (3 of 3): unable to proceed"},
 				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadFailed", Message: "Error while reconciling 1.0.0-abc: the update could not be applied"},
 				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 			},

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -858,9 +858,9 @@ func summarizeTaskGraphErrors(errs []error) error {
 		for _, err := range errs {
 			if uErr, ok := err.(*payload.UpdateError); ok {
 				if uErr.Task != nil {
-					klog.Infof("Update error %d of %d: %s %s (%T: %v)", uErr.Task.Index, uErr.Task.Total, uErr.Reason, uErr.Message, uErr.Nested, uErr.Nested)
+					klog.Infof("Update error %d/%d: %s %s", uErr.Task.Index, uErr.Task.Total, uErr.Reason, uErr)
 				} else {
-					klog.Infof("Update error: %s %s (%T: %v)", uErr.Reason, uErr.Message, uErr.Nested, uErr.Nested)
+					klog.Infof("Update error: %s %s", uErr.Reason, uErr)
 				}
 			} else {
 				klog.Infof("Update error: %T: %v", err, err)

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -123,6 +123,9 @@ type UpdateError struct {
 }
 
 func (e *UpdateError) Error() string {
+	if e.Nested != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Nested)
+	}
 	return e.Message
 }
 


### PR DESCRIPTION
For example, this would get the underlying reason logged, vs. our current behavior where we don't share this information, even [in our own logs][1]:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/pr-logs/pull/operator-framework_operator-marketplace/151/pull-ci-operator-framework-operator-marketplace-master-e2e-aws/777/artifacts/e2e-aws/pods/openshift-cluster-version_cluster-version-operator-bd6c56bbf-7khsr_cluster-version-operator.log.gz | gunzip
...
E0418 15:45:40.228571       1 task.go:77] error running apply for clusteroperator "network" (39 of 332): Cluster operator network has not yet reported success
...
```

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1701352#c3