### PR TITLE
cincinnati: add arch parameter to requests

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -41,7 +41,7 @@ type Update node
 // finding all of the children. These children are the available updates for
 // the current version and their payloads indicate from where the actual update
 // image can be downloaded.
-func (c Client) GetUpdates(upstream string, channel string, version semver.Version) ([]Update, error) {
+func (c Client) GetUpdates(upstream string, arch string, channel string, version semver.Version) ([]Update, error) {
 	transport := http.Transport{}
 	// Prepare parametrized cincinnati query.
 	cincinnatiURL, err := url.Parse(upstream)
@@ -49,6 +49,7 @@ func (c Client) GetUpdates(upstream string, channel string, version semver.Versi
 		return nil, fmt.Errorf("failed to parse upstream URL: %s", err)
 	}
 	queryParams := cincinnatiURL.Query()
+	queryParams.Add("arch", arch)
 	queryParams.Add("channel", channel)
 	queryParams.Add("id", c.id.String())
 	queryParams.Add("version", version.String())

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGetUpdates(t *testing.T) {
 	clientID := uuid.Must(uuid.Parse("01234567-0123-0123-0123-0123456789ab"))
+	arch := "test-arch"
 	channelName := "test-channel"
 	tests := []struct {
 		name    string
@@ -28,14 +29,14 @@ func TestGetUpdates(t *testing.T) {
 	}{{
 		name:          "one update available",
 		version:       "4.0.0-4",
-		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
 		available: []Update{
 			{semver.MustParse("4.0.0-5"), "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		},
 	}, {
 		name:          "two updates available",
 		version:       "4.0.0-5",
-		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-5",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-5",
 		available: []Update{
 			{semver.MustParse("4.0.0-6"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
 			{semver.MustParse("4.0.0-6+2"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"},
@@ -43,11 +44,11 @@ func TestGetUpdates(t *testing.T) {
 	}, {
 		name:          "no updates available",
 		version:       "4.0.0-0.okd-0",
-		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-0.okd-0",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-0.okd-0",
 	}, {
 		name:          "unknown version",
 		version:       "4.0.0-3",
-		expectedQuery: "channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
 		err:           "currently installed version 4.0.0-3 not found in the \"test-channel\" channel",
 	}}
 	for _, test := range tests {
@@ -126,7 +127,7 @@ func TestGetUpdates(t *testing.T) {
 
 			c := NewClient(clientID, proxyURL, tlsConfig)
 
-			updates, err := c.GetUpdates(ts.URL, channelName, semver.MustParse(test.version))
+			updates, err := c.GetUpdates(ts.URL, arch, channelName, semver.MustParse(test.version))
 			if test.err == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"runtime"
 	"testing"
 	"time"
 
@@ -692,7 +693,7 @@ metadata:
 		t.Logf("latest version:\n%s", printCV(lastCV))
 		t.Fatal("no request received at upstream URL")
 	}
-	expectedQuery := fmt.Sprintf("channel=test-channel&id=%s&version=0.0.1", id.String())
+	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", runtime.GOARCH, id.String())
 	expectedQueryValues, err := url.ParseQuery(expectedQuery)
 	if err != nil {
 		t.Fatalf("could not parse expected query: %v", err)


### PR DESCRIPTION
OpenShift is going to be gaining support for architectures other than
AMD64 soon. In order to make sure that the updates provided to a cluster
are compatible with the underlying architecture(s), we are adding an
"arch" parameter to the Cincinnati upstream queries. This new parameter
will contain a set of architectures, separated by commas, that need to
be supported by a release image in order for it to be applied to the
cluster. In a homogeneous deployment, the set of architectures will only
contain a single architecture (this is what this patch implements).
Eventually, once heterogeneous deployments are supported, the set may
contain multiple architectures. The details of heterogeneous deployments
and their constraints haven't been fully fleshed out, so this scheme may
change over time.