### PR TITLE
metrics: Give all cluster_version types a `from_version` label

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -9,7 +9,7 @@ The cluster version is reported as seconds since the epoch with labels for `vers
 * `cluster` - the same as current, but the value is the creation timestamp of the cluster version (cluster age)
 * `failure` - if the failure condition is set, reports the last transition time for both desired and current versions
 * `desired` - reported if different from current as the most recent timestamp on the cluster version
-* `completed` - the time the most recent version was completely applied, or is zero
+* `completed` - the time the most recent version was completely applied, or absent if not reached
 * `updating` - if the operator is moving to a new version, the time the update started
 
 ```

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -6,11 +6,14 @@ The cluster version is reported as seconds since the epoch with labels for `vers
 `image`. The `type` label reports which value is reported:
 
 * `current` - the version the operator is applying right now (the running CVO version) and the age of the payload
-* `cluster` - the same as current, but the value is the creation timestamp of the cluster version (cluster age)
+* `cluster` - the initial version of the cluster, and value is the creation timestamp of the cluster version (cluster age)
 * `failure` - if the failure condition is set, reports the last transition time for both desired and current versions
 * `desired` - reported if different from current as the most recent timestamp on the cluster version
 * `completed` - the time the most recent version was completely applied, or absent if not reached
 * `updating` - if the operator is moving to a new version, the time the update started
+
+The `from_version` label is set where appropriate and is the previous completed version for the provided `type`. Empty for
+`cluster`, and otherwise empty if there was no previous completed version (still installing).
 
 ```
 # HELP cluster_version Reports the version of the cluster.
@@ -19,7 +22,7 @@ cluster_version{image="test/image:1",type="current",version="4.0.2"} 130000000
 cluster_version{image="test/image:1",type="failure",version="4.0.2"} 132000400
 cluster_version{image="test/image:2",type="desired",version="4.0.3"} 132000400
 cluster_version{image="test/image:1",type="completed",version="4.0.2"} 132000100
-cluster_version{image="test/image:1",type="cluster",version="4.0.2"} 131000000
+cluster_version{image="test/image:0",type="cluster",version="4.0.1"} 131000000
 cluster_version{image="test/image:2",type="updating",version="4.0.3"} 132000400
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -106,13 +106,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "updating", "version": "", "image": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "updating", "version": "", "image": ""})
 			},
 		},
 		{
@@ -201,13 +200,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 2, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[2], 2, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -231,13 +229,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": ""})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "", "image": ""})
-				expectMetric(t, metrics[2], 0, map[string]string{"type": "completed", "version": "", "image": ""})
-				expectMetric(t, metrics[3], 0, map[string]string{"upstream": "<default>", "channel": ""})
+				expectMetric(t, metrics[2], 0, map[string]string{"upstream": "<default>", "channel": ""})
 			},
 		},
 		{
@@ -266,13 +263,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -302,7 +298,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 6 {
+				if len(metrics) != 5 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 6, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
@@ -310,7 +306,6 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2"})
 				expectMetric(t, metrics[3], 4, map[string]string{"type": "failure", "version": "1.0.0", "image": "test/image:2"})
 				expectMetric(t, metrics[4], 4, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[5], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 		{
@@ -336,13 +331,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1"})
 				expectMetric(t, metrics[2], 0, map[string]string{"type": "failure", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[3], 0, map[string]string{"type": "completed", "version": "", "image": ""})
 			},
 		},
 	}


### PR DESCRIPTION
The `updating` type is hard to join in PromQL. Instead, report a label for
each type that is the previous completed version. Also change the `cluster`
type to return the original version of the cluster (first history entry).

This answers the following questions:

"what stable version is this cluster updating from"
"what was the first version recorded for this cluster"

Intended to fix bug 1720308 in 4.1