### PR TITLE
cvo: report only unavailable operators with cluster_operator_up

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -259,9 +259,8 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 			break
 		}
 		g := m.clusterOperatorUp.WithLabelValues(op.Name, firstVersion)
-		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorDegraded)
 		available := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable)
-		if available && !failing {
+		if available {
 			g.Set(1)
 		} else {
 			g.Set(0)

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -186,7 +186,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1"})
+				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": "10.1.5-1"})
 				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available"})
 				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Degraded"})
 				expectMetric(t, metrics[4], 1, map[string]string{"type": ""})


### PR DESCRIPTION
The `ClusterOperatorDown`[1] alert is described as:

> Cluster Operator XYZ has not been available for 10 mins

However, the metric we fire this alert on is based on "available" AND NOT "degraded", which means we also report "ClusterOperatorDown" for operators that are degraded (but still available).

Alternative for this PR could be fixing description of this alert, but I don't see degraded operator for longer than 10 minutes as something we need to fire critical alert on?

[1] https://github.com/openshift/cluster-version-operator/blob/master/install/0000_90_cluster-version-operator_02_servicemonitor.yaml#L47