### PR TITLE
pkg/payload/task_graph: "on" -> "on worker" logging

### DIFF
--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -572,7 +572,7 @@ func RunGraph(ctx context.Context, graph *TaskGraph, maxParallelism int, fn func
 						klog.V(4).Infof("No more work for %d", job)
 						return
 					}
-					klog.V(4).Infof("Running %d on %d", runTask.index, job)
+					klog.V(4).Infof("Running %d on worker %d", runTask.index, job)
 					err := fn(nestedCtx, runTask.tasks)
 					completeCh <- taskStatus{index: runTask.index, success: err == nil}
 					if err != nil {


### PR DESCRIPTION
The old format is from cb4e0375e6 (#88), but @abhinavdahiya [points out][1] that `on %d` could use a bit more context.

[1]: https://github.com/openshift/cluster-version-operator/pull/264#discussion_r433554377