### PR TITLE
install: add service monitor manifest

### DIFF
--- a/install/0000_90_cluster-version-operator_00_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_00_servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: cluster-version-operator
+  name: cluster-version-operator
+  namespace: openshift-cluster-version
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - openshift-cluster-version
+  selector:
+    matchLabels:
+      k8s-app: cluster-version-operator


### PR DESCRIPTION
Since each team should own their monitoring configuration we are removing ServiceMonitor manifests from cluster-monitoring-operator.

Related to https://github.com/openshift/cluster-monitoring-operator/pull/390

/cc @brancz @smarterclayton 