### PR TITLE
Bug 1766907: Add proxy support for CVO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Building and Publishing CVO
 
 ```sh
-./hack/build-image.sh && REPO=<your personal repo (quay.io/ahbinavdahiya | docker.io/abhinavdahiya)> ./hack/push-image.go
+./hack/build-image.sh && REPO=<your personal repo (quay.io/ahbinavdahiya | docker.io/abhinavdahiya)> ./hack/push-image.sh
 ```
 
 1. This builds image locally and then pushes `${VERSION}` and `latest` tags to `${REPO}/origin-cluster-version-operator`.
@@ -17,7 +17,7 @@
 2. Run the following command to create release-image at `docker.io/abhinavdahiya/origin-release:latest`:
 
 ```sh
-oc adm release new -n openshift --server https://api.ci.openshift.org \
+oc adm release new -n origin \
     --from-image-stream=origin-v4.0 \
     --to-image-base=docker.io/abhinavdahiya/origin-cluster-version-operator:latest \
     --to-image docker.io/abhinavdahiya/origin-release:latest

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -24,7 +24,6 @@ import (
 // object. It will set the RetrievedUpdates condition. Updates are only checked if it has been more than
 // the minimumUpdateCheckInterval since the last check.
 func (optr *Operator) syncAvailableUpdates(config *configv1.ClusterVersion) error {
-	var tlsConfig *tls.Config
 	usedDefaultUpstream := false
 	upstream := string(config.Spec.Upstream)
 	if len(upstream) == 0 {
@@ -41,15 +40,9 @@ func (optr *Operator) syncAvailableUpdates(config *configv1.ClusterVersion) erro
 		return nil
 	}
 
-	proxyURL, cmNameRef, err := optr.getHTTPSProxyURL()
+	proxyURL, tlsConfig, err := optr.getTransportOpts()
 	if err != nil {
 		return err
-	}
-	if cmNameRef != "" {
-		tlsConfig, err = optr.getTLSConfig(cmNameRef)
-		if err != nil {
-			return err
-		}
 	}
 
 	updates, condition := calculateAvailableUpdatesStatus(string(config.Spec.ClusterID), proxyURL, tlsConfig, upstream, arch, channel, optr.releaseVersion)

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -2,7 +2,9 @@ package cvo
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/url"
 	"strconv"
 	"sync"
 	"time"
@@ -651,4 +653,22 @@ func (optr *Operator) defaultPreconditionChecks() precondition.List {
 	return []precondition.Precondition{
 		preconditioncv.NewUpgradeable(optr.cvLister),
 	}
+}
+
+// getTransportOpts retrieves the URL of the cluster proxy and the CA
+// trust, if they exist.
+func (optr *Operator) getTransportOpts() (*url.URL, *tls.Config, error) {
+	proxyURL, cmNameRef, err := optr.getHTTPSProxyURL()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var tlsConfig *tls.Config
+	if cmNameRef != "" {
+		tlsConfig, err = optr.getTLSConfig(cmNameRef)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return proxyURL, tlsConfig, nil
 }

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
@@ -207,6 +209,16 @@ func New(
 	return optr
 }
 
+// verifyClientBuilder is a wrapper around the operator's HTTPClient method.
+// It is used by the releaseVerifier to get an up-to-date http client.
+type verifyClientBuilder struct {
+	builder func() (*http.Client, error)
+}
+
+func (vcb *verifyClientBuilder) HTTPClient() (*http.Client, error) {
+	return vcb.builder()
+}
+
 // InitializeFromPayload retrieves the payload contents and verifies the initial state, then configures the
 // controller that loads and applies content to the cluster. It returns an error if the payload appears to
 // be in error rather than continuing.
@@ -223,8 +235,11 @@ func (optr *Operator) InitializeFromPayload(restConfig *rest.Config, burstRestCo
 	optr.releaseCreated = update.ImageRef.CreationTimestamp.Time
 	optr.releaseVersion = update.ImageRef.Name
 
+	// Wraps operator's HTTPClient method to allow releaseVerifier to create http client with up-to-date config.
+	clientBuilder := &verifyClientBuilder{builder: optr.HTTPClient}
+
 	// attempt to load a verifier as defined in the payload
-	verifier, err := verify.LoadFromPayload(update)
+	verifier, err := verify.LoadFromPayload(update, clientBuilder)
 	if err != nil {
 		return err
 	}
@@ -653,6 +668,27 @@ func (optr *Operator) defaultPreconditionChecks() precondition.List {
 	return []precondition.Precondition{
 		preconditioncv.NewUpgradeable(optr.cvLister),
 	}
+}
+
+// HTTPClient provides a method for generating an HTTP client
+// with the proxy and trust settings, if set in the cluster.
+func (optr *Operator) HTTPClient() (*http.Client, error) {
+	proxyURL, tlsConfig, err := optr.getTransportOpts()
+	if err != nil {
+		return nil, err
+	}
+	transportOption := &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: tlsConfig,
+	}
+	transportConfig := &transport.Config{Transport: transportOption}
+	transport, err := transport.New(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Transport: transport,
+	}, nil
 }
 
 // getTransportOpts retrieves the URL of the cluster proxy and the CA

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/client-go/transport"
-
 	"github.com/openshift/cluster-version-operator/lib"
 	"github.com/openshift/cluster-version-operator/pkg/payload"
 	"golang.org/x/crypto/openpgp"
@@ -161,16 +159,13 @@ func Test_releaseVerifier_Verify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			transport, err := transport.New(&transport.Config{})
 			if err != nil {
 				t.Fatal(err)
 			}
 			v := &releaseVerifier{
-				verifiers: tt.verifiers,
-				stores:    tt.stores,
-				client: &http.Client{
-					Transport: transport,
-				},
+				verifiers:     tt.verifiers,
+				stores:        tt.stores,
+				clientBuilder: &simpleClientBuilder{},
 			}
 			if err := v.Verify(context.Background(), tt.releaseDigest); (err != nil) != tt.wantErr {
 				t.Errorf("releaseVerifier.Verify() error = %v, wantErr %v", err, tt.wantErr)
@@ -344,7 +339,7 @@ func Test_loadReleaseVerifierFromPayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadFromPayload(tt.update)
+			got, err := LoadFromPayload(tt.update, &simpleClientBuilder{})
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("loadReleaseVerifierFromPayload() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This PR adds proxy support to the CVO for verifying signatures. It centralizes some of the proxy logic used in Cincinnati to be shared. More significantly, it restructures the releaseVerifier struct to be able to use an up-to-date proxy. The releaseVerifier is created before a watch has been established on the cluster proxy. This PR ensures that the releaseVerifier gets the proxy after it is available to the operator and that the proxy settings are updated if there are any changes to the configuration.

Fixes BZ-1766907.