### PR TITLE
Fix remove containers logic

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -62,8 +62,8 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {
-	var existingCurr *corev1.Container
 	for i, existingContainer := range *existing {
+		var existingCurr *corev1.Container
 		for _, requiredContainer := range required {
 			if existingContainer.Name == requiredContainer.Name {
 				existingCurr = &(*existing)[i]

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -30,11 +30,16 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "remove regular containers from existing",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
+					corev1.Container{Name: "test"},
+					corev1.Container{Name: "to-be-removed"}}},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
 					corev1.Container{Name: "test"}}},
-			input: corev1.PodSpec{},
 
 			expectedModified: true,
-			expected:         corev1.PodSpec{},
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test"}}},
 		},
 		{
 			name: "remove regular and init containers from existing",


### PR DESCRIPTION
Existing logic does fails to reset the pointer to `nil`. Fixed this by declaring pointer variable at appropriate location.
Plus modified unit tests to cover this scenario.