### PR TITLE
Preserve up to 50 version history entries

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -110,7 +110,8 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 		}
 	}
 
-	pruneStatusHistory(config, 10)
+	// TODO: prune Z versions over transitions to Y versions, keep initial installed version
+	pruneStatusHistory(config, 50)
 
 	config.Status.Desired = desired
 }


### PR DESCRIPTION
A future change will perform selective pruning and preserve the initial
version of the code.

@wking to get us out the door, as discussed.