### PR TITLE
[WIP] Adding golangci-lint to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,9 @@ verify-codegen-crds:
 verify-codegen: verify-codegen-crds
 verify: verify-codegen
 .PHONY: update-codegen-crds update-codegen verify-codegen-crds verify-codegen verify
+
+# TODO: Add install step for golangci-lint version 1.24.0
+# TODO: Once we fix the resonable amount of lint issues, we need to make it default in the unit test
+.PHONY: lint
+lint:
+	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./lib/...

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,29 @@
+run:
+  deadline: 30m
+
+linters:
+  disable-all: true
+  enable:
+#  - gofmt
+#  - goimports
+#  - golint
+#  - gosimple
+#  - ineffassign
+#  - misspell
+#  - unused
+  - deadcode
+#  - govet
+#  - gocyclo
+#  - varcheck
+#  - structcheck
+#  - maligned
+#  - errcheck
+#  - interfacer
+#  - unconvert
+#  - goconst
+#  - gosec
+#  - megacheck
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/openshift/cluster-version-operator


### PR DESCRIPTION
- [ ] Add install step for golangci-lint version 1.24.0
- [ ] Fix the dead code
```
golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./lib/...   
lib/validation/validation.go:72:6: `hasAmbiguousPayloadForVersion` is unused (deadcode)
func hasAmbiguousPayloadForVersion(config *configv1.ClusterVersion, version string) bool {
     ^
lib/resourcemerge/core.go:346:6: `setStringSliceIfSet` is unused (deadcode)
func setStringSliceIfSet(modified *bool, existing *[]string, required []string) {
     ^
pkg/payload/task_graph.go:391:6: `covers` is unused (deadcode)
func covers(all []int, some []int) bool {
     ^
pkg/cvo/internal/generic.go:101:6: `createPatch` is unused (deadcode)
func createPatch(original, modified runtime.Object) ([]byte, error) {
     ^
pkg/cvo/sync_worker.go:935:6: `ownerRefModifier` is unused (deadcode)
func ownerRefModifier(config *configv1.ClusterVersion) resourcebuilder.MetaV1ObjectModifierFunc {
     ^
pkg/cvo/cvo_scenarios_test.go:2497:6: `waitFor` is unused (deadcode)
func waitFor(t *testing.T, fn func() bool) {
     ^
pkg/cvo/cvo_test.go:3177:6: `expectUpdate` is unused (deadcode)
func expectUpdate(t *testing.T, a ktesting.Action, resource, namespace string, obj interface{}) {
``` 
