### PR TITLE
metrics: Omit `cluster_version{type="completed"}` when not available

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -9,7 +9,7 @@ The cluster version is reported as seconds since the epoch with labels for `vers
 * `cluster` - the same as current, but the value is the creation timestamp of the cluster version (cluster age)
 * `failure` - if the failure condition is set, reports the last transition time for both desired and current versions
 * `desired` - reported if different from current as the most recent timestamp on the cluster version
-* `completed` - the time the most recent version was completely applied, or is zero
+* `completed` - the time the most recent version was completely applied, or absent if not reached
 * `updating` - if the operator is moving to a new version, the time the update started
 
 ```

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -106,13 +106,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "updating", "version": "", "image": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "updating", "version": "", "image": ""})
 			},
 		},
 		{
@@ -201,13 +200,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 2, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[2], 2, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -231,13 +229,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 0, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -266,13 +263,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -302,7 +298,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 6 {
+				if len(metrics) != 5 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 6, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
@@ -310,7 +306,6 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
 				expectMetric(t, metrics[3], 4, map[string]string{"type": "failure", "version": "1.0.0", "image": "test/image:2"})
 				expectMetric(t, metrics[4], 4, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[5], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -336,13 +331,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 0, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 	}


### PR DESCRIPTION
The cluster_version completed type was inconsistent with other types in that it was always included but the version label was unset when no completed update had been applied. Instead, only include the series when a completed update has been applied.

Discovered while building dashboards for metrics - the `completed` and `updating` metrics are similar in usage (tell me when updating, tell me when completed) and so this makes them consistent.