### PR TITLE
pkg/cvo/sync_worker: Drop unused 'reconciling' from SyncWorker

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -130,7 +130,6 @@ type SyncWorker struct {
 	retriever     PayloadRetriever
 	builder       payload.ResourceBuilder
 	preconditions precondition.List
-	reconciling   bool
 
 	// minimumReconcileInterval is the minimum time between reconcile attempts, and is
 	// used to define the maximum backoff interval when syncOnce() returns an error.


### PR DESCRIPTION
The property landed with SyncWorker in 961873d66a (#82), but has never been used.