### PR TITLE
cvo: Verified true boolean not written to cv.status.history during update

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -132,7 +132,7 @@ func (o *Options) Run() error {
 
 		// exit after 2s no matter what
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(5 * time.Second):
 			glog.Fatalf("Exiting")
 		case <-ch:
 			glog.Fatalf("Received shutdown signal twice, exiting")


### PR DESCRIPTION
When we upgrade the CVO causes itself to reboot by updating the
deployment. The CVO gets signalled with SIGTERM and then releases
the leader lease. However, there is no guarantee the latest status
of the CVO has been flushed to the cluster version object which
can mean the "verified: true" flag that the sync worker calculates
when it retrieves the payload doesn't get written. The new CVO pod
loads from the payload and so doesn't have the verified flag.

While in the future we may want to completely decouple verification
from payload retrieval (background worker that verifies available
updates as well as checks historical records), for now we need to
ensure the loaded state is persisted to the CV. Since there may be
useful human information available about the payload that a failed
new CVO pod might not get a chance to write, alter the CVO sync
loop to perform one final status sync during shutdown, and increase
the amount of time we wait before hard shutdown to 5s to give it
more room to happen.