### PR TITLE
inject proxy env vars into requesting workload resources

### DIFF
--- a/lib/resourcebuilder/podspec.go
+++ b/lib/resourcebuilder/podspec.go
@@ -1,0 +1,47 @@
+package resourcebuilder
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// updatePodSpecWithProxy mutates the input podspec with proxy env vars for all init containers and containers
+// matching the container names.
+func updatePodSpecWithProxy(podSpec *corev1.PodSpec, containerNames []string, httpProxy, httpsProxy, noProxy string) error {
+	hasProxy := len(httpsProxy) > 0 || len(httpProxy) > 0 || len(noProxy) > 0
+	if !hasProxy {
+		return nil
+	}
+
+	for _, containerName := range containerNames {
+		found := false
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name != containerName {
+				continue
+			}
+			found = true
+
+			podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: httpProxy})
+			podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: httpsProxy})
+			podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, corev1.EnvVar{Name: "NO_PROXY", Value: noProxy})
+		}
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name != containerName {
+				continue
+			}
+			found = true
+
+			podSpec.InitContainers[i].Env = append(podSpec.InitContainers[i].Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: httpProxy})
+			podSpec.InitContainers[i].Env = append(podSpec.InitContainers[i].Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: httpsProxy})
+			podSpec.InitContainers[i].Env = append(podSpec.InitContainers[i].Env, corev1.EnvVar{Name: "NO_PROXY", Value: noProxy})
+		}
+
+		if !found {
+			return fmt.Errorf("requested injection for non-existent container: %q", containerName)
+		}
+	}
+
+	return nil
+
+}

--- a/lib/resourcebuilder/podspec_test.go
+++ b/lib/resourcebuilder/podspec_test.go
@@ -1,0 +1,112 @@
+package resourcebuilder
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestUpdatePodSpecWithProxy(t *testing.T) {
+	tests := []struct {
+		name string
+
+		input                          *corev1.PodSpec
+		containerNames                 []string
+		httpProxy, httpsProxy, noProxy string
+
+		expectedErr string
+		expected    *corev1.PodSpec
+	}{
+		{
+			name: "no proxy info",
+			input: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+					},
+				},
+			},
+			expected: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+					},
+				},
+			},
+		},
+		{
+			name:           "proxy info",
+			containerNames: []string{"foo", "init-foo"},
+			httpsProxy:     "httpsProxy-val",
+			noProxy:        "noProxy-val",
+			input: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init-foo",
+					},
+					{
+						Name: "init-bar",
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				},
+			},
+			expected: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init-foo",
+						Env: []corev1.EnvVar{
+							{Name: "HTTP_PROXY", Value: ""},
+							{Name: "HTTPS_PROXY", Value: "httpsProxy-val"},
+							{Name: "NO_PROXY", Value: "noProxy-val"},
+						},
+					},
+					{
+						Name: "init-bar",
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name: "foo",
+						Env: []corev1.EnvVar{
+							{Name: "HTTP_PROXY", Value: ""},
+							{Name: "HTTPS_PROXY", Value: "httpsProxy-val"},
+							{Name: "NO_PROXY", Value: "noProxy-val"},
+						},
+					},
+					{
+						Name: "bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := updatePodSpecWithProxy(test.input, test.containerNames, test.httpProxy, test.httpsProxy, test.noProxy)
+			switch {
+			case err == nil && len(test.expectedErr) == 0:
+			case err != nil && len(test.expectedErr) == 0:
+				t.Fatal(err)
+			case err == nil && len(test.expectedErr) != 0:
+				t.Fatal(err)
+			case err != nil && len(test.expectedErr) != 0 && err.Error() != test.expectedErr:
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(test.input, test.expected) {
+				t.Error(diff.ObjectDiff(test.input, test.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
set .metadata.annotations["config.openshift.io/inject-proxy"]="container1,initcontainer2"
to inject into specified container names