### PR TITLE
Add annotations to manifests to exclude in hosted deployment

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   selector:
     matchLabels:

--- a/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
+++ b/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-version
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
     k8s-app: cluster-version-operator
   name: cluster-version-operator
   namespace: openshift-cluster-version
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - interval: 30s
@@ -24,6 +26,8 @@ metadata:
     k8s-app: cluster-version-operator
   name: cluster-version-operator
   namespace: openshift-cluster-version
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: cluster-version

--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-cluster-version
   labels:
     k8s-app: cluster-version-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252