### PR TITLE
ClusterVersion version column should be last completed

### DIFF
--- a/install/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/install/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -18,7 +18,7 @@ spec:
   additionalPrinterColumns:
   - name: Version
     type: string
-    JSONPath: .status.desired.version
+    JSONPath: .status.history[?(@.state=="Completed")].version
   - name: Available
     type: string
     JSONPath: .status.conditions[?(@.type=="Available")].status


### PR DESCRIPTION
Use history instead of desired version in the custom columns, since desired state can be set to empty when a user provides invalid input.  The first "Completed" entry in history is our "current" version - if
one doesn't exist, we have "no version".

Reproducer:

1. `oc adm upgrade --to-image=X` (triggering signature verification error)
2. `oc get clusterversion` has an empty VERSION column