### PR TITLE
Using optr.queue.ShutDown directly as upstream K8s is fixed now

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -323,9 +323,7 @@ func loadConfigMapVerifierDataFromUpdate(update *payload.Update, clientBuilder v
 // Run runs the cluster version operator until stopCh is completed. Workers is ignored for now.
 func (optr *Operator) Run(ctx context.Context, workers int) {
 	defer utilruntime.HandleCrash()
-	// TODO: when Kube 77170 is fixed we can remove the use of the once here
-	var shutdownOnce sync.Once
-	defer shutdownOnce.Do(func() { optr.queue.ShutDown() })
+	defer optr.queue.ShutDown()
 	stopCh := ctx.Done()
 	workerStopCh := make(chan struct{})
 
@@ -361,7 +359,7 @@ func (optr *Operator) Run(ctx context.Context, workers int) {
 	<-stopCh
 
 	// stop the queue, then wait for the worker to exit
-	shutdownOnce.Do(func() { optr.queue.ShutDown() })
+	optr.queue.ShutDown()
 	<-workerStopCh
 }
 


### PR DESCRIPTION
Upstream pull request https://github.com/kubernetes/kubernetes/pull/77170. It is available in upstream v1.15

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>