### PR TITLE
Bug 1791863: lib/resourcemerge/core: Clear livenessProbe and readinessProbe if nil in required

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -138,12 +138,8 @@ func ensureContainer(modified *bool, existing *corev1.Container, required corev1
 		ensureVolumeMount(modified, existingCurr, required)
 	}
 
-	if required.LivenessProbe != nil {
-		ensureProbePtr(modified, &existing.LivenessProbe, required.LivenessProbe)
-	}
-	if required.ReadinessProbe != nil {
-		ensureProbePtr(modified, &existing.ReadinessProbe, required.ReadinessProbe)
-	}
+	ensureProbePtr(modified, &existing.LivenessProbe, required.LivenessProbe)
+	ensureProbePtr(modified, &existing.ReadinessProbe, required.ReadinessProbe)
 
 	// our security context should always win
 	ensureSecurityContextPtr(modified, &existing.SecurityContext, required.SecurityContext)
@@ -170,11 +166,10 @@ func ensureEnvFromSource(modified *bool, existing *[]corev1.EnvFromSource, requi
 }
 
 func ensureProbePtr(modified *bool, existing **corev1.Probe, required *corev1.Probe) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
-	if *existing == nil {
+	if *existing == nil || required == nil {
 		*modified = true
 		*existing = required
 		return


### PR DESCRIPTION
We've [claimed][0]:

> if we have no required, then we don't care what someone else has set

since this code landed in d9f6718de0 (#7).  But we do care in situations like [rhbz#1791863][1], where a 4.3 -> 4.2 downgrade leaves 4.3 readiness probes in place for a 4.2 operator which has no `/readyz`.

With this pull-request we still have a few other types where we claim to not care:

```console
$ git grep -hB1 'someone else has set' | grep func
func ensureSecurityContextPtr(modified *bool, existing **corev1.SecurityContext, required *corev1.SecurityContext) {
func ensureCapabilitiesPtr(modified *bool, existing **corev1.Capabilities, required *corev1.Capabilities) {
func ensureAffinityPtr(modified *bool, existing **corev1.Affinity, required *corev1.Affinity) {
func ensurePodSecurityContextPtr(modified *bool, existing **corev1.PodSecurityContext, required *corev1.PodSecurityContext) {
func ensureSELinuxOptionsPtr(modified *bool, existing **corev1.SELinuxOptions, required *corev1.SELinuxOptions) {
func setBoolPtr(modified *bool, existing **bool, required *bool) {
func setInt64Ptr(modified *bool, existing **int64, required *int64) {
```

but I'm leaving them alone until we have a clearer picture about whether we care about those specific properties or not.

[0]: https://github.com/openshift/cluster-version-operator/commit/d9f6718de071cd886851b68e8b3d72fbe6618f6f#diff-f7675c7b39553e431cdc6c3ba8f5c482R140
[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1791863#c1