### PR TITLE
Bug 1834568: Add cert to service to support https

### DIFF
--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: cluster-version-operator
   annotations:
+    service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   type: ClusterIP


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1809195 is to add
https metrics target. The PR to fix that bug is failing CI upgrade
test since the 0001_00_cluster-version-operator_03_service with the
service.beta.openshift.io/serving-cert-secret-name annotation is
coming too late. So the monitoring tools aren't creating the secret
causing the CVO container to fail to start.

This PR adds the annotation to the service so that change can be
fielded ahead of remaining changes necessary to support https
target.