### PR TITLE
pkg/verify: Ensure signature name matches release name

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -88,7 +88,7 @@ func (r *payloadRetriever) RetrievePayload(ctx context.Context, update configv1.
 	if index := strings.LastIndex(update.Image, "@"); index != -1 {
 		releaseDigest = update.Image[index+1:]
 	}
-	if err := r.verifier.Verify(ctx, releaseDigest); err != nil {
+	if err := r.verifier.Verify(ctx, fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:%s", update.Version), releaseDigest); err != nil {
 		vErr := &payload.UpdateError{
 			Reason:  "ImageVerificationFailed",
 			Message: fmt.Sprintf("The update cannot be verified: %v", err),


### PR DESCRIPTION
Guard against attackers who present a target image that has been signed by a trusted key, but which is not the expected release image.  For example, it could be a bare RHEL image and not an OpenShift release image.