### PR TITLE
Bug 1763821: pkg/payload/task_graph: Canceling the task graph partway though is an error even if no tasks fail

### DIFF
--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -612,5 +612,9 @@ func RunGraph(ctx context.Context, graph *TaskGraph, maxParallelism int, fn func
 	if len(errs) > 0 {
 		return errs
 	}
+	// if the context was cancelled, we may have unfinished work
+	if err := ctx.Err(); err != nil {
+		return []error{err}
+	}
 	return nil
 }

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -721,12 +721,14 @@ func TestRunGraph(t *testing.T) {
 		wantErrs   []string
 	}{
 		{
+			name: "tasks executed in order",
 			nodes: []*TaskNode{
 				{Tasks: tasks("a", "b")},
 			},
 			order: []string{"a", "b"},
 		},
 		{
+			name: "nodes executed after dependencies",
 			nodes: []*TaskNode{
 				{Tasks: tasks("c"), In: []int{3}},
 				{Tasks: tasks("d", "e"), In: []int{3}},
@@ -756,6 +758,7 @@ func TestRunGraph(t *testing.T) {
 			},
 		},
 		{
+			name: "task error interrupts node processing",
 			nodes: []*TaskNode{
 				{Tasks: tasks("c"), In: []int{2}},
 				{Tasks: tasks("d"), In: []int{2}, Out: []int{3}},
@@ -781,6 +784,7 @@ func TestRunGraph(t *testing.T) {
 			},
 		},
 		{
+			name: "mid-task cancellation error interrupts node processing",
 			nodes: []*TaskNode{
 				{Tasks: tasks("c"), In: []int{2}},
 				{Tasks: tasks("d"), In: []int{2}, Out: []int{3}},
@@ -796,15 +800,15 @@ func TestRunGraph(t *testing.T) {
 					case <-time.After(time.Second):
 						t.Fatalf("expected context")
 					case <-ctx.Done():
-						t.Logf("got cancelled context")
-						return fmt.Errorf("cancelled")
+						t.Logf("got canceled context")
+						return ctx.Err()
 					}
 					return fmt.Errorf("error A")
 				}
 				return nil
 			},
 			want:     []string{"a", "b", "c"},
-			wantErrs: []string{"cancelled"},
+			wantErrs: []string{"context canceled"},
 			invariants: func(t *testing.T, got []string) {
 				for _, s := range got {
 					if s == "e" {
@@ -814,6 +818,7 @@ func TestRunGraph(t *testing.T) {
 			},
 		},
 		{
+			name: "task errors in parallel nodes both reported",
 			nodes: []*TaskNode{
 				{Tasks: tasks("a"), Out: []int{1}},
 				{Tasks: tasks("b"), In: []int{0}, Out: []int{2, 4, 8}},
@@ -838,6 +843,26 @@ func TestRunGraph(t *testing.T) {
 			},
 			want:     []string{"a", "b", "d1", "d2", "d3"},
 			wantErrs: []string{"error - c1", "error - f"},
+		},
+		{
+			name: "cancelation without task errors is reported",
+			nodes: []*TaskNode{
+				{Tasks: tasks("a"), Out: []int{1}},
+				{Tasks: tasks("b"), In: []int{0}},
+			},
+			sleep:    time.Millisecond,
+			parallel: 1,
+			errorOn: func(t *testing.T, name string, ctx context.Context, cancelFn func()) error {
+				if name == "a" {
+					cancelFn()
+					time.Sleep(time.Second)
+					return nil
+				}
+				t.Fatalf("task b should never run")
+				return nil
+			},
+			want:     []string{"a"},
+			wantErrs: []string{"context canceled"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Avoid situations [like][1]:

```
2019-10-21T10:34:30.63940461Z I1021 10:34:30.639073       1 start.go:19] ClusterVersionOperator v1.0.0-106-g0725bd53-dirty
...
2019-10-21T10:34:31.132673574Z I1021 10:34:31.132635       1 sync_worker.go:453] Running sync quay.io/runcom/origin-release:v4.2-1196 (force=true) on generation 2 in state Updating at attempt 0
...
2019-10-21T10:40:16.168632703Z I1021 10:40:16.168604       1 sync_worker.go:579] Running sync for customresourcedefinition "baremetalhosts.metal3.io" (101 of 432)
2019-10-21T10:40:16.18425522Z I1021 10:40:16.184220       1 task_graph.go:583] Canceled worker 0
2019-10-21T10:40:16.184381244Z I1021 10:40:16.184360       1 task_graph.go:583] Canceled worker 3
...
2019-10-21T10:40:16.21772875Z I1021 10:40:16.217715       1 task_graph.go:603] Workers finished
2019-10-21T10:40:16.217777479Z I1021 10:40:16.217759       1 task_graph.go:611] Result of work: []
2019-10-21T10:40:16.217864206Z I1021 10:40:16.217846       1 task_graph.go:539] Stopped graph walker due to cancel
...
2019-10-21T10:43:08.743798997Z I1021 10:43:08.743740       1 sync_worker.go:453] Running sync quay.io/runcom/origin-release:v4.2-1196 (force=true) on generation 2 in state Reconciling at attempt 0
...
```

Where the CVO cancels some workers, sees that there are no errors, and decides "upgrade complete" despite never having attempted to push the bulk of its manifests.  With this commit, the result of work will include several worker-canceled errors, and we'll take another upgrade round instead of declaring success and moving into reconciling.

[1]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1/754/artifacts/e2e-aws-upgrade/must-gather/registry-svc-ci-openshift-org-origin-4-1-sha256-f8c863ea08d64eea7b3a9ffbbde9c01ca90501afe6c0707e9c35f0ed7e92a9df/namespaces/openshift-cluster-version/pods/cluster-version-operator-5f5d465967-t57b2/cluster-version-operator/cluster-version-operator/logs/current.log