### PR TITLE
Bug 1786315: pkg/cvo/updatepayload: Drop ephemeral-storage request

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -175,7 +175,6 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:              resource.MustParse("10m"),
 								corev1.ResourceMemory:           resource.MustParse("50Mi"),
-								corev1.ResourceEphemeralStorage: resource.MustParse("2Mi"),
 							},
 						},
 					}},


### PR DESCRIPTION
I dunno why there is no capacity reporting in 4.2, but ephemeral-storage capacity reporting is not working there, leading to version pods dying [with][1]:

> Node didn't have enough resource: ephemeral-storage, requested: 2097152, used: 0, capacity: 0

For an example of a 4.2 cluster without ephemeral-storage capacity reporting, see [this 4.2.10 -> 4.2.12 update test][2]:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/12620/artifacts/e2e-aws-upgrade/must-gather/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-a0dbe73b7831a8ddb9a2c58a560461d7c2c23a92231289a2104b93e7723c0eff/cluster-scoped-resources/core/nodes/ip-10-0-129-58.ec2.internal.yaml | yaml2json | jq .status.capacity | json2yaml
attachable-volumes-aws-ebs: '39'
cpu: '4'
hugepages-1Gi: '0'
hugepages-2Mi: '0'
memory: 16419384Ki
pods: '250'
```

Capacity reporting is working in 4.3, e.g. see [this 4.2.12 -> 4.3.0-0.nightly-2020-01-02-141332
update test][3].

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/13437/artifacts/e2e-aws-upgrade/must-gather/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-c6c63e67c3d38a704c8695a40bb64b9975df2bda3f00c9379592cd5596126f2d/cluster-scoped-resources/core/nodes/ip-10-0-130-241.ec2.internal.yaml | yaml2json | jq .status.capacity | json2yaml
attachable-volumes-aws-ebs: '39'
cpu: '4'
ephemeral-storage: 124768236Ki
hugepages-1Gi: '0'
hugepages-2Mi: '0'
memory: 16419384Ki
pods: '250'
```

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1786315
[2]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/12620
[3]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/13437