### PR TITLE
install/0000_90_cluster-version-operator_02_servicemonitor: Drop "unstable" from ClusterOperatorDegraded

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -52,7 +52,7 @@ spec:
         severity: critical
     - alert: ClusterOperatorDegraded
       annotations:
-        message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 10 mins. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
+        message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 10 mins. Operator is degraded because {{ "{{ $labels.reason }}" }}.
       expr: |
         cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"} == 1
       for: 10m


### PR DESCRIPTION
If we considered `Degraded=True` something that impacted update stability, I expect we'd want a guard against it that blocked new updates until admins coaxed the operator back into happiness.  This commit softens wording from af62f04483 (#232).

/assign @abhinavdahiya