### PR TITLE
Bug 1790629: use st.Manifest.OriginalFilename if object doesn't have a name

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -53,11 +53,15 @@ func (st *Task) Copy() *Task {
 }
 
 func (st *Task) String() string {
+	name := st.Manifest.Object().GetName()
+	if len(name) == 0 {
+		name = st.Manifest.OriginalFilename
+	}
 	ns := st.Manifest.Object().GetNamespace()
 	if len(ns) == 0 {
-		return fmt.Sprintf("%s %q (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), st.Manifest.Object().GetName(), st.Index, st.Total)
+		return fmt.Sprintf("%s %q (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), name, st.Index, st.Total)
 	}
-	return fmt.Sprintf("%s \"%s/%s\" (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), ns, st.Manifest.Object().GetName(), st.Index, st.Total)
+	return fmt.Sprintf("%s \"%s/%s\" (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), ns, name, st.Index, st.Total)
 }
 
 // Run attempts to create the provided object until it succeeds or context is cancelled. It returns the

--- a/pkg/payload/task_test.go
+++ b/pkg/payload/task_test.go
@@ -1,0 +1,169 @@
+package payload
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/cluster-version-operator/lib"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestTaskString(t *testing.T) {
+	tests := []struct {
+		name string
+		task *Task
+		want string
+	}{
+		{
+			name: "Manifest with name",
+			task: &Task{Manifest: &lib.Manifest{
+				OriginalFilename: "a",
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Test",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "file-json",
+						},
+					},
+				},
+			}},
+			want: ` "file-json" (0 of 0)`,
+		},
+		{
+			name: "Manifest with GVK",
+			task: &Task{Manifest: &lib.Manifest{
+				GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Test",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "file-json",
+						},
+					},
+				},
+			}},
+			want: `ingress "file-json" (0 of 0)`,
+		},
+		{
+			name: "Manifest with name and namespace",
+			task: &Task{Manifest: &lib.Manifest{
+				OriginalFilename: "a",
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Test",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name":      "file-json",
+							"namespace": "foo",
+						},
+					},
+				},
+			}},
+			want: ` "foo/file-json" (0 of 0)`,
+		},
+		{
+			name: "Manifest with GVK and namespace",
+			task: &Task{Manifest: &lib.Manifest{
+				GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Test",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name":      "file-json",
+							"namespace": "foo",
+						},
+					},
+				},
+			}},
+			want: `ingress "foo/file-json" (0 of 0)`,
+		},
+		{
+			name: "index and total",
+			task: &Task{
+				Manifest: &lib.Manifest{
+					GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+					Obj: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind":       "Test",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name": "file-json",
+							},
+						},
+					},
+				},
+				Index: 3,
+				Total: 7,
+			},
+			want: `ingress "file-json" (3 of 7)`,
+		},
+		{
+			name: "Namespaced, index and total",
+			task: &Task{
+				Manifest: &lib.Manifest{
+					GVK: schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+					Obj: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind":       "Test",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "file-json",
+								"namespace": "foo",
+							},
+						},
+					},
+				},
+				Index: 5,
+				Total: 10,
+			},
+			want: `ingress "foo/file-json" (5 of 10)`,
+		},
+		{
+			name: "List",
+			task: &Task{Manifest: &lib.Manifest{
+				OriginalFilename: "list_manifest.yaml",
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "List",
+						"apiVersion": "v1",
+						"items": []interface{}{
+							"foo",
+							"bar",
+						},
+					},
+				},
+			}},
+			want: ` "list_manifest.yaml" (0 of 0)`,
+		},
+		{
+			name: "List and GVK",
+			task: &Task{Manifest: &lib.Manifest{
+				OriginalFilename: "list_manifest.yaml",
+				GVK:              schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"},
+				Obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "List",
+						"apiVersion": "v1",
+						"items": []interface{}{
+							"foo",
+							"bar",
+						},
+					},
+				},
+			}},
+			want: `list "list_manifest.yaml" (0 of 0)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.task.String(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is helpful when one of the manifests doesn't have a name (like `kind: List` in [image-registry PR](https://github.com/openshift/cluster-image-registry-operator/commit/d197841e7944138ee2dc0815f2749c4f67657889#diff-88bbb853bcd5a5fbc188c46767630fadR1))

This list still cannot be applied (`apply` requires a name to find existing resource) but it would be helpful to debug these kind of issues.

TODO:
* [x] Add unittest