### PR TITLE
Bug 1795412: Print whether CRDs are updated

### DIFF
--- a/lib/resourceapply/apiext.go
+++ b/lib/resourceapply/apiext.go
@@ -8,6 +8,7 @@ import (
 	apiextclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -30,6 +31,8 @@ func ApplyCustomResourceDefinitionV1beta1(client apiextclientv1beta1.CustomResou
 	if !*modified {
 		return existing, false, nil
 	}
+
+	klog.V(2).Infof("Updating CRD %s", required.Name)
 
 	actual, err := client.CustomResourceDefinitions().Update(existing)
 	return actual, true, err
@@ -54,6 +57,8 @@ func ApplyCustomResourceDefinitionV1(client apiextclientv1.CustomResourceDefinit
 	if !*modified {
 		return existing, false, nil
 	}
+
+	klog.V(2).Infof("Updating CRD %s", required.Name)
 
 	actual, err := client.CustomResourceDefinitions().Update(existing)
 	return actual, true, err


### PR DESCRIPTION
This will help to see hotloops due to missing defaults in manifests, leading invisibly to https://bugzilla.redhat.com/show_bug.cgi?id=1795412.