### PR TITLE
start: Initialize the payload and fail if it can't be read at startup

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -109,7 +109,12 @@ func (o *Options) Run() error {
 	if err != nil {
 		return err
 	}
+
+	// initilialize the controllers and attempt to load the payload information
 	controllerCtx := o.NewControllerContext(cb)
+	if err := controllerCtx.CVO.InitializeFromPayload(); err != nil {
+		return err
+	}
 
 	// TODO: Kube 1.14 will contain a ReleaseOnCancel boolean on
 	//   LeaderElectionConfig that allows us to have the lock code

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -657,6 +657,9 @@ metadata:
 	options.PayloadOverride = payloadDir
 	options.EnableMetrics = false
 	controllers := options.NewControllerContext(cb)
+	if err := controllers.CVO.InitializeFromPayload(); err != nil {
+		t.Fatal(err)
+	}
 
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}).(*cvo.SyncWorker)
 	controllers.CVO.SetSyncWorkerForTesting(worker)


### PR DESCRIPTION
Avoid the possibility of a bad release image being created that can't
correctly read the payload by failing hard on startup if the payload is
invalid.