### PR TITLE
status: Simplify operator not available status

### DIFF
--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -83,9 +83,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: missing version information for operand-1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: missing version information for operand-1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {
@@ -109,9 +109,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: missing version information for operand-1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: missing version information for operand-1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {
@@ -137,9 +137,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: upgrading operand-1 from v0 to v1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: upgrading operand-1 from v0 to v1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {
@@ -165,9 +165,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: upgrading operand-1 from v0 to v1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: upgrading operand-1 from v0 to v1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {
@@ -197,9 +197,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: upgrading operand-1 from v0 to v1, upgrading operand-2 from v0 to v1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: upgrading operand-1 from v0 to v1, upgrading operand-2 from v0 to v1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {
@@ -229,9 +229,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is still updating: upgrading operand-2 from v0 to v1"),
+			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co is still updating: upgrading operand-2 from v0 to v1",
+			Message: "Cluster operator test-co is still updating",
 			Name:    "test-co",
 		},
 	}, {


### PR DESCRIPTION
In practice, the output of displaying version operands is redundant and our current use doesn't require it. Since the core output is

"we are going to X, these are the things not there yet"

also showing

"we are going to X, these are the things not there yet A-X,B-X,C-X"

makes it harder to understand what is going on.

Strip all sub version reporting from cluster operators, and in the future we can improve this if we have a use case.

---

Encountered while debugging failure output in upgrades - the key messages are always the actual Degraded conditition, and the extra versions are always variants of the operator version.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/1724/

```
Multiple errors are preventing progress:
* Cluster operator authentication is still updating: upgrading oauth-openshift from 4.2.0-0.ci-2019-05-18-031713_openshift to 4.2.0-0.ci-2019-05-18-224753_openshift
* Cluster operator cluster-autoscaler is still updating
* Cluster operator monitoring is still updating
* Cluster operator openshift-controller-manager is still updating
* Cluster operator service-catalog-controller-manager is still updating
* Could not update deployment "openshift-cloud-credential-operator/cloud-credential-operator" (93 of 350)
...
```

The first message is almost completely wasted space.

/cherrypick release-4.1