### PR TITLE
payload: Task graph might lose some work if cancelled

### DIFF
--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -612,5 +612,9 @@ func RunGraph(ctx context.Context, graph *TaskGraph, maxParallelism int, fn func
 	if len(errs) > 0 {
 		return errs
 	}
+	// if the context was cancelled, we may have unfinished work
+	if err := ctx.Err(); err != nil {
+		return []error{err}
+	}
 	return nil
 }


### PR DESCRIPTION
A context cancel is always an error for the task graph