### PR TITLE
Bug 1825003: pkg/payload/task: Include name/reason in "unknown error" message

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -222,5 +222,9 @@ func SummaryForReason(reason, name string) string {
 	if strings.HasPrefix(reason, "UpdatePayload") {
 		return "the update could not be applied"
 	}
-	return "an unknown error has occurred"
+
+	if len(name) > 0 {
+		return fmt.Sprintf("%s has an unknown error: %s", name, reason)
+	}
+	return fmt.Sprintf("an unknown error has occurred: %s", reason)
 }


### PR DESCRIPTION
Because this makes it easier to grow the `SummaryForReason` logic.  The previous, generic error message is not very useful (e.g. as seen [here][1]).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1710012#c0