### PR TITLE
Fixing example command to fetch desired image from ClusterVersion resource

### DIFF
--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -1,14 +1,14 @@
 # ClusterVersion Custom Resource
 
-The `ClusterVersion` is a custom resource object which holds the current version of the cluster.
+The `ClusterVersion` is a custom resource object which holds the desired version of the cluster.
 This object is used by the administrator to declare their target cluster state, which the cluster-version operator (CVO) then works to transition the cluster to that target state.
 
-## Finding your current update image
+## Finding your desired update image
 
-You can extract the current update image from the `ClusterVersion` object:
+You can extract the desired update image from the `ClusterVersion` object:
 
 ```console
-$ oc get clusterversion -o jsonpath='{.status.current.image}{"\n"}' version
+$ oc get clusterversion -o jsonpath='{.status.desired.image}{"\n"}' version
 registry.svc.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833
 ```
 


### PR DESCRIPTION
With reference to [1] and [2], suggesting to change example command and comments to replace _current_ to _desired_. Let me know if any corrections required.

[1]
https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go#L87

[2] 
```console
$ oc explain clusterversion.status.desired.image
KIND:     ClusterVersion
VERSION:  config.openshift.io/v1

FIELD:    image <string>

DESCRIPTION:
     image is a container image location that contains the update. When this
     field is part of spec, image is optional if version is specified and the
     availableUpdates field contains a matching version.
```