### PR TITLE
Bug 1685338: pkg/cvo: Reason granularity for RemoteFailed

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -58,22 +58,18 @@ func (err *Error) Error() string {
 // finding all of the children. These children are the available updates for
 // the current version and their payloads indicate from where the actual update
 // image can be downloaded.
-func (c Client) GetUpdates(upstream string, arch string, channel string, version semver.Version) ([]Update, error) {
+func (c Client) GetUpdates(uri *url.URL, arch string, channel string, version semver.Version) ([]Update, error) {
 	transport := http.Transport{}
 	// Prepare parametrized cincinnati query.
-	cincinnatiURL, err := url.Parse(upstream)
-	if err != nil {
-		return nil, &Error{Reason: "InvalidURI", Message: fmt.Sprintf("failed to parse upstream URL: %s", err)}
-	}
-	queryParams := cincinnatiURL.Query()
+	queryParams := uri.Query()
 	queryParams.Add("arch", arch)
 	queryParams.Add("channel", channel)
 	queryParams.Add("id", c.id.String())
 	queryParams.Add("version", version.String())
-	cincinnatiURL.RawQuery = queryParams.Encode()
+	uri.RawQuery = queryParams.Encode()
 
 	// Download the update graph.
-	req, err := http.NewRequest("GET", cincinnatiURL.String(), nil)
+	req, err := http.NewRequest("GET", uri.String(), nil)
 	if err != nil {
 		return nil, &Error{Reason: "InvalidRequest", Message: err.Error(), cause: err}
 	}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -49,7 +49,7 @@ func TestGetUpdates(t *testing.T) {
 		name:          "unknown version",
 		version:       "4.0.0-3",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
-		err:           "currently installed version 4.0.0-3 not found in the \"test-channel\" channel",
+		err:           "VersionNotFound: currently installed version 4.0.0-3 not found in the \"test-channel\" channel",
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -127,7 +127,12 @@ func TestGetUpdates(t *testing.T) {
 
 			c := NewClient(clientID, proxyURL, tlsConfig)
 
-			updates, err := c.GetUpdates(ts.URL, arch, channelName, semver.MustParse(test.version))
+			uri, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			updates, err := c.GetUpdates(uri, arch, channelName, semver.MustParse(test.version))
 			if test.err == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -127,6 +127,14 @@ func calculateAvailableUpdatesStatus(clusterID string, proxyURL *url.URL, tlsCon
 		}
 	}
 
+	uuid, err := uuid.Parse(string(clusterID))
+	if err != nil {
+		return nil, configv1.ClusterOperatorStatusCondition{
+			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "InvalidID",
+			Message: fmt.Sprintf("invalid cluster ID: %s", err),
+		}
+	}
+
 	if len(arch) == 0 {
 		return nil, configv1.ClusterOperatorStatusCondition{
 			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "NoArchitecture",
@@ -157,12 +165,19 @@ func calculateAvailableUpdatesStatus(clusterID string, proxyURL *url.URL, tlsCon
 		}
 	}
 
-	updates, err := checkForUpdate(clusterID, proxyURL, tlsConfig, upstream, arch, channel, currentVersion)
+	updates, err := cincinnati.NewClient(uuid, proxyURL, tlsConfig).GetUpdates(upstream, arch, channel, currentVersion)
 	if err != nil {
 		klog.V(2).Infof("Upstream server %s could not return available updates: %v", upstream, err)
+		if updateError, ok := err.(*cincinnati.Error); ok {
+			return nil, configv1.ClusterOperatorStatusCondition{
+				Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: updateError.Reason,
+				Message: fmt.Sprintf("Unable to retrieve available updates: %s", updateError.Message),
+			}
+		}
+		// this should never happen
 		return nil, configv1.ClusterOperatorStatusCondition{
-			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed",
-			Message: fmt.Sprintf("Unable to retrieve available updates: %v", err),
+			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "Unknown",
+			Message: fmt.Sprintf("Unable to retrieve available updates: %s", err),
 		}
 	}
 
@@ -180,18 +195,6 @@ func calculateAvailableUpdatesStatus(clusterID string, proxyURL *url.URL, tlsCon
 
 		LastTransitionTime: metav1.Now(),
 	}
-}
-
-func checkForUpdate(clusterID string, proxyURL *url.URL, tlsConfig *tls.Config, upstream, arch, channel string, currentVersion semver.Version) ([]cincinnati.Update, error) {
-	uuid, err := uuid.Parse(string(clusterID))
-	if err != nil {
-		return nil, err
-	}
-
-	if len(upstream) == 0 {
-		return nil, fmt.Errorf("no upstream URL set for cluster version")
-	}
-	return cincinnati.NewClient(uuid, proxyURL, tlsConfig).GetUpdates(upstream, arch, channel, currentVersion)
 }
 
 // getHTTPSProxyURL returns a url.URL object for the configured

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -127,6 +127,14 @@ func calculateAvailableUpdatesStatus(clusterID string, proxyURL *url.URL, tlsCon
 		}
 	}
 
+	upstreamURI, err := url.Parse(upstream)
+	if err != nil {
+		return nil, configv1.ClusterOperatorStatusCondition{
+			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "InvalidURI",
+			Message: fmt.Sprintf("failed to parse upstream URL: %s", err),
+		}
+	}
+
 	uuid, err := uuid.Parse(string(clusterID))
 	if err != nil {
 		return nil, configv1.ClusterOperatorStatusCondition{
@@ -165,7 +173,7 @@ func calculateAvailableUpdatesStatus(clusterID string, proxyURL *url.URL, tlsCon
 		}
 	}
 
-	updates, err := cincinnati.NewClient(uuid, proxyURL, tlsConfig).GetUpdates(upstream, arch, channel, currentVersion)
+	updates, err := cincinnati.NewClient(uuid, proxyURL, tlsConfig).GetUpdates(upstreamURI, arch, channel, currentVersion)
 	if err != nil {
 		klog.V(2).Infof("Upstream server %s could not return available updates: %v", upstream, err)
 		if updateError, ok := err.(*cincinnati.Error); ok {

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2451,7 +2451,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
-					Reason:  "RemoteFailed",
+					Reason:  "ResponseFailed",
 					Message: "Unable to retrieve available updates: unexpected HTTP status: 500 Internal Server Error",
 				},
 			},


### PR DESCRIPTION
We [want][1] to be able to distinguish these conditions, which can be due to internal misconfiguration or external Cincinnati/network errors.  The former can be fixed by cluster admins.  The latter could go either way.

I dropped the `len(upstream)` guard from `checkForUpdate` because there's already an earlier guard in `syncAvailableUpdates`.  The guard I'm removing is from db150e6db4 (#45).  The covering guard is from the later 286641de68 (#55).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1685338