### PR TITLE
lib/resourcemerge/core: Fix setInt32Ptr for "both nil" case

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -473,6 +473,9 @@ func setInt32(modified *bool, existing *int32, required int32) {
 }
 
 func setInt32Ptr(modified *bool, existing **int32, required *int32) {
+	if *existing == nil && required == nil {
+		return
+	}
 	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -1,0 +1,41 @@
+package resourcemerge
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/pointer"
+)
+
+func TestEnsurePodSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing corev1.PodSpec
+		input    corev1.PodSpec
+
+		expectedModified bool
+		expected         corev1.PodSpec
+	}{{
+		name:     "empty inputs",
+		existing: corev1.PodSpec{},
+		input:    corev1.PodSpec{},
+
+		expectedModified: false,
+		expected:         corev1.PodSpec{},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modified := pointer.BoolPtr(false)
+			ensurePodSpec(modified, &test.existing, test.input)
+			if *modified != test.expectedModified {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
+			}
+
+			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
+				t.Errorf("mismatch PodSpec got: %v want: %v", test.existing, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Don't set `modified` if both `*existing` and `required` are `nil`.  Also add unit tests which cover this indirectly.