### PR TITLE
Bug 1843732: pkg/cvo/sync_worker: Do not treat "All errors were context errors..." as success

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -636,8 +636,10 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 		return nil
 	})
 	if len(errs) > 0 {
-		err := cr.Errors(errs)
-		return err
+		if err := cr.Errors(errs); err != nil {
+			return err
+		}
+		return errs[0]
 	}
 
 	// update the status


### PR DESCRIPTION
Cherry-picked from #378 and edited to resolve context conflicts because release-4.4 lacks #318.