### PR TITLE
Bug 1738527: install: enable prometheus-operator to watch over namespace in search for ServiceMonitor

### DIFF
--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -7,3 +7,4 @@ metadata:
   labels:
     name: openshift-cluster-version
     openshift.io/run-level: "1"
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
Follow-up to #234 

Without this label prometheus-operator doesn't watch `openshift-cluster-version` namespace in search for ServiceMonitor.

/assign @abhinavdahiya 
/cc @s-urbaniak