### PR TITLE
pkg/cvo: ensure payload is retirved once when forced upgrade

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -455,7 +455,7 @@ func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers in
 
 	// cache the payload until the release image changes
 	validPayload := w.payload
-	if validPayload == nil || !equalUpdate(configv1.Update{Image: validPayload.ReleaseImage}, update) {
+	if validPayload == nil || !equalUpdate(configv1.Update{Image: validPayload.ReleaseImage}, configv1.Update{Image: update.Image}) {
 		klog.V(4).Infof("Loading payload")
 		reporter.Report(SyncWorkerStatus{
 			Generation:  work.Generation,


### PR DESCRIPTION
Currently the `!equalUpdate` is always true when the upgrade was force. This causes all the syncs to retrieve the payload and then sync.. when the payload only needs to be retrieved once. Also added a test to ensure the behavior.

