### PR TITLE
Bug 1787334: pkg/cvo/updatepayload: Drop ephemeral-storage request

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -175,7 +175,6 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:              resource.MustParse("10m"),
 								corev1.ResourceMemory:           resource.MustParse("50Mi"),
-								corev1.ResourceEphemeralStorage: resource.MustParse("2Mi"),
 							},
 						},
 					}},


### PR DESCRIPTION
Reopening #289 on release-4.3, since Prow seemed to not notice [my changing #289's base branch][1].

[1]: https://github.com/openshift/cluster-version-operator/pull/289#event-2918526191