### PR TITLE
Bug 1838872: Avoid pre-creating clusteroperators that should be excluded

### DIFF
--- a/hack/cluster-version-util/task_graph.go
+++ b/hack/cluster-version-util/task_graph.go
@@ -30,7 +30,7 @@ func newTaskGraphCmd() *cobra.Command {
 
 func runTaskGraphCmd(cmd *cobra.Command, args []string) error {
 	manifestDir := args[0]
-	release, err := payload.LoadUpdate(manifestDir, "")
+	release, err := payload.LoadUpdate(manifestDir, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -236,7 +236,7 @@ func (vcb *verifyClientBuilder) HTTPClient() (*http.Client, error) {
 // controller that loads and applies content to the cluster. It returns an error if the payload appears to
 // be in error rather than continuing.
 func (optr *Operator) InitializeFromPayload(restConfig *rest.Config, burstRestConfig *rest.Config) error {
-	update, err := payload.LoadUpdate(optr.defaultPayloadDir(), optr.releaseImage)
+	update, err := payload.LoadUpdate(optr.defaultPayloadDir(), optr.releaseImage, optr.exclude)
 	if err != nil {
 		return fmt.Errorf("the local release contents are invalid - no current version can be determined from disk: %v", err)
 	}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -76,6 +76,7 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
 		client:                      client,
 		cvLister:                    &clientCVLister{client: client},
+		exclude:                     "exclude-test",
 	}
 
 	dynamicScheme := runtime.NewScheme()
@@ -90,7 +91,7 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 		wait.Backoff{
 			Steps: 1,
 		},
-		"",
+		"exclude-test",
 	)
 	o.configSync = worker
 

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_20_a_exclude.yml
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_20_a_exclude.yml
@@ -1,0 +1,6 @@
+kind: Test
+apiVersion: v1
+metadata:
+  name: file-20-yml
+  annotations:
+    exclude.release.openshift.io/exclude-test: "true"

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -107,7 +107,7 @@ type Update struct {
 	Manifests    []lib.Manifest
 }
 
-func LoadUpdate(dir, releaseImage string) (*Update, error) {
+func LoadUpdate(dir, releaseImage, excludeIdentifier string) (*Update, error) {
 	payload, tasks, err := loadUpdatePayloadMetadata(dir, releaseImage)
 	if err != nil {
 		return nil, err
@@ -154,6 +154,15 @@ func LoadUpdate(dir, releaseImage string) (*Update, error) {
 				errs = append(errs, errors.Wrapf(err, "error parsing %s", file.Name()))
 				continue
 			}
+			// Filter out manifests that should be excluded based on annotation
+			filteredMs := []lib.Manifest{}
+			for _, manifest := range ms {
+				if shouldExclude(excludeIdentifier, &manifest) {
+					continue
+				}
+				filteredMs = append(filteredMs, manifest)
+			}
+			ms = filteredMs
 			for i := range ms {
 				ms[i].OriginalFilename = filepath.Base(file.Name())
 			}
@@ -177,6 +186,12 @@ func LoadUpdate(dir, releaseImage string) (*Update, error) {
 	payload.ManifestHash = base64.URLEncoding.EncodeToString(hash.Sum(nil))
 	payload.Manifests = manifests
 	return payload, nil
+}
+
+func shouldExclude(excludeIdentifier string, manifest *lib.Manifest) bool {
+	excludeAnnotation := fmt.Sprintf("exclude.release.openshift.io/%s", excludeIdentifier)
+	annotations := manifest.Object().GetAnnotations()
+	return annotations != nil && annotations[excludeAnnotation] == "true"
 }
 
 // ValidateDirectory checks if a directory can be a candidate update by

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -104,7 +104,7 @@ func Test_loadUpdatePayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadUpdate(tt.args.dir, tt.args.releaseImage)
+			got, err := LoadUpdate(tt.args.dir, tt.args.releaseImage, "exclude-test")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadUpdatePayload() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -487,7 +487,7 @@ func Test_TaskGraph_real(t *testing.T) {
 	if len(path) == 0 {
 		t.Skip("TEST_GRAPH_PATH unset")
 	}
-	p, err := LoadUpdate(path, "arbitrary/image:1")
+	p, err := LoadUpdate(path, "arbitrary/image:1", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In 4.5 we added code to precreate cluster-operator resources. However, in the precreate loop we're not checking whether resources should be excluded based on annotation. This adds a check to the loop so we can preserve pre-4.5 behavior.