### PR TITLE
Bug 1826349: hack/build-go: Use OS_GIT_VERSION if available

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -14,7 +14,8 @@ GOARCH=${GOACH:-${GOHOSTARCH}}
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"
 
-if [ -z ${VERSION_OVERRIDE+a} ]; then
+VERSION_OVERRIDE=${VERSION_OVERRIDE:-${OS_GIT_VERSION:-}}
+if [ -z "${VERSION_OVERRIDE:-}" ]; then
 	echo "Using version from git..."
 	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi


### PR DESCRIPTION

This would update the build script, so that OCP could be built using
a custom semver string from OS_GIT_VERSION instead of `git describe` output