### PR TITLE
Bug 1797123: pkg/cvo: Fetch proxy CA certs from openshift-config-managed/trusted-ca-bundle

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2628,6 +2628,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			optr.proxyLister = &clientProxyLister{client: optr.client}
 			optr.coLister = &clientCOLister{client: optr.client}
 			optr.cvLister = &clientCVLister{client: optr.client}
+			optr.cmConfigManagedLister = &cmConfigLister{}
 			optr.eventRecorder = record.NewFakeRecorder(100)
 
 			if tt.handler != nil {

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -1,7 +1,8 @@
 package internal
 
 const (
-	ConfigNamespace    = "openshift-config"
-	InstallerConfigMap = "openshift-install"
-	ManifestsConfigMap = "openshift-install-manifests"
+	ConfigNamespace        = "openshift-config"
+	ConfigManagedNamespace = "openshift-config-managed"
+	InstallerConfigMap     = "openshift-install"
+	ManifestsConfigMap     = "openshift-install-manifests"
 )


### PR DESCRIPTION
[The API docs][1] recommend avoiding `trustedCA` (unless you happen to be the "proxy validator") and instead pulling the trust bundle from this managed namespace.  The docs also explain that the `trusted-ca-bundle` ConfigMap has already been merged with the system certificates, so we don't need to inject those locally.  If `trusted-ca-bundle` doesn't exist, we'll fall back to our local system store.

Our logic was touched most recently in 5968cdf933 (#231), which resolved the "looking in the wrong place" issue by looking at the `trustedCA` source (which feeds the proxy validator).  With this commit we switch that around and look at the proxy validator's output.

[1]: https://github.com/openshift/api/blob/f2a771e1a90ceb4e65f1ca2c8b11fc1ac6a66da8/config/v1/types_proxy.go#L44-L52