### PR TITLE
pkg/cvo/sync_worker: Log precondition handling

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -511,7 +511,7 @@ func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers in
 		payloadUpdate.VerifiedImage = info.Verified
 		payloadUpdate.LoadedAt = time.Now()
 
-		// need to make sure the payload is only set when the preconditions have been successfull
+		// need to make sure the payload is only set when the preconditions have been successful
 		if !info.Local && len(w.preconditions) > 0 {
 			reporter.Report(SyncWorkerStatus{
 				Generation:  work.Generation,


### PR DESCRIPTION
To make it easier to debug precondition failures like [rhbz#1827166][1].

This backports #360 to 4.4 for testing.  It also backports #346 to avoid a rebase conflict.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1827166