### PR TITLE
Update readme to include fast fill logic

### DIFF
--- a/docs/dev/clusteroperator.md
+++ b/docs/dev/clusteroperator.md
@@ -33,6 +33,11 @@ There are 2 important things that need to be set in the ClusterOperator Custom R
 - `.metadata.name`: name for finding the live instance
 - `.status.versions[name=operator].version`: this is the version that the operator is expected to report. ClusterVersionOperator only respects the `.status.conditions` from instances that report their version.
 
+Additionally you might choose to include some fundamental relatedObjects.
+The must-gather and insights operator depend on cluster operators and related objects in order to identify resources to create.
+Because cluster operators are delegated to the operator install and upgrade failures of new operators can fail to gather the requisite info if the cluster degrades before those steps.
+To mitigate this scenario the ClusterVersionOperator will do a best effort to fast-fill cluster-operators using the ClusterOperator Custom Resource in /manifests. 
+
 Example:
 
 For a cluster operator `my-cluster-operator`, that is reporting its status using a ClusterOperator instance named `my-cluster-operator`.


### PR DESCRIPTION
This https://github.com/openshift/cluster-version-operator/pull/318 introduced a PrecreatingMode which actually let the CVO to push the clusterOperator in manifests.
This changes previous behaviour and enables a new pattern for individual operators to set related objects into the clusterOperator defined in manifests/ https://github.com/openshift/cluster-kube-apiserver-operator/pull/833
https://github.com/openshift/cluster-etcd-operator/pull/312
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/398