### PR TITLE
Bug 1783221: lib/resourcemerge/core: Fix panic on container/port removal

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -62,7 +62,8 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {
-	for i, existingContainer := range *existing {
+	for i := len(*existing) - 1; i >= 0; i-- {
+		existingContainer := &(*existing)[i]
 		var existingCurr *corev1.Container
 		for _, requiredContainer := range required {
 			if existingContainer.Name == requiredContainer.Name {
@@ -203,7 +204,8 @@ func ensureContainerPort(modified *bool, existing *corev1.ContainerPort, require
 }
 
 func EnsureServicePorts(modified *bool, existing *[]corev1.ServicePort, required []corev1.ServicePort) {
-	for i, existingServicePort := range *existing {
+	for i := len(*existing) - 1; i >= 0; i-- {
+		existingServicePort := &(*existing)[i]
 		var existingCurr *corev1.ServicePort
 		for _, requiredServicePort := range required {
 			if existingServicePort.Name == requiredServicePort.Name {

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -247,6 +247,27 @@ func TestEnsurePodSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove a container",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-A"},
+					corev1.Container{Name: "test-B"},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-B"},
+				},
+			},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-B"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Avoid:

```console
$ go test ./lib/resourcemerge/
panic: runtime error: index out of range [recovered]
			 panic: runtime error: index out of range

goroutine 38 [running]:
testing.tRunner.func1(0xc0001ab000)
  /home/trking/sdk/go1.12.9/src/testing/testing.go:830 +0x392
panic(0xccb520, 0x163f880)
  /home/trking/sdk/go1.12.9/src/runtime/panic.go:522 +0x1b5
github.com/openshift/cluster-version-operator/lib/resourcemerge.ensureContainers(0xc0000bbd57, 0xc0001d4040, 0xc0001cd760, 0x1, 0x1)
  /home/trking/.local/lib/go/src/github.com/openshift/cluster-version-operator/lib/resourcemerge/core.go:69 +0x840
github.com/openshift/cluster-version-operator/lib/resourcemerge.ensurePodSpec(0xc0001c5d57, 0xc0001d4010, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0001cd760, 0x1, ...)
  /home/trking/.local/lib/go/src/github.com/openshift/cluster-version-operator/lib/resourcemerge/core.go:28 +0xc6
github.com/openshift/cluster-version-operator/lib/resourcemerge.TestEnsurePodSpec.func1(0xc0001ab000)
  /home/trking/.local/lib/go/src/github.com/openshift/cluster-version-operator/lib/resourcemerge/core_test.go:276 +0xc7
testing.tRunner(0xc0001ab000, 0xc0001d8770)
  /home/trking/sdk/go1.12.9/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
  /home/trking/sdk/go1.12.9/src/testing/testing.go:916 +0x35a
FAIL		github.com/openshift/cluster-version-operator/lib/resourcemerge	0.010s
```

when removing an entry mutated the existing slice without re-entering the `for i, whatever := range *existing`.

No fix yet, but there's a test that reproduces the bug's panic.