### PR TITLE
Adding support for other archs than amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
-RUN hack/build-go.sh
+RUN hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/cluster-version-operator/_output/linux/amd64/cluster-version-operator /usr/bin/
+COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY bootstrap /bootstrap
 ENTRYPOINT ["/usr/bin/cluster-version-operator"]


### PR DESCRIPTION
This modifies the Dockerfile to add the build support for archs other than amd64, based on the commit: https://github.com/openshift/cluster-version-operator/commit/bd1c181d38016f5f840353cbd7ce45fdce1f546a