### PR TITLE
WIP: Bug 1741786: cmd: Add --telemetry-id option

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -20,6 +20,7 @@ var (
 	renderOpts struct {
 		releaseImage string
 		outputDir    string
+		telemetryID  string
 	}
 )
 
@@ -27,6 +28,7 @@ func init() {
 	rootCmd.AddCommand(renderCmd)
 	renderCmd.PersistentFlags().StringVar(&renderOpts.outputDir, "output-dir", "", "The output directory where the manifests will be rendered.")
 	renderCmd.PersistentFlags().StringVar(&renderOpts.releaseImage, "release-image", "", "The Openshift release image url.")
+	renderCmd.PersistentFlags().StringVar(&renderOpts.telemetryID, "telemetry-id", "", "A telemetry ID which should be used for the default ClusterVersion spec.clusterID.")
 }
 
 func runRenderCmd(cmd *cobra.Command, args []string) {
@@ -39,7 +41,7 @@ func runRenderCmd(cmd *cobra.Command, args []string) {
 	if renderOpts.releaseImage == "" {
 		klog.Fatalf("missing --release-image flag, it is required")
 	}
-	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage); err != nil {
+	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, renderOpts.telemetryID); err != nil {
 		klog.Fatalf("Render command failed: %v", err)
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,5 +29,6 @@ func init() {
 	cmd.PersistentFlags().StringVar(&opts.NodeName, "node-name", opts.NodeName, "kubernetes node name CVO is scheduled on.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpdate, "enable-auto-update", opts.EnableAutoUpdate, "Enables the autoupdate controller.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The Openshift release image url.")
+	cmd.PersistentFlags().StringVar(&opts.telemetryID, "telemetry-id", "", "A telemetry ID which should be used for the default ClusterVersion spec.clusterID.")
 	rootCmd.AddCommand(cmd)
 }

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -28,7 +28,7 @@ cluster_version{image="test/image:2",type="cluster",version="4.0.3",from_version
 cluster_version{image="test/image:3",type="updating",version="4.0.4",from_version="4.0.3"} 132000400
 # HELP cluster_version_available_updates Report the count of available versions for an upstream and channel.
 # TYPE cluster_version_available_updates gauge
-cluster_version_available_updates{channel="fast",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0
+cluster_version_available_updates{channel="stable-4.2",upstream="https://api.openshift.com/api/upgrades_info/v1/graph"} 0
 ```
 
 Metrics about cluster operators:

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -22,6 +22,7 @@ spec:
         args:
           - "start"
           - "--release-image={{.ReleaseImage}}"
+          - "--telemetry-id={{.TelemetryID}}"
           - "--enable-auto-update=false"
           - "--v=4"
         resources:

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -490,7 +490,7 @@ func (optr *Operator) getOrCreateClusterVersion() (*configv1.ClusterVersion, boo
 		},
 		Spec: configv1.ClusterVersionSpec{
 			Upstream:  upstream,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 			ClusterID: configv1.ClusterID(optr.telemetryID),
 		},
 	}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -127,7 +127,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 	})
 	verifyAllStatus(t, worker.StatusCh())
@@ -152,7 +152,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			History: []configv1.UpdateHistory{
@@ -193,7 +193,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			ObservedGeneration: 1,
@@ -276,7 +276,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			ObservedGeneration: 1,
@@ -398,7 +398,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 	})
 	verifyAllStatus(t, worker.StatusCh())
@@ -423,7 +423,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			History: []configv1.UpdateHistory{
@@ -464,7 +464,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			Desired:            desired,
@@ -547,7 +547,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			ObservedGeneration: 1,
@@ -636,7 +636,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &desired,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -718,7 +718,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &desired,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -823,7 +823,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     actual.Spec.ClusterID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &copied,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -862,7 +862,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &desired,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -946,7 +946,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &desired,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -1046,7 +1046,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     actual.Spec.ClusterID,
-			Channel:       "fast",
+			Channel:       "stable-4.2",
 			DesiredUpdate: &copied,
 		},
 		Status: configv1.ClusterVersionStatus{
@@ -1089,7 +1089,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1256,7 +1256,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1412,7 +1412,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1466,7 +1466,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1579,7 +1579,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1621,7 +1621,7 @@ func TestCVO_VerifyInitializingPayloadState(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
@@ -1679,7 +1679,7 @@ func TestCVO_VerifyUpdatingPayloadState(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
-			Channel:   "fast",
+			Channel:   "stable-4.2",
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -274,7 +274,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 				})
 			},
@@ -301,7 +301,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -331,7 +331,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -374,7 +374,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -404,7 +404,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -448,7 +448,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -478,7 +478,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -518,7 +518,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -548,7 +548,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						Desired: configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
@@ -584,7 +584,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 					},
 				),
@@ -601,7 +601,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
@@ -638,7 +638,7 @@ func TestOperator_sync(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -665,7 +665,7 @@ func TestOperator_sync(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
@@ -702,7 +702,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 				}),
 			},
@@ -720,7 +720,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -761,7 +761,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -797,7 +797,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -851,7 +851,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -894,7 +894,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -954,7 +954,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1005,7 +1005,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1062,7 +1062,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1101,7 +1101,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1157,7 +1157,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1193,7 +1193,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1234,7 +1234,7 @@ func TestOperator_sync(t *testing.T) {
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
 							Upstream:  configv1.URL("http://localhost:8080/graph"),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -1284,7 +1284,7 @@ func TestOperator_sync(t *testing.T) {
 				name:         "default",
 				availableUpdates: &availableUpdates{
 					Upstream: "http://localhost:8080/graph",
-					Channel:  "fast",
+					Channel:  "stable-4.2",
 					Updates: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
@@ -1302,7 +1302,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						ObservedGeneration: 2,
@@ -1330,7 +1330,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						AvailableUpdates: []configv1.Update{
@@ -1367,7 +1367,7 @@ func TestOperator_sync(t *testing.T) {
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				availableUpdates: &availableUpdates{
 					Upstream: "",
-					Channel:  "fast",
+					Channel:  "stable-4.2",
 					Updates: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
@@ -1385,7 +1385,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  "",
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						ObservedGeneration: 2,
@@ -1413,7 +1413,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  "",
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						AvailableUpdates: []configv1.Update{
@@ -1449,7 +1449,7 @@ func TestOperator_sync(t *testing.T) {
 				name:         "default",
 				availableUpdates: &availableUpdates{
 					Upstream: "http://localhost:8080/graph",
-					Channel:  "fast",
+					Channel:  "stable-4.2",
 					Updates: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
@@ -1746,7 +1746,7 @@ func TestOperator_sync(t *testing.T) {
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
 							Upstream:  configv1.URL("http://localhost:8080/graph"),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -1806,7 +1806,7 @@ func TestOperator_sync(t *testing.T) {
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
 							Upstream:  configv1.URL("http://localhost:8080/graph"),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -1848,7 +1848,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Spec: configv1.ClusterVersionSpec{
 						Upstream: configv1.URL("http://localhost:8080/graph"),
-						Channel:  "fast",
+						Channel:  "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1893,7 +1893,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: "not-valid-cluster-id",
 						Upstream:  configv1.URL("#%GG"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 				}),
 			},
@@ -1913,7 +1913,7 @@ func TestOperator_sync(t *testing.T) {
 						// The object passed to status has these spec fields cleared
 						// ClusterID: "not-valid-cluster-id",
 						// Upstream:  configv1.URL("#%GG"),
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1952,7 +1952,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: "not-valid-cluster-id",
 						Upstream:  configv1.URL("#%GG"),
-						Channel:   "fast",
+						Channel:   "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -1991,7 +1991,7 @@ func TestOperator_sync(t *testing.T) {
 						ClusterID: "",
 						Upstream:  configv1.URL(""),
 
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
@@ -2089,7 +2089,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -2101,7 +2101,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			wantUpdates: &availableUpdates{
 				Upstream: "",
-				Channel:  "fast",
+				Channel:  "stable-4.2",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2167,7 +2167,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -2179,7 +2179,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			wantUpdates: &availableUpdates{
 				Upstream: "",
-				Channel:  "fast",
+				Channel:  "stable-4.2",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2206,7 +2206,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -2223,7 +2223,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			wantUpdates: &availableUpdates{
 				Upstream: "",
-				Channel:  "fast",
+				Channel:  "stable-4.2",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2257,7 +2257,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -2275,7 +2275,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			wantUpdates: &availableUpdates{
 				Upstream: "",
-				Channel:  "fast",
+				Channel:  "stable-4.2",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:   configv1.RetrievedUpdates,
 					Status: configv1.ConditionTrue,
@@ -2313,7 +2313,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -2331,7 +2331,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			wantUpdates: &availableUpdates{
 				Upstream: "",
-				Channel:  "fast",
+				Channel:  "stable-4.2",
 				Updates: []configv1.Update{
 					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
@@ -2352,7 +2352,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				minimumUpdateCheckInterval: 1 * time.Minute,
 				availableUpdates: &availableUpdates{
 					Upstream: "http://localhost:8080/graph",
-					Channel:  "fast",
+					Channel:  "stable-4.2",
 					At:       time.Now(),
 				},
 
@@ -2368,7 +2368,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 						},
 						Spec: configv1.ClusterVersionSpec{
 							ClusterID: configv1.ClusterID(id),
-							Channel:   "fast",
+							Channel:   "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -167,7 +167,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 							Name: "default",
 						},
 						Spec: configv1.ClusterVersionSpec{
-							Channel: "fast",
+							Channel: "stable-4.2",
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
@@ -202,7 +202,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 						Name: "default",
 					},
 					Spec: configv1.ClusterVersionSpec{
-						Channel: "fast",
+						Channel: "stable-4.2",
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -477,7 +477,7 @@ func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers in
 			return err
 		}
 
-		payloadUpdate, err := payload.LoadUpdate(info.Directory, update.Image)
+		payloadUpdate, err := payload.LoadUpdate(info.Directory, update.Image, "FIXME: get the Operator.telemetryID somehow?")
 		if err != nil {
 			reporter.Report(SyncWorkerStatus{
 				Generation:  work.Generation,

--- a/pkg/payload/image.go
+++ b/pkg/payload/image.go
@@ -9,7 +9,7 @@ import (
 // ImageForShortName returns the image using the updatepayload embedded in
 // the Operator.
 func ImageForShortName(name string) (string, error) {
-	up, err := LoadUpdate(DefaultPayloadDir, "")
+	up, err := LoadUpdate(DefaultPayloadDir, "", "")
 	if err != nil {
 		return "", errors.Wrapf(err, "error loading release manifests from %q", DefaultPayloadDir)
 	}

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -104,7 +104,7 @@ func Test_loadUpdatePayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadUpdate(tt.args.dir, tt.args.releaseImage)
+			got, err := LoadUpdate(tt.args.dir, tt.args.releaseImage, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadUpdatePayload() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -15,14 +15,17 @@ import (
 )
 
 // Render renders all the manifests from /manifests to outputDir.
-func Render(outputDir, releaseImage string) error {
+func Render(outputDir, releaseImage string, telemetryID string) error {
 	var (
 		manifestsDir  = filepath.Join(DefaultPayloadDir, CVOManifestDir)
 		oManifestsDir = filepath.Join(outputDir, "manifests")
 		bootstrapDir  = "/bootstrap"
 		oBootstrapDir = filepath.Join(outputDir, "bootstrap")
 
-		renderConfig = manifestRenderConfig{ReleaseImage: releaseImage}
+		renderConfig = manifestRenderConfig{
+			ReleaseImage: releaseImage,
+			TelemetryID:  telemetryID,
+		}
 	)
 
 	tasks := []struct {
@@ -103,6 +106,7 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, skipFiles s
 
 type manifestRenderConfig struct {
 	ReleaseImage string
+	TelemetryID  string
 }
 
 // renderManifest Executes go text template from `manifestBytes` with `config`.

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -375,7 +375,7 @@ func Test_TaskGraph_real(t *testing.T) {
 	if len(path) == 0 {
 		t.Skip("TEST_GRAPH_PATH unset")
 	}
-	p, err := LoadUpdate(path, "arbitrary/image:1")
+	p, err := LoadUpdate(path, "arbitrary/image:1", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -50,6 +50,7 @@ const (
 // Options are the valid inputs to starting the CVO.
 type Options struct {
 	ReleaseImage string
+	TelemetryID  string
 
 	Kubeconfig string
 	NodeName   string
@@ -326,6 +327,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			o.NodeName,
 			o.Namespace, o.Name,
 			o.ReleaseImage,
+			o.TelemetryID,
 			o.PayloadOverride,
 			resyncPeriod(o.ResyncInterval)(),
 			cvInformer.Config().V1().ClusterVersions(),


### PR DESCRIPTION
As an alternative to:

* removing the ClusterVersion defaulting (#238), or
* moving the telemetry ID [out into a Telemetry-specific config object][2]

this commit allows us to address the race between the installer-created ClusterVersion and the cluster-version-operator-generated default ClusterVersion by removing the former while still allowing an installer-generated Telemetry ID.

We currently need an installer-generated Telemetry ID to support things like [OpenShift Dedicated (OSD)][3], where we currently use the telemetry ID that [the installer exposes in `metadata.json`][4] to feed [the cluster manager][5].  There is concern that if Hive [6] extracted the Telemetry ID from the running cluster (vs. feeding in an installer-chosen ID), that this would race with the cluster's reported Telemetry and that, for example, Hive-launched OSD Telemetry might be erroneously claimed to be a user-provisioned cluster.

I'm less clear on why we don't prefer pushing the Telemetry ID into a Telemetry-specific config.  It seems like it would be less work than this commit (which has a lot of middleman plumbing).  I'm not entirely clear on the API we're committed to supporting for ClusterVersion's `spec.clusterID` property.  But this CVO plumbing was what we were able to form a good-enough-for-now consensus around, and we can come back later with a Telemetery-config approach if we can build consensus around that.

Also update the default channel from `fast` to `stable-4.2`; if we're going to rely on the CVO-generated default, we need it to have a channel that actually exists.

I've added the WIP subject because there are still two FIXMEs where I'm still working out the plumbing.

[1]: https://github.com/openshift/cluster-version-operator/pull/238
[2]: https://github.com/openshift/cluster-version-operator/pull/238#issuecomment-522350796
[3]: https://www.openshift.com/products/dedicated/
[4]: https://github.com/openshift/installer/blob/4e204c5e509de1bd31113b0c0e73af1a35e52c0a/pkg/types/clustermetadata.go#L17-L18
[5]: https://cloud.redhat.com/openshift/
[6]: https://github.com/openshift/hive/