### PR TITLE
OWNERS: Add Scott Dodson as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,5 @@ approvers:
   - crawford
   - smarterclayton
   - abhinavdahiya
+  - sdodson
   - wking


### PR DESCRIPTION
The repo-scoped `OWNERS` file here isn't large, and the CVO is nobody's main focus.  Add group-lead @sdodson to broaden the set of folk who can be talked into approving changes during a maintainer shortage ;).