### PR TITLE
docs/dev/clusteroperator: Point at the reconciliation docs

### DIFF
--- a/docs/user/reconciliation.md
+++ b/docs/user/reconciliation.md
@@ -74,6 +74,7 @@ $ cat /tmp/release/release-manifests/image-references
 ## Manifest graph
 
 The cluster-version operator unpacks the release image, ingests manifests, loads them into a graph.
+Only manifests with `.yaml`, `.yml`, or `.json` extensions are considered, like `kubectl create -f DIR`.
 For upgrades, the graph is ordered by the number and component of the manifest file:
 
 <div style="text-align:center">


### PR DESCRIPTION
cde8d50a83 (#201) just landed, so drop some of the reconciliation docs from the parallel 105ea1f5e2 (#222) and similar in favor of a link to the new reconciliation location.

Also move the file-extension note over to the reconciliation side, since it's more generic than ClusterOperator.  It's not really user docs either, but that's the most generic location we have at the moment.

Also fix a few more `Failing` -> `Degraded` bits to catch up with fad0688c34 (#232) and similar.