### PR TITLE
Bug 1838497: pkg/cvo/sync_worker: Do not treat "All errors were context errors..." as success

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -626,8 +626,8 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 	if precreateObjects {
 		payload.RunGraph(ctx, graph, 8, func(ctx context.Context, tasks []*payload.Task) error {
 			for _, task := range tasks {
-				if contextIsCancelled(ctx) {
-					return cr.CancelError()
+				if err := ctx.Err(); err != nil {
+					return cr.ContextError(err)
 				}
 				if task.Manifest.GVK != configv1.SchemeGroupVersion.WithKind("ClusterOperator") {
 					continue
@@ -645,8 +645,8 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 	// update each object
 	errs := payload.RunGraph(ctx, graph, maxWorkers, func(ctx context.Context, tasks []*payload.Task) error {
 		for _, task := range tasks {
-			if contextIsCancelled(ctx) {
-				return cr.CancelError()
+			if err := ctx.Err(); err != nil {
+				return cr.ContextError(err)
 			}
 			cr.Update()
 
@@ -690,11 +690,11 @@ func init() {
 	)
 }
 
-type errCanceled struct {
+type errContext struct {
 	err error
 }
 
-func (e errCanceled) Error() string { return e.err.Error() }
+func (e errContext) Error() string { return e.err.Error() }
 
 // consistentReporter hides the details of calculating the status based on the progress
 // of the graph runner.
@@ -731,7 +731,7 @@ func (r *consistentReporter) Error(err error) {
 	copied := r.status
 	copied.Step = "ApplyResources"
 	copied.Fraction = float32(r.done) / float32(r.total)
-	if !isCancelledError(err) {
+	if !isContextError(err) {
 		copied.Failure = err
 	}
 	r.reporter.Report(copied)
@@ -752,10 +752,10 @@ func (r *consistentReporter) Errors(errs []error) error {
 	return err
 }
 
-func (r *consistentReporter) CancelError() error {
+func (r *consistentReporter) ContextError(err error) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	return errCanceled{fmt.Errorf("update was cancelled at %d of %d", r.done, r.total)}
+	return errContext{fmt.Errorf("update %s at %d of %d", err, r.done, r.total)}
 }
 
 func (r *consistentReporter) Complete() {
@@ -771,11 +771,11 @@ func (r *consistentReporter) Complete() {
 	r.reporter.Report(copied)
 }
 
-func isCancelledError(err error) bool {
+func isContextError(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := err.(errCanceled)
+	_, ok := err.(errContext)
 	return ok
 }
 
@@ -796,11 +796,12 @@ func isImageVerificationError(err error) bool {
 // not truly an error (cancellation).
 // TODO: take into account install vs upgrade
 func summarizeTaskGraphErrors(errs []error) error {
-	// we ignore cancellation errors since they don't provide good feedback to users and are an internal
-	// detail of the server
-	err := errors.FilterOut(errors.NewAggregate(errs), isCancelledError)
+	// we ignore context errors (canceled or timed out) since they don't
+	// provide good feedback to users and are an internal detail of the
+	// server
+	err := errors.FilterOut(errors.NewAggregate(errs), isContextError)
 	if err == nil {
-		klog.V(4).Infof("All errors were cancellation errors: %v", errs)
+		klog.V(4).Infof("All errors were context errors: %v", errs)
 		return nil
 	}
 	agg, ok := err.(errors.Aggregate)
@@ -968,16 +969,6 @@ func ownerRefModifier(config *configv1.ClusterVersion) resourcebuilder.MetaV1Obj
 	oref := metav1.NewControllerRef(config, ownerKind)
 	return func(obj metav1.Object) {
 		obj.SetOwnerReferences([]metav1.OwnerReference{*oref})
-	}
-}
-
-// contextIsCancelled returns true if the provided context is cancelled.
-func contextIsCancelled(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	default:
-		return false
 	}
 }
 

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -668,8 +668,10 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 		return nil
 	})
 	if len(errs) > 0 {
-		err := cr.Errors(errs)
-		return err
+		if err := cr.Errors(errs); err != nil {
+			return err
+		}
+		return errs[0]
 	}
 
 	// update the status


### PR DESCRIPTION
With this commit, I drop `contextIsCancelled` in favor of `Context.Err()`. From [the docs][1]:

> If Done is not yet closed, Err returns nil.  If Done is closed, Err returns a non-nil error explaining why: Canceled if the context was canceled or DeadlineExceeded if the context's deadline passed.  After Err returns a non-nil error, successive calls to Err return the same error.

I dunno why we'd been checking `Done()` instead, but `contextIsCancelled` dates back to 961873d66a (#82).

I've also generalized a number of `*Cancel*` helpers to be `*Context*` to remind folks that `Context.Err()` can be `DeadlineExceeded` as well as `Canceled`, and the CVO uses both `WithCancel` and `WithTimeout`.  The new error messages will be either:

    update context deadline exceeded at 1 of 2

or:

    update context canceled at 1 of 2

Instead of always claiming:

    update was cancelled at 1 of 2

[1]: https://golang.org/pkg/context/#Context