### PR TITLE
Bug 1749890: Iterate through the payload in chunks during reconciliation

### DIFF
--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -233,6 +233,118 @@ func TestByNumberAndComponent(t *testing.T) {
 	}
 }
 
+func TestShiftOrder(t *testing.T) {
+	tasks := func(names ...string) []*Task {
+		var arr []*Task
+		for _, name := range names {
+			arr = append(arr, &Task{Manifest: &lib.Manifest{OriginalFilename: name}})
+		}
+		return arr
+	}
+	tests := []struct {
+		name   string
+		step   int
+		stride int
+		tasks  [][]*TaskNode
+		want   [][]*TaskNode
+	}{
+		{
+			step:   0,
+			stride: 8,
+			tasks: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+			want: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+		},
+		{
+			step:   1,
+			stride: 8,
+			tasks: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+			want: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+				},
+			},
+		},
+		{
+			step:   2,
+			stride: 8,
+			tasks: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+			want: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+		},
+		{
+			step:   1,
+			stride: 2,
+			tasks: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_03_x-y-z_file1")},
+				},
+			},
+			want: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_03_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+				},
+			},
+		},
+		{
+			step:   2,
+			stride: 3,
+			tasks: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_03_x-y-z_file1")},
+				},
+			},
+			want: [][]*TaskNode{
+				{
+					&TaskNode{Tasks: tasks("0000_03_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_01_x-y-z_file1")},
+					&TaskNode{Tasks: tasks("0000_02_x-y-z_file1")},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fn := func([]*Task) [][]*TaskNode {
+				return test.tasks
+			}
+			if out := ShiftOrder(fn, test.step, test.stride)(nil); !reflect.DeepEqual(test.want, out) {
+				t.Errorf("%s", diff.ObjectReflectDiff(test.want, out))
+			}
+		})
+	}
+}
+
 func TestFlattenByNumberAndComponent(t *testing.T) {
 	tasks := func(names ...string) []*Task {
 		var arr []*Task


### PR DESCRIPTION
When a large chunk of the objects in the payload are deleted, the
current algorithm for reconcile could in theory take an unlimited
number of attempts to try the entire payload. Instead, for each
permutation of order, try 8 successive attempts starting at
different positions within the step order. I.e.:

```
attempt 1: permute CGEABHDF, start at C
attempt 2: permute CGEABHDF, start at G
...
attempt 8: permute CGEABHDF, start at F
attempt 9: permute AHFECBGD, start at A
...
```

This significantly caps the number of attempts required to cover
the full payload.

Grew irritated at this when testing how the cluster recovers from
a mass deletion event (it takes upwards of 12-16 sync intervals to
restore all objects, just due to the wait on creating objects).