### PR TITLE
Bug 1793051: cvo: pass limiter when creating a store

### DIFF
--- a/pkg/verify/verifyconfigmap/store.go
+++ b/pkg/verify/verifyconfigmap/store.go
@@ -41,6 +41,7 @@ func NewStore(client corev1client.ConfigMapsGetter, limiter *rate.Limiter) *Stor
 	return &Store{
 		client: client,
 		ns:     "openshift-config-managed",
+		limiter: limiter,
 	}
 }
 


### PR DESCRIPTION
`NewStore` creates a limiter, but doesn't pass it to `Store`. Later Store 
attempts to use it in `DigestSignatures` - and explodes