### PR TITLE
Bug 1787422: pkg/cvo/updatepayload: Drop ephemeral-storage request

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -175,7 +175,6 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:              resource.MustParse("10m"),
 								corev1.ResourceMemory:           resource.MustParse("50Mi"),
-								corev1.ResourceEphemeralStorage: resource.MustParse("2Mi"),
 							},
 						},
 					}},


### PR DESCRIPTION
Forward-porting #288 to 4.3.  Although 4.3 kubelet capacity reporting works, we still need to drop the 4.3 request, to support flows like:

1. 4.2 cluster running with 4.2 CVO and 4.2 kubelets (so no capacity reporting).
2. Admin requests an update to 4.3.1.
3. 4.2 CVO launches a version pod without requests, because of the 4.2 reversion (#288).  This works fine.
4. Update gets far enough to run a 4.3 CVO.
5. Update hangs on some 4.3.1 bug, while it's still running 4.2 kubelets.
6. Admin requests an update to 4.3.2.
7. 4.3 CVO launches a version pod with an ephemeral-storage request, which hangs because the 4.2 kubelets are still running and not reporting ephemeral-storage capacity.