### PR TITLE
pkg/cvo/sync_worker: Promote "Sync succeeded" to v4

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -329,7 +329,9 @@ func (w *SyncWorker) Start(ctx context.Context, maxWorkers int) {
 				utilruntime.HandleError(fmt.Errorf("unable to synchronize image (waiting %s): %v", interval, err))
 				continue
 			}
-			klog.V(5).Infof("Sync succeeded, reconciling")
+			if work.State != payload.ReconcilingPayload {
+				klog.V(4).Infof("Sync succeeded, transitioning from %s to %s", work.State, payload.ReconcilingPayload)
+			}
 
 			work.Completed++
 			work.State = payload.ReconcilingPayload


### PR DESCRIPTION
To match the existing v4 logs for:

    Running sync %s (force=%t) on generation %d in state %s at attempt %d

To avoid excessive noise, also restrict it to edge transitions between states (the `Running sync ...` line exposes the level) and include the source state in the logged message.  Because the * -> `Reconciling` transition is important, and deserves at least as much weight in the logs as "we're about to start a new sync cycle" and a log entry that comes before the next `Until` sleep.