### PR TITLE
pkg/cvo/sync_worker: Flatten a nested 'if changed'

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -382,10 +382,8 @@ func (w *SyncWorker) calculateNext(work *SyncWork) bool {
 	// the state Update() calculated (to allow us to start in reconciling)
 	if work.Empty() {
 		work.State = w.work.State
-	} else {
-		if changed {
-			work.State = payload.UpdatingPayload
-		}
+	} else if changed {
+		work.State = payload.UpdatingPayload
 	}
 	// always clear the completed variable if we are not reconciling
 	if work.State != payload.ReconcilingPayload {


### PR DESCRIPTION
One less level of nesting makes for slightly easier reading.  The nested `if changed` landed when `sync_worker.go` was born in 961873d66a (#82).