### PR TITLE
Bug 1706202: Use klog directly or no line info is printed

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -3,7 +3,7 @@ package resourcebuilder
 import (
 	"context"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
@@ -61,7 +61,7 @@ func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiex
 			return false, err
 		}
 		if err != nil {
-			glog.Errorf("error getting CustomResourceDefinition %s: %v", crd.Name, err)
+			klog.Errorf("error getting CustomResourceDefinition %s: %v", crd.Name, err)
 			return false, nil
 		}
 
@@ -70,7 +70,7 @@ func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiex
 				return true, nil
 			}
 		}
-		glog.V(4).Infof("CustomResourceDefinition %s is not ready. conditions: %v", c.Name, c.Status.Conditions)
+		klog.V(4).Infof("CustomResourceDefinition %s is not ready. conditions: %v", c.Name, c.Status.Conditions)
 		return false, nil
 	}, ctx.Done())
 }

--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
@@ -63,7 +63,7 @@ func waitForDeploymentCompletion(ctx context.Context, client appsclientv1.Deploy
 		if err != nil {
 			// Do not return error here, as we could be updating the API Server itself, in which case we
 			// want to continue waiting.
-			glog.Errorf("error getting Deployment %s during rollout: %v", deployment.Name, err)
+			klog.Errorf("error getting Deployment %s during rollout: %v", deployment.Name, err)
 			return false, nil
 		}
 
@@ -74,7 +74,7 @@ func waitForDeploymentCompletion(ctx context.Context, client appsclientv1.Deploy
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedReplicas == d.Status.Replicas && d.Status.UnavailableReplicas == 0 {
 			return true, nil
 		}
-		glog.V(4).Infof("Deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
+		klog.V(4).Infof("Deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
 		return false, nil
 	}, ctx.Done())
 }
@@ -126,7 +126,7 @@ func waitForDaemonsetRollout(ctx context.Context, client appsclientv1.DaemonSets
 		if err != nil {
 			// Do not return error here, as we could be updating the API Server itself, in which case we
 			// want to continue waiting.
-			glog.Errorf("error getting Daemonset %s during rollout: %v", daemonset.Name, err)
+			klog.Errorf("error getting Daemonset %s during rollout: %v", daemonset.Name, err)
 			return false, nil
 		}
 
@@ -137,7 +137,7 @@ func waitForDaemonsetRollout(ctx context.Context, client appsclientv1.DaemonSets
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedNumberScheduled == d.Status.DesiredNumberScheduled && d.Status.NumberUnavailable == 0 {
 			return true, nil
 		}
-		glog.V(4).Infof("Daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberAvailable)
+		klog.V(4).Infof("Daemonset %s is not ready. status: (desired: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberReady, d.Status.NumberAvailable)
 		return false, nil
 	}, ctx.Done())
 }

--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
@@ -58,7 +58,7 @@ func WaitForJobCompletion(ctx context.Context, client batchclientv1.JobsGetter, 
 	return wait.PollImmediateUntil(defaultObjectPollInterval, func() (bool, error) {
 		j, err := client.Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
 		if err != nil {
-			glog.Errorf("error getting Job %s: %v", job.Name, err)
+			klog.Errorf("error getting Job %s: %v", job.Name, err)
 			return false, nil
 		}
 

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	_ "github.com/golang/glog" // integration tests set glog flags.
+	_ "k8s.io/klog" // integration tests set glog flags.
 	"github.com/google/uuid"
 )
 

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,7 +32,7 @@ func (optr *Operator) syncAvailableUpdates(config *configv1.ClusterVersion) erro
 	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
 	u := optr.getAvailableUpdates()
 	if u != nil && u.Upstream == upstream && u.Channel == channel && u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
-		glog.V(4).Infof("Available updates were recently retrieved, will try later.")
+		klog.V(4).Infof("Available updates were recently retrieved, will try later.")
 		return nil
 	}
 
@@ -127,7 +127,7 @@ func calculateAvailableUpdatesStatus(clusterID, upstream, channel, version strin
 
 	currentVersion, err := semver.Parse(version)
 	if err != nil {
-		glog.V(2).Infof("Unable to parse current semantic version %q: %v", version, err)
+		klog.V(2).Infof("Unable to parse current semantic version %q: %v", version, err)
 		return nil, configv1.ClusterOperatorStatusCondition{
 			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "InvalidCurrentVersion",
 			Message: "The current cluster version is not a valid semantic version and cannot be used to calculate upgrades.",
@@ -136,7 +136,7 @@ func calculateAvailableUpdatesStatus(clusterID, upstream, channel, version strin
 
 	updates, err := checkForUpdate(clusterID, upstream, channel, currentVersion)
 	if err != nil {
-		glog.V(2).Infof("Upstream server %s could not return available updates: %v", upstream, err)
+		klog.V(2).Infof("Upstream server %s could not return available updates: %v", upstream, err)
 		return nil, configv1.ClusterOperatorStatusCondition{
 			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed",
 			Message: fmt.Sprintf("Unable to retrieve available updates: %v", err),

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/google/uuid"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -2471,7 +2471,7 @@ func fakeClientsetWithUpdates(obj *configv1.ClusterVersion) *fake.Clientset {
 			obj.Status = update.Status
 			rv, _ := strconv.Atoi(update.ResourceVersion)
 			obj.ResourceVersion = strconv.Itoa(rv + 1)
-			glog.V(5).Infof("updated object to %#v", obj)
+			klog.V(5).Infof("updated object to %#v", obj)
 			return true, obj.DeepCopy(), nil
 		}
 		return false, nil, fmt.Errorf("unrecognized")

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +51,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 	}
 
 	if len(config.Status.History) == 0 {
-		glog.V(5).Infof("initialize new history completed=%t desired=%#v", completed, desired)
+		klog.V(5).Infof("initialize new history completed=%t desired=%#v", completed, desired)
 		config.Status.History = append(config.Status.History, configv1.UpdateHistory{
 			Version: desired.Version,
 			Image:   desired.Image,
@@ -68,7 +68,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 	}
 
 	if mergeEqualVersions(last, desired) {
-		glog.V(5).Infof("merge into existing history completed=%t desired=%#v last=%#v", completed, desired, last)
+		klog.V(5).Infof("merge into existing history completed=%t desired=%#v last=%#v", completed, desired, last)
 		if completed {
 			last.State = configv1.CompletedUpdate
 			if last.CompletionTime == nil {
@@ -76,7 +76,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 			}
 		}
 	} else {
-		glog.V(5).Infof("must add a new history entry completed=%t desired=%#v != last=%#v", completed, desired, last)
+		klog.V(5).Infof("must add a new history entry completed=%t desired=%#v != last=%#v", completed, desired, last)
 		last.CompletionTime = &now
 		if completed {
 			config.Status.History = append([]configv1.UpdateHistory{
@@ -103,7 +103,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 	}
 
 	// leave this here in case we find other future history bugs and need to debug it
-	if glog.V(5) && len(config.Status.History) > 1 {
+	if klog.V(5) && len(config.Status.History) > 1 {
 		if config.Status.History[0].Image == config.Status.History[1].Image && config.Status.History[0].Version == config.Status.History[1].Version {
 			data, _ := json.MarshalIndent(config.Status.History, "", "  ")
 			panic(fmt.Errorf("tried to update cluster version history to contain duplicate image entries: %s", string(data)))
@@ -146,7 +146,7 @@ const ClusterVersionInvalid configv1.ClusterStatusConditionType = "Invalid"
 // syncStatus calculates the new status of the ClusterVersion based on the current sync state and any
 // validation errors found. We allow the caller to pass the original object to avoid DeepCopying twice.
 func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, status *SyncWorkerStatus, validationErrs field.ErrorList) error {
-	glog.V(5).Infof("Synchronizing errs=%#v status=%#v", validationErrs, status)
+	klog.V(5).Infof("Synchronizing errs=%#v status=%#v", validationErrs, status)
 
 	// update the config with the latest available updates
 	if updated := optr.getAvailableUpdates().NeedsUpdate(config); updated != nil {
@@ -304,8 +304,8 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 		})
 	}
 
-	if glog.V(6) {
-		glog.Infof("Apply config: %s", diff.ObjectReflectDiff(original, config))
+	if klog.V(6) {
+		klog.Infof("Apply config: %s", diff.ObjectReflectDiff(original, config))
 	}
 	updated, err := applyClusterVersionStatus(optr.client.ConfigV1(), config, original)
 	optr.rememberLastUpdate(updated)

--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
@@ -93,7 +93,7 @@ func (r *payloadRetriever) RetrievePayload(ctx context.Context, update configv1.
 		if !update.Force {
 			return PayloadInfo{}, vErr
 		}
-		glog.Warningf("An image was retrieved from %q that failed verification: %v", update.Image, vErr)
+		klog.Warningf("An image was retrieved from %q that failed verification: %v", update.Image, vErr)
 		info.VerificationError = vErr
 	} else {
 		info.Verified = true

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -207,7 +207,7 @@ type payloadTasks struct {
 }
 
 func loadUpdatePayloadMetadata(dir, releaseImage string) (*Update, []payloadTasks, error) {
-	glog.V(4).Infof("Loading updatepayload from %q", dir)
+	klog.V(4).Infof("Loading updatepayload from %q", dir)
 	if err := ValidateDirectory(dir); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
 
@@ -107,7 +107,7 @@ func LoadFromPayload(update *payload.Update) (Interface, error) {
 				}
 				stores = append(stores, u)
 			default:
-				glog.Warningf("An unexpected key was found in %s and will be ignored (expected store-* or verifier-public-key-*): %s", src, k)
+				klog.Warningf("An unexpected key was found in %s and will be ignored (expected store-* or verifier-public-key-*): %s", src, k)
 			}
 		}
 		if len(stores) == 0 {
@@ -231,11 +231,11 @@ func (v *releaseVerifier) Verify(ctx context.Context, releaseDigest string) erro
 		for k, keyring := range remaining {
 			content, _, err := verifySignatureWithKeyring(bytes.NewReader(signature), keyring)
 			if err != nil {
-				glog.V(4).Infof("keyring %q could not verify signature: %v", k, err)
+				klog.V(4).Infof("keyring %q could not verify signature: %v", k, err)
 				continue
 			}
 			if err := verifyAtomicContainerSignature(content, releaseDigest); err != nil {
-				glog.V(4).Infof("signature %q is not valid: %v", path, err)
+				klog.V(4).Infof("signature %q is not valid: %v", path, err)
 				continue
 			}
 			delete(remaining, k)
@@ -265,9 +265,9 @@ func (v *releaseVerifier) Verify(ctx context.Context, releaseDigest string) erro
 	}
 
 	if len(remaining) > 0 {
-		if glog.V(4) {
+		if klog.V(4) {
 			for k := range remaining {
-				glog.Infof("Unable to verify %s against keyring %s", releaseDigest, k)
+				klog.Infof("Unable to verify %s against keyring %s", releaseDigest, k)
 			}
 		}
 		return fmt.Errorf("unable to locate a valid signature for one or more sources")
@@ -291,7 +291,7 @@ func checkFileSignatures(ctx context.Context, dir string, maxSignaturesToCheck i
 			break
 		}
 		if err != nil {
-			glog.V(4).Infof("unable to load signature: %v", err)
+			klog.V(4).Infof("unable to load signature: %v", err)
 			continue
 		}
 		ok, err := fn(path, data)
@@ -329,7 +329,7 @@ func checkHTTPSignatures(ctx context.Context, client *http.Client, u url.URL, ma
 		// load the body, being careful not to allow unbounded reads
 		resp, err := client.Do(req)
 		if err != nil {
-			glog.V(4).Infof("unable to load signature: %v", err)
+			klog.V(4).Infof("unable to load signature: %v", err)
 			continue
 		}
 		data, err := func() ([]byte, error) {
@@ -347,7 +347,7 @@ func checkHTTPSignatures(ctx context.Context, client *http.Client, u url.URL, ma
 			}
 			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 				if i == 1 {
-					glog.V(4).Infof("Could not find signature at store location %v", sigURL)
+					klog.V(4).Infof("Could not find signature at store location %v", sigURL)
 				}
 				return nil, fmt.Errorf("unable to retrieve signature from %v: %d", sigURL, resp.StatusCode)
 			}
@@ -358,7 +358,7 @@ func checkHTTPSignatures(ctx context.Context, client *http.Client, u url.URL, ma
 			break
 		}
 		if err != nil {
-			glog.V(4).Info(err)
+			klog.V(4).Info(err)
 			continue
 		}
 		if len(data) == 0 {


### PR DESCRIPTION
The glog wrapper of klog has a fatal flaw - it doesn't print the
correct line number of a message. This makes debugging almost impossible
in high level debug.

Fix this by using the method directly.