### PR TITLE
Bug 1797806: metrics: include upi installs in cluster_installer

### DIFF
--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -3,4 +3,5 @@ package internal
 const (
 	ConfigNamespace    = "openshift-config"
 	InstallerConfigMap = "openshift-install"
+	ManifestsConfigMap = "openshift-install-manifests"
 )


### PR DESCRIPTION
This is a follow-on to c1477328, which added the cluster_installer
series originally. Recently, the installer started injecting a new
ConfigMap (openshift-install-manifests), which includes information
about the manifest generation stage of the install. Because this phase
always happens, this ConfigMap is included in every cluster created by
this newer installer. We can now look at the presence of this new
ConfigMap and the absence of the openshift-install ConfigMap to
determine that the cluster was installed using UPI. We can additionally
look at its contents to determine information about the installer.