### PR TITLE
apiext: wait for CRD using v1beta1 for compatibility on upgrades

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -71,12 +71,12 @@ func (b *crdBuilder) Do(ctx context.Context) error {
 	}
 
 	if updated {
-		return waitForCustomResourceDefinitionCompletion(ctx, b.clientV1, name)
+		return waitForCustomResourceDefinitionCompletion(ctx, b.clientV1beta1, name)
 	}
 	return nil
 }
 
-func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiextclientv1.CustomResourceDefinitionsGetter, crd string) error {
+func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiextclientv1beta1.CustomResourceDefinitionsGetter, crd string) error {
 	return wait.PollImmediateUntil(defaultObjectPollInterval, func() (bool, error) {
 		c, err := client.CustomResourceDefinitions().Get(crd, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -89,7 +89,7 @@ func waitForCustomResourceDefinitionCompletion(ctx context.Context, client apiex
 		}
 
 		for _, condition := range c.Status.Conditions {
-			if condition.Type == apiextv1.Established && condition.Status == apiextv1.ConditionTrue {
+			if condition.Type == apiextv1beta1.Established && condition.Status == apiextv1beta1.ConditionTrue {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
This is softening 4ee7b07 (#259) to use the older v1beta1 API version for waiting for CRDs to be established. This fixes the creation of v1beta1 CRDs before kube-apiserver is updated during a 4.2->4.3 update.

Note: this will not fix the creation of v1 CRDs before kube-apiserver is upgraded. Hence, we are still restricted in the use of v1 CRDs for early manifests.