### PR TITLE
WIP resourcebuilder: set a bigger timeout when waiting for deployment to apply

### DIFF
--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -77,7 +77,7 @@ func (b *deploymentBuilder) Do(ctx context.Context) error {
 	return nil
 }
 func waitForDeploymentCompletion(ctx context.Context, client appsclientv1.DeploymentsGetter, deployment *appsv1.Deployment) error {
-	return wait.PollImmediateUntil(defaultObjectPollInterval, func() (bool, error) {
+	return wait.PollImmediateUntil(deploymentApplyPollInterval, func() (bool, error) {
 		d, err := client.Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			// exit early to recreate the deployment.

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -91,3 +91,5 @@ func New(mapper *ResourceMapper, rest *rest.Config, m lib.Manifest) (Interface, 
 // defaultObjectPollInterval is the default interval to poll the API to determine whether an object
 // is ready. Use this when a more specific interval is not necessary.
 const defaultObjectPollInterval = 3 * time.Second
+
+const deploymentApplyPollInterval = 30 * time.Second


### PR DESCRIPTION
CVO gives up too early when waiting for deployment to roll out, [logs](https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1/1069/artifacts/e2e-aws-upgrade/pods/openshift-cluster-version_cluster-version-operator-654cbcccd-hfftq_cluster-version-operator.log)
```
I0109 02:29:09.898207       1 sync_worker.go:621] Running sync for deployment "openshift-machine-config-operator/machine-config-operator" (434 of 522)
I0109 02:29:09.916996       1 apps.go:115] Deployment machine-config-operator is not ready. status: (replicas: 1, updated: 1, ready: 1, unavailable: 0)
I0109 02:29:12.920730       1 apps.go:115] Deployment machine-config-operator is not ready. status: (replicas: 2, updated: 1, ready: 1, unavailable: 1)
I0109 02:29:15.920863       1 apps.go:115] Deployment machine-config-operator is not ready. status: (replicas: 2, updated: 1, ready: 1, unavailable: 1)
...
E0109 02:29:16.478418       1 task.go:77] error running apply for deployment "openshift-machine-config-operator/machine-config-operator" (434 of 522): timed out waiting for the condition
...
I0109 02:29:16.478685       1 task_graph.go:611] Result of work: [Could not update deployment "openshift-machine-config-operator/machine-config-operator" (434 of 522)]
```

The task is expected to run 3 times up to 3 minutes, but due to short timeout it completes less than in 9 seconds.

The PR would increase timeout used in `waitForDeploymentCompletion` to wait for at least 90 seconds 

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1786993
