### PR TITLE
Bug 1756461: pkg/cvo/status: Don't clobber last.CompletionTime when adding new entries

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -84,7 +84,9 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Upda
 		}
 	} else {
 		klog.V(5).Infof("must add a new history entry completed=%t desired=%#v != last=%#v", completed, desired, last)
-		last.CompletionTime = &now
+		if last.CompletionTime == nil {
+			last.CompletionTime = &now
+		}
 		if completed {
 			config.Status.History = append([]configv1.UpdateHistory{
 				{


### PR DESCRIPTION
Fix a bug where `history[n-1].completionTime == history[n].startedTime`.  @smarterclayton [pointed out this fix][2].

[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1756461#c3