### PR TITLE
WIP Bug 1786993: resourcebuilder: set a bigger timeout when waiting for deployment to apply

### DIFF
--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -77,7 +77,7 @@ func (b *deploymentBuilder) Do(ctx context.Context) error {
 	return nil
 }
 func waitForDeploymentCompletion(ctx context.Context, client appsclientv1.DeploymentsGetter, deployment *appsv1.Deployment) error {
-	return wait.PollImmediateUntil(defaultObjectPollInterval, func() (bool, error) {
+	return wait.PollImmediateUntil(deploymentApplyPollInterval, func() (bool, error) {
 		d, err := client.Deployments(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			// exit early to recreate the deployment.

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -91,3 +91,5 @@ func New(mapper *ResourceMapper, rest *rest.Config, m lib.Manifest) (Interface, 
 // defaultObjectPollInterval is the default interval to poll the API to determine whether an object
 // is ready. Use this when a more specific interval is not necessary.
 const defaultObjectPollInterval = 3 * time.Second
+
+const deploymentApplyPollInterval = 30 * time.Second


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cluster-version-operator/pull/295 on release-4.3

This is WIP to test 4.2 -> 4.3 upgrades