### PR TITLE
Bug 1702087: install/0000_00_cluster-version-operator_01_clusteroperator.crd: Failing -> Degraded

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -16,9 +16,9 @@ spec:
     description: Whether the operator is processing changes.
     name: Progressing
     type: string
-  - JSONPath: .status.conditions[?(@.type=="Failing")].status
-    description: Whether the operator is failing changes.
-    name: Failing
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: Whether the operator is degraded.
+    name: Degraded
     type: string
   - JSONPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
     description: The time the operator's Available status last changed.


### PR DESCRIPTION
[Fix][1]:

```console
$ oc get clusteroperators kube-apiserver
NAME             VERSION                             AVAILABLE   PROGRESSING   FAILING   SINCE
kube-apiserver   4.1.0-0.nightly-2019-04-22-005054   True        False                   20m
```

when the ClusterOperator only sets `Degraded`.  This should have happened in 94c4e576d1 (#165).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1702087