### PR TITLE
Add http transport for cincinnati to enable proxy

### DIFF
--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	_ "k8s.io/klog" // integration tests set glog flags.
 	"github.com/google/uuid"
+	_ "k8s.io/klog" // integration tests set glog flags.
 )
 
 func TestGetUpdates(t *testing.T) {
@@ -120,8 +120,9 @@ func TestGetUpdates(t *testing.T) {
 
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
+			var proxyURL *url.URL
 
-			c := NewClient(clientID)
+			c := NewClient(clientID, proxyURL)
 
 			updates, err := c.GetUpdates(ts.URL, channelName, semver.MustParse(test.version))
 			if test.err == "" {

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -10,8 +10,8 @@ import (
 	"github.com/openshift/cluster-version-operator/pkg/verify"
 
 	"github.com/blang/semver"
-	"k8s.io/klog"
 	"github.com/google/uuid"
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -101,6 +101,7 @@ type Operator struct {
 
 	cvLister    configlistersv1.ClusterVersionLister
 	coLister    configlistersv1.ClusterOperatorLister
+	proxyLister configlistersv1.ProxyLister
 	cacheSynced []cache.InformerSynced
 
 	// queue tracks applying updates to a cluster.
@@ -135,6 +136,7 @@ func New(
 	minimumInterval time.Duration,
 	cvInformer configinformersv1.ClusterVersionInformer,
 	coInformer configinformersv1.ClusterOperatorInformer,
+	proxyInformer configinformersv1.ProxyInformer,
 	client clientset.Interface,
 	kubeClient kubernetes.Interface,
 	enableMetrics bool,
@@ -161,6 +163,9 @@ func New(
 		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterversion"),
 		availableUpdatesQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "availableupdates"),
 	}
+
+	optr.proxyLister = proxyInformer.Lister()
+	proxyInformer.Informer().AddEventHandler(optr.eventHandler())
 
 	cvInformer.Informer().AddEventHandler(optr.eventHandler())
 

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/klog"
 	"github.com/google/uuid"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
@@ -42,15 +42,35 @@ var (
 	defaultCompletionTime = metav1.Time{Time: time.Unix(2, 0)}
 )
 
+type clientProxyLister struct {
+	client clientset.Interface
+}
+
+func (c *clientProxyLister) Get(name string) (*configv1.Proxy, error) {
+	return c.client.ConfigV1().Proxies().Get(name, metav1.GetOptions{})
+}
+
+func (c *clientProxyLister) List(selector labels.Selector) (ret []*configv1.Proxy, err error) {
+	list, err := c.client.ConfigV1().Proxies().List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	var items []*configv1.Proxy
+	for i := range list.Items {
+		items = append(items, &list.Items[i])
+	}
+	return items, nil
+}
+
 type clientCVLister struct {
 	client clientset.Interface
 }
 
 func (c *clientCVLister) Get(name string) (*configv1.ClusterVersion, error) {
-	return c.client.Config().ClusterVersions().Get(name, metav1.GetOptions{})
+	return c.client.ConfigV1().ClusterVersions().Get(name, metav1.GetOptions{})
 }
 func (c *clientCVLister) List(selector labels.Selector) (ret []*configv1.ClusterVersion, err error) {
-	list, err := c.client.Config().ClusterVersions().List(metav1.ListOptions{LabelSelector: selector.String()})
+	list, err := c.client.ConfigV1().ClusterVersions().List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, err
 	}
@@ -61,15 +81,32 @@ func (c *clientCVLister) List(selector labels.Selector) (ret []*configv1.Cluster
 	return items, nil
 }
 
+type proxyLister struct {
+	Err   error
+	Items []*configv1.Proxy
+}
+
+func (r *proxyLister) List(selector labels.Selector) (ret []*configv1.Proxy, err error) {
+	return r.Items, r.Err
+}
+func (r *proxyLister) Get(name string) (*configv1.Proxy, error) {
+	for _, s := range r.Items {
+		if s.Name == name {
+			return s, nil
+		}
+	}
+	return nil, errors.NewNotFound(schema.GroupResource{}, name)
+}
+
 type clientCOLister struct {
 	client clientset.Interface
 }
 
 func (c *clientCOLister) Get(name string) (*configv1.ClusterOperator, error) {
-	return c.client.Config().ClusterOperators().Get(name, metav1.GetOptions{})
+	return c.client.ConfigV1().ClusterOperators().Get(name, metav1.GetOptions{})
 }
 func (c *clientCOLister) List(selector labels.Selector) (ret []*configv1.ClusterOperator, err error) {
-	list, err := c.client.Config().ClusterOperators().List(metav1.ListOptions{LabelSelector: selector.String()})
+	list, err := c.client.ConfigV1().ClusterOperators().List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, err
 	}
@@ -1959,6 +1996,7 @@ func TestOperator_sync(t *testing.T) {
 			if tt.init != nil {
 				tt.init(optr)
 			}
+			optr.proxyLister = &clientProxyLister{client: optr.client}
 			optr.cvLister = &clientCVLister{client: optr.client}
 			optr.coLister = &clientCOLister{client: optr.client}
 			if optr.configSync == nil {
@@ -2332,6 +2370,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			optr := tt.optr
 			optr.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			optr.proxyLister = &clientProxyLister{client: optr.client}
 			optr.coLister = &clientCOLister{client: optr.client}
 			optr.cvLister = &clientCVLister{client: optr.client}
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -13,9 +13,9 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/klog"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -325,6 +325,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			resyncPeriod(o.ResyncInterval)(),
 			cvInformer.Config().V1().ClusterVersions(),
 			sharedInformers.Config().V1().ClusterOperators(),
+			sharedInformers.Config().V1().Proxies(),
 			cb.ClientOrDie(o.Namespace),
 			cb.KubeClientOrDie(o.Namespace, useProtobuf),
 			o.EnableMetrics,


### PR DESCRIPTION
- Modified Cincinnati client to accept the http transport struct
so that a https proxy can be set
- Created new function getHTTPTransportProxy that
retrieves the proxy config, creates the transport and returns the
transport ptr.