### PR TITLE
Bug 1762920: install: add alerts for cluster-version-operator

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    k8s-app: cluster-version-operator
+  name: cluster-version-operator
+  namespace: openshift-cluster-version
+spec:
+  groups:
+  - name: cluster-version
+    rules:
+    - alert: ClusterVersionOperatorDown
+      annotations:
+        message: Cluster version operator has disappeared from Prometheus target discovery. Operator may be down or disabled, cluster will not be kept up to date and upgrades will not be possible.
+      expr: |
+        absent(up{job="cluster-version-operator"} == 1)
+      for: 10m
+      labels:
+        severity: critical
+  - name: cluster-operators
+    rules:
+    - alert: ClusterOperatorDown
+      annotations:
+        message: Cluster operator {{ "{{ $labels.name }}" }} has not been available for 10 mins. Operator may be down or disabled, cluster will not be kept up to date and upgrades will not be possible.
+      expr: |
+        cluster_operator_up{job="cluster-version-operator"} == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: ClusterOperatorDegraded
+      annotations:
+        message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 10 mins. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
+      expr: |
+        cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"} == 1
+      for: 10m
+      labels:
+        severity: critical
+    - alert: ClusterOperatorFlapping
+      annotations:
+        message: Cluster operator {{ "{{ $labels.name }}" }} up status is changing often. This might cause upgrades to be unstable.
+      expr: |
+        changes(cluster_operator_up{job="cluster-version-operator"}[2m]) > 2
+      for: 10m
+      labels:
+        severity: warning

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -3,15 +3,12 @@ package cvo
 import (
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
-
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	"github.com/openshift/cluster-version-operator/pkg/internal"
@@ -263,7 +260,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 			break
 		}
 		g := m.clusterOperatorUp.WithLabelValues(op.Name, firstVersion)
-		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, ClusterStatusFailing)
+		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorDegraded)
 		available := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable)
 		if available && !failing {
 			g.Set(1)

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -175,7 +175,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 								},
 								Conditions: []configv1.ClusterOperatorStatusCondition{
 									{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
-									{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(5, 0)}},
+									{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(5, 0)}},
 								},
 							},
 						},
@@ -189,7 +189,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
 				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1"})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available"})
-				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Failing"})
+				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Degraded"})
 				expectMetric(t, metrics[4], 1, map[string]string{"type": ""})
 			},
 		},

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -30,9 +30,12 @@ func Render(outputDir, releaseImage string) error {
 		odir      string
 		skipFiles sets.String
 	}{{
-		idir:      manifestsDir,
-		odir:      oManifestsDir,
-		skipFiles: sets.NewString("image-references"),
+		idir: manifestsDir,
+		odir: oManifestsDir,
+		skipFiles: sets.NewString(
+			"image-references",
+			"0000_90_cluster-version-operator_02_servicemonitor.yaml",
+		),
 	}, {
 		idir:      bootstrapDir,
 		odir:      oBootstrapDir,


### PR DESCRIPTION
Backports #232 to release-4.1. Also pulls in the precursor commits from #221, and #214.

This one is smaller cherry-pick of https://github.com/openshift/cluster-version-operator/pull/253 because that one needs changes in the CMO to move the servicemonitor to the CVO management.

This only moves the alerts using `PrometheusRule` skipping the `ServiceMonitor`

This is not a clean cherry-pick and definitely needs review.

/cc @wking @smarterclayton 