### PR TITLE
pkg/cvo: Standardize "%d/%d" -> "%d of %d"

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -676,7 +676,7 @@ func (r *consistentReporter) Errors(errs []error) error {
 func (r *consistentReporter) CancelError() error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	return errCanceled{fmt.Errorf("update was cancelled at %d/%d", r.done, r.total)}
+	return errCanceled{fmt.Errorf("update was cancelled at %d of %d", r.done, r.total)}
 }
 
 func (r *consistentReporter) Complete() {
@@ -737,7 +737,7 @@ func summarizeTaskGraphErrors(errs []error) error {
 		for _, err := range errs {
 			if uErr, ok := err.(*payload.UpdateError); ok {
 				if uErr.Task != nil {
-					klog.Infof("Update error %d/%d: %s %s (%T: %v)", uErr.Task.Index, uErr.Task.Total, uErr.Reason, uErr.Message, uErr.Nested, uErr.Nested)
+					klog.Infof("Update error %d of %d: %s %s (%T: %v)", uErr.Task.Index, uErr.Task.Total, uErr.Reason, uErr.Message, uErr.Nested, uErr.Nested)
 				} else {
 					klog.Infof("Update error: %s %s (%T: %v)", uErr.Reason, uErr.Message, uErr.Nested, uErr.Nested)
 				}


### PR DESCRIPTION
Make it easier to grep for a problem-asset in the logs.  Currently:

```console
$ curl -s --compressed https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/178/pull-ci-openshift-cluster-version-operator-master-e2e-aws-upgrade/134/artifacts/e2e-aws-upgrade/must-gather/namespaces/openshift-cluster-version/pods/cluster-version-operator-7cb5846b6b-ljbd5/cluster-version-operator/cluster-version-operator/logs/current.log | grep kube-apiserver | grep '48.*381' | head -n6
2019-06-13T14:35:28.248884894Z I0613 14:35:28.248875       1 sync_worker.go:574] Running sync for namespace "openshift-kube-apiserver-operator" (40 of 381)
2019-06-13T14:35:28.448511089Z I0613 14:35:28.448453       1 sync_worker.go:587] Done syncing for service "openshift-kube-apiserver-operator/metrics" (43 of 381)
2019-06-13T14:35:28.448511089Z I0613 14:35:28.448486       1 sync_worker.go:574] Running sync for configmap "openshift-kube-apiserver-operator/kube-apiserver-operator-config" (44 of 381)
2019-06-13T14:35:28.749442607Z I0613 14:35:28.749427       1 sync_worker.go:574] Running sync for clusteroperator "kube-apiserver" (48 of 381)
2019-06-13T14:42:04.194847868Z E0613 14:42:04.194686       1 task.go:77] error running apply for clusteroperator "kube-apiserver" (48 of 381): Cluster operator kube-apiserver is still updating
2019-06-13T14:42:04.194933181Z I0613 14:42:04.194915       1 sync_worker.go:740] Update error 48/381: ClusterOperatorNotAvailable Cluster operator kube-apiserver is still updating (*errors.errorString: cluster operator kube-apiserver is still updating)
```