### PR TITLE
Bug 1800346: lib/resourcemerge/core: Fix panic on container removal

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -62,7 +62,8 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {
-	for i, existingContainer := range *existing {
+	for i := len(*existing) - 1; i >= 0; i-- {
+		existingContainer := &(*existing)[i]
 		var existingCurr *corev1.Container
 		for _, requiredContainer := range required {
 			if existingContainer.Name == requiredContainer.Name {

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -336,6 +336,27 @@ func TestEnsurePodSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove a container",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-A"},
+					corev1.Container{Name: "test-B"},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-B"},
+				},
+			},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{Name: "test-B"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull-request cherry-picks e8e80c2c8f (#282) back to the 4.2 branch.  But since f268b6d478 (#272) and its `EnsureServicePorts` was never backported to the 4.2 branch, I've only kept the container portion of e8e80c2c8f in this PR.