### PR TITLE
docs/dev/clusterversion: Set 'group' in patch manifests

### DIFF
--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -58,6 +58,7 @@ $ cat <<EOF >version-patch-first-override.yaml
   path: /spec/overrides
   value:
   - kind: DaemonSet
+    group: apps/v1
     name: cluster-network-operator
     namespace: openshift-cluster-network-operator
     unmanaged: true
@@ -70,6 +71,7 @@ $ cat <<EOF >version-patch-add-override.yaml
   path: /spec/overrides/-
   value:
     kind: DaemonSet
+    group: apps/v1
     name: cluster-network-operator
     namespace: openshift-cluster-network-operator
     unmanaged: true


### PR DESCRIPTION
I'm not sure when we started enforcing this, but against a recent 4.2 nightly:

```console
$ cat version-patch.yaml
- op: add
  path: /spec/overrides
  value:
  - kind: ImageStream
    name: must-gather
    namespace: openshift
    unmanaged: true
$ oc patch clusterversion version --type json -p "$(cat version-patch.yaml)"
The ClusterVersion "version" is invalid: ... "image":"registry.svc.ci.openshift.org/wking/openshift4@sha256:9b5d0863abafcb98d1be5a4cf153e919530ba79ea4b18c390d602f9284cf916b", "startedTime":"2019-09-16T18:44:55Z", "state":"Completed", "verified":false, "version":"4.2.0-0.nightly-2019-09-11-114314"}}, "observedGeneration":1, "versionHash":"ukrOqloEb10="}}: validation failure list:
spec.overrides.group in body is required
```