### PR TITLE
Bug 1741786: pkg/cvo: Drop ClusterVersion defaulting during bootstrap

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -14,6 +14,7 @@ spec:
       - "start"
       - "--release-image={{.ReleaseImage}}"
       - "--enable-auto-update=false"
+      - "--enable-default-cluster-version=false"
       - "--v=4"
       - "--kubeconfig=/etc/kubernetes/kubeconfig"
     securityContext:

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,6 +28,7 @@ func init() {
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", opts.Kubeconfig, "Kubeconfig file to access a remote cluster (testing only)")
 	cmd.PersistentFlags().StringVar(&opts.NodeName, "node-name", opts.NodeName, "kubernetes node name CVO is scheduled on.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpdate, "enable-auto-update", opts.EnableAutoUpdate, "Enables the autoupdate controller.")
+	cmd.PersistentFlags().BoolVar(&opts.EnableDefaultClusterVersion, "enable-default-cluster-version", opts.EnableDefaultClusterVersion, "Allows the operator to create a ClusterVersion object if one does not already exist.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The Openshift release image url.")
 	rootCmd.AddCommand(cmd)
 }

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -23,6 +23,7 @@ spec:
           - "start"
           - "--release-image={{.ReleaseImage}}"
           - "--enable-auto-update=false"
+          - "--enable-default-cluster-version=true"
           - "--v=4"
         resources:
           requests:

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -85,6 +85,10 @@ type Operator struct {
 	// releaseCreated, if set, is the timestamp of the current update.
 	releaseCreated time.Time
 
+	// enableDefaultClusterVersion allows the operator to create a
+	// ClusterVersion object if one does not already exist.
+	enableDefaultClusterVersion bool
+
 	client        clientset.Interface
 	kubeClient    kubernetes.Interface
 	eventRecorder record.EventRecorder
@@ -133,6 +137,7 @@ func New(
 	nodename string,
 	namespace, name string,
 	releaseImage string,
+	enableDefaultClusterVersion bool,
 	overridePayloadDir string,
 	minimumInterval time.Duration,
 	cvInformer configinformersv1.ClusterVersionInformer,
@@ -152,6 +157,8 @@ func New(
 		namespace:    namespace,
 		name:         name,
 		releaseImage: releaseImage,
+
+		enableDefaultClusterVersion: enableDefaultClusterVersion,
 
 		statusInterval:             15 * time.Second,
 		minimumUpdateCheckInterval: minimumInterval,
@@ -349,12 +356,16 @@ func (optr *Operator) sync(key string) error {
 
 	// ensure the cluster version exists, that the object is valid, and that
 	// all initial conditions are set.
-	original, changed, err := optr.getOrCreateClusterVersion()
+	original, changed, err := optr.getOrCreateClusterVersion(optr.enableDefaultClusterVersion)
 	if err != nil {
 		return err
 	}
 	if changed {
 		klog.V(4).Infof("Cluster version changed, waiting for newer event")
+		return nil
+	}
+	if original == nil {
+		klog.V(4).Infof("No ClusterVersion object and defaulting not enabled, waiting for one")
 		return nil
 	}
 
@@ -448,7 +459,7 @@ func (optr *Operator) rememberLastUpdate(config *configv1.ClusterVersion) {
 	optr.lastResourceVersion = i
 }
 
-func (optr *Operator) getOrCreateClusterVersion() (*configv1.ClusterVersion, bool, error) {
+func (optr *Operator) getOrCreateClusterVersion(enableDefault bool) (*configv1.ClusterVersion, bool, error) {
 	obj, err := optr.cvLister.Get(optr.name)
 	if err == nil {
 		// if we are waiting to see a newer cached version, just exit
@@ -460,6 +471,10 @@ func (optr *Operator) getOrCreateClusterVersion() (*configv1.ClusterVersion, boo
 
 	if !apierrors.IsNotFound(err) {
 		return nil, false, err
+	}
+
+	if !enableDefault {
+		return nil, false, nil
 	}
 
 	var upstream configv1.URL

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -69,11 +69,12 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 	})
 
 	o := &Operator{
-		namespace: "test",
-		name:      "version",
-		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
-		client:    client,
-		cvLister:  &clientCVLister{client: client},
+		namespace:                   "test",
+		name:                        "version",
+		enableDefaultClusterVersion: true,
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
+		client:                      client,
+		cvLister:                    &clientCVLister{client: client},
 	}
 
 	dynamicScheme := runtime.NewScheme()

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -255,11 +255,12 @@ func TestOperator_sync(t *testing.T) {
 		{
 			name: "create version and status",
 			optr: Operator{
-				releaseVersion: "4.0.1",
-				releaseImage:   "image/image:v4.0.1",
-				namespace:      "test",
-				name:           "default",
-				client:         fake.NewSimpleClientset(),
+				releaseVersion:              "4.0.1",
+				releaseImage:                "image/image:v4.0.1",
+				enableDefaultClusterVersion: true,
+				namespace:                   "test",
+				name:                        "default",
+				client:                      fake.NewSimpleClientset(),
 			},
 			wantActions: func(t *testing.T, optr *Operator) {
 				f := optr.client.(*fake.Clientset)

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -55,7 +55,8 @@ type Options struct {
 	NodeName   string
 	ListenAddr string
 
-	EnableAutoUpdate bool
+	EnableAutoUpdate            bool
+	EnableDefaultClusterVersion bool
 
 	// for testing only
 	Name            string
@@ -326,6 +327,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			o.NodeName,
 			o.Namespace, o.Name,
 			o.ReleaseImage,
+			o.EnableDefaultClusterVersion,
 			o.PayloadOverride,
 			resyncPeriod(o.ResyncInterval)(),
 			cvInformer.Config().V1().ClusterVersions(),

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -234,6 +234,7 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	options.Namespace = ns
 	options.Name = ns
 	options.ListenAddr = ""
+	options.EnableDefaultClusterVersion = true
 	options.NodeName = "test-node"
 	options.ReleaseImage = payloadImage1
 	options.PayloadOverride = filepath.Join(dir, "ignored")
@@ -385,6 +386,7 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	options.Namespace = ns
 	options.Name = ns
 	options.ListenAddr = ""
+	options.EnableDefaultClusterVersion = true
 	options.NodeName = "test-node"
 	options.ReleaseImage = payloadImage1
 	options.PayloadOverride = filepath.Join(dir, "ignored")


### PR DESCRIPTION
This avoids a race between:

* The cluster-version operator pushing its internally-generated default and
* The cluster-bootstrap process pushing the installer-generated ClusterVersion into the cluster ([rhbz#1741786][1])

Because cluster-bootstrap does not override already-existing objects, when the CVO's default won that race, the cluster would come up with a bogus `channel` (`fast`, instead of the installer's default `stable-4.2`, etc.) and `clusterID` (causing the reported Telemetry to come in under a different UUID than the one the installer [provided in its `metadata.json` output][2]).

By removing the default, the CVO will continue applying the current version and reporting some metrics like `cluster_version{type="current"}`.  But it will not report metrics that depend on the state stored in the ClusterVersion object (past versions, `cluster_version{type="failure"}`, etc.).  And even the metrics it does provide may not make it up to the Telemetry API because the monitoring operator will not be able to pass [the Telemeter container][3] the [expected `clusterID`][4].  I'm not clear on how the Telemeter config is updated when the ClusterVersion's `clusterID` *does* change because of [this guard][5], but the monitoring operator is [willing to continue without it][6].  The monitoring operator only updates the Telemeter Deployment to [*set* (or update) the cluster ID][7]; it never clears an existing cluster ID.

While we won't get Telemetry out of the cluster until the cluster-bootstrap process (or somebody else) pushes the ClusterVersion in, we can still alert on it locally.  I haven't done that in this PR, because #232 is in flight touching this space.

The defaulting logic dates back to the early CVOConfig work in ea678b1af4 (#2).  @smarterclayton [expressed concern][9] about recovering from ClusterVersion deletion without the default, but:

* Who deletes their ClusterVersion?

* Even if someone wanted to delete their ClusterVersion, we'll want to eventually make the CVO an admission gate for ClusterVersion changes (ab4d84a021).  So (once we set up that admission gate), someone determined to remove ClusterVersion would have to disable that admission config before they could remove the ClusterVersion.  That seems like enough steps that you wouldn't blow ClusterVersion away by accident.

* If you do successfully remove your ClusterVersion, you're going to lose all the status and history it contained.  If you scale down your CVO and then remove your ClusterVersion, it's going to be hard to recover that lost information.  If you left the CVO running, we could presumably cache the whole thing in memory and push it back into the cluster.  That would at least avoid the "compiled-in CVO defaults differ from user's choices" issue.  But we'd still be fighting with the user over the presence of ClusterVersion, and I'd rather not.

* Telemetry will continue pushing reports with the last-seen clusterID, so unless you disabled Telemetry first, future "ClusterVersion is missing" alerts (not added in this commit, see earlier paragraph mentioning alerts) would make it out to let us know that something was being silly.

I'm pushing this up to get feedback on the approach (CC @abhinavdahiya).  The WIP is because I haven't updated the unit test to handle the lack of defaulting.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1741786
[2]: https://github.com/openshift/installer/blob/4e204c5e509de1bd31113b0c0e73af1a35e52c0a/pkg/types/clustermetadata.go#L17-L18
[3]: https://github.com/openshift/cluster-monitoring-operator/blob/14b1093149217a6ab5e7603f19ff5449f1ec12fc/manifests/0000_50_cluster_monitoring_operator_04-deployment.yaml#L62
[4]: https://github.com/openshift/cluster-monitoring-operator/blob/14b1093149217a6ab5e7603f19ff5449f1ec12fc/pkg/manifests/config.go#L217-L229
[5]: https://github.com/openshift/cluster-monitoring-operator/blob/14b1093149217a6ab5e7603f19ff5449f1ec12fc/pkg/operator/operator.go#L369-L370
[6]: https://github.com/openshift/cluster-monitoring-operator/blob/14b1093149217a6ab5e7603f19ff5449f1ec12fc/pkg/operator/operator.go#L376
[7]: https://github.com/openshift/cluster-monitoring-operator/blob/14b1093149217a6ab5e7603f19ff5449f1ec12fc/pkg/manifests/manifests.go#L1762-L1763
[9]: https://bugzilla.redhat.com/show_bug.cgi?id=1708697#c12