### PR TITLE
OWNERS: Document 'component' property

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,7 @@ approvers:
   - wking
   - vrutkovs
   - jottofar
+
+# This is a Red Hat extension, mapping the Git repository to an OpenShift Bugzilla component:
+# https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform
 component: "Cluster Version Operator"


### PR DESCRIPTION
Example of OpenShift components:

```console
$ curl -sH Accept:application/json -H Content-Type:application/json --data '{"jsonrpc":"2.0","method":"SelectizeJS.list_components","id":1,"params":[{"term":"..","descrs":1,"disabled":0,"product":"v314_product"}]}' https://bugzilla.redhat.com/jsonrpc.cgi | jq -r '[.result[].value] | sort[]'
Build
Cincinnati
Cloud Compute
Cloud Credential Operator
Cluster Loader
Cluster Version Operator
Compliance Operator
...
```

Based on @sdodson's [comment][1]:

> It's used downstream to facilitate mapping to BZ Components.

[1]: https://github.com/openshift/cluster-version-operator/pull/344#issuecomment-610902992