### PR TITLE
Bug 1782982: pkg/verify/verifyconfigmap: Use {algo}-{hash} prefixes

### DIFF
--- a/pkg/verify/verifyconfigmap/store.go
+++ b/pkg/verify/verifyconfigmap/store.go
@@ -85,10 +85,17 @@ func (s *Store) DigestSignatures(ctx context.Context, digest string) ([][]byte, 
 		s.rememberMostRecentConfigMaps(configMaps.Items)
 	}
 
+	parts := strings.SplitN(digest, ":", 3)
+	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return nil, fmt.Errorf("the provided digest must be of the form ALGO:HASH")
+	}
+	algo, hash := parts[0], parts[1]
+	prefix := fmt.Sprintf("%s-%s", algo, hash)
+
 	var signatures [][]byte
 	for _, cm := range items {
 		for k, v := range cm.BinaryData {
-			if strings.HasPrefix(k, digest) {
+			if strings.HasPrefix(k, prefix) {
 				signatures = append(signatures, v)
 			}
 		}


### PR DESCRIPTION
Instead of using the `{algo}:{hash}` digest directly, because [colons are not allowed in ConfigMap keys][1]:

```go
const configMapKeyFmt = `[-._a-zA-Z0-9]+`
```

The keys also have a [maximum length][1] of [253 characters][2], but sha256 digests are only a 6 char algorithm, 1 char delimiter, and 64 char hex hash, so there's plenty of space for user-defined suffixes in the ConfigMap keys.

I'm using a hyphen (`-`) as the delimiter, because neither the canonical `:` nor the `=` used for signature URIs are [allowed in ConfigMap keys][1].  Hyphens are not valid in algorithm-component, although they [are valid in algorithm-separator][3]:

```
digest              ::= algorithm ":" encoded
algorithm           ::= algorithm-component (algorithm-separator algorithm-component)*
algorithm-component ::= [a-z0-9]+
algorithm-separator ::= [+._-]
encoded             ::= [a-zA-Z0-9=_-]+
```

Unfortunately, the only characters [allowed in ConfigMap keys][1] but not [in the algorithm][3] are A-Z, and those don't seem like intuitive delimiters.  In the unlucky event that the ambiguity introduced by hyphen delimiters leads to us matching a prefix that was actually intended for a different digest, the collected signature will just fail to verify, and we'll move on to consider other keys, ConfigMaps, and eventually HTTP(S) URIs in search of valid signatures.

[1]: https://github.com/kubernetes/apimachinery/blob/v0.17.3/pkg/util/validation/validation.go#L375-L397
[2]: https://github.com/kubernetes/apimachinery/blob/v0.17.3/pkg/util/validation/validation.go#L158-L159
[3]: https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests