### PR TITLE
Bug 1665828: cmd/main.go: fix cli use to cluster-version-operator instead of version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,14 +7,9 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	componentName      = "version"
-	componentNamespace = "openshift-cluster-version"
-)
-
 var (
 	rootCmd = &cobra.Command{
-		Use:   componentName,
+		Use:   "cluster-version-operator",
 		Short: "Run Cluster Version Controller",
 		Long:  "",
 	}


### PR DESCRIPTION
/assign @wking 