### PR TITLE
Update version-patch.yaml in clusterversion.md

### DIFF
--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -50,15 +50,32 @@ kind: DaemonSet
 metadata:
   name: cluster-network-operator
   namespace: openshift-cluster-network-operator
-$ cat <<EOF >version-patch.yaml
-> - op: add
->   path: /spec/overrides/-
->   value:
->     kind: DaemonSet
->     name: cluster-network-operator
->     namespace: openshift-cluster-network-operator
->     unmanaged: true
-> EOF
+```
+If there are currently no other overrides configured:
+```console
+$ cat <<EOF >version-patch-first-override.yaml
+- op: add
+  path: /spec/overrides
+  value:
+  - kind: DaemonSet
+    name: cluster-network-operator
+    namespace: openshift-cluster-network-operator
+    unmanaged: true
+EOF
+```
+To add to list of already existing overrides:
+```console
+$ cat <<EOF >version-patch-add-override.yaml
+- op: add
+  path: /spec/overrides/-
+  value:
+    kind: DaemonSet
+    name: cluster-network-operator
+    namespace: openshift-cluster-network-operator
+    unmanaged: true
+EOF
+```
+```console
 $ oc patch clusterversion version --type json -p "$(cat version-patch.yaml)"
 ```
 


### PR DESCRIPTION
Now that we have no default overrides, the version-patch has to add the
overrides field.  According to patch docs (that I found http://jsonpatch.com/#add) the Add Op
1) If the path includes an array index, the new value is added to the entity at the specified index
2) If the path doesn't exist, a new member is created
3) If the path does exist, the value is replaced

~This worked for me~ Nope a second add squashed my first... 
Now that I've opened, I'm holding until I fix that ^^ 
