### PR TITLE
Bug 1768260: lib,pkg: provide detailed errors for workload failures

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -207,6 +207,16 @@ func SummaryForReason(reason, name string) string {
 		return "a cluster operator has not yet rolled out"
 	case "ClusterOperatorsNotAvailable":
 		return "some cluster operators have not yet rolled out"
+	case "WorkloadNotAvailable":
+		if len(name) > 0 {
+			return fmt.Sprintf("the workload %s has not yet successfully rolled out", name)
+		}
+		return "a workload has not yet rolled out"
+	case "WorkloadNotProgressing":
+		if len(name) > 0 {
+			return fmt.Sprintf("the workload %s cannot roll out", name)
+		}
+		return "a workload cannot roll out"
 	}
 
 	if strings.HasPrefix(reason, "UpdatePayload") {


### PR DESCRIPTION
waitFor{Deployment,Daemonset} now return UpdateError's so that the sync cycle can include detailed errors.

deployment:
- when replicafailure condition is true, returns WorkloadNotProgressing update error.
- when available condition is false or progressing is true, returns WorkloadNotAvailable update error.

daemonset:
It returns WorkloadNotAvailbale update error whenever the daemonset has not rolled out.