### PR TITLE
bug 1764017: Fix replicas comparison

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -10,7 +10,7 @@ import (
 func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
-	if required.Spec.Replicas != nil && required.Spec.Replicas != existing.Spec.Replicas {
+	if required.Spec.Replicas != nil && *required.Spec.Replicas != *existing.Spec.Replicas {
 		*modified = true
 		existing.Spec.Replicas = required.Spec.Replicas
 	}

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestEnsureDeployment(t *testing.T) {
-	replicas := int32(2)
-	expectedReplicas := int32(2)
 	labelSelector := metav1.LabelSelector{}
 	tests := []struct {
 		name     string
@@ -25,29 +23,29 @@ func TestEnsureDeployment(t *testing.T) {
 			name: "different replica count",
 			existing: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &replicas}},
+					Replicas: int32Pointer(2)}},
 			required: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &expectedReplicas}},
+					Replicas: int32Pointer(3)}},
 
 			expectedModified: true,
 			expected: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &expectedReplicas}},
+					Replicas: int32Pointer(3)}},
 		},
 		{
 			name: "same replica count",
 			existing: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &replicas}},
+					Replicas: int32Pointer(2)}},
 			required: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &replicas}},
+					Replicas: int32Pointer(2)}},
 
 			expectedModified: false,
 			expected: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &replicas}},
+					Replicas: int32Pointer(2)}},
 		},
 		{
 			name:     "existing-selector-nil-required-selector-non-nil",
@@ -76,4 +74,8 @@ func TestEnsureDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func int32Pointer(i int32) *int32 {
+	return &i
 }


### PR DESCRIPTION
The CVO wrongly makes an update API call and returns `modified=true` when ensuring deployments with same number of replicas