### PR TITLE
payload/render: update the bootstrap render to skip servicemonitor

### DIFF
--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -30,9 +30,12 @@ func Render(outputDir, releaseImage string) error {
 		odir      string
 		skipFiles sets.String
 	}{{
-		idir:      manifestsDir,
-		odir:      oManifestsDir,
-		skipFiles: sets.NewString("image-references"),
+		idir: manifestsDir,
+		odir: oManifestsDir,
+		skipFiles: sets.NewString(
+			"image-references",
+			"0000_90_cluster-version-operator_00_servicemonitor.yaml",
+		),
 	}, {
 		idir:      bootstrapDir,
 		odir:      oBootstrapDir,


### PR DESCRIPTION
the `manifests` directory on the bootstrap is used by the cluster-bootstrap to push to the cluster.
`servicemonitor` for cvo was added by https://github.com/openshift/cluster-version-operator/pull/214
`servicemonitor` api is created by the cluster-monitoring-operator and therefore this causes the bootstrapping to get stuck until we get the monitoring operator running.

This skips the `servicemonitor` in the bootstrap render as it is not required for the bootstrap cvo pod.

/cc @smarterclayton @brancz 