### PR TITLE
Bug 1847672: Expand supported set of probe field mutations

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -164,6 +164,10 @@ func ensureProbePtr(modified *bool, existing **corev1.Probe, required *corev1.Pr
 
 func ensureProbe(modified *bool, existing *corev1.Probe, required corev1.Probe) {
 	setInt32(modified, &existing.InitialDelaySeconds, required.InitialDelaySeconds)
+	setInt32(modified, &existing.TimeoutSeconds, required.TimeoutSeconds)
+	setInt32(modified, &existing.PeriodSeconds, required.PeriodSeconds)
+	setInt32(modified, &existing.SuccessThreshold, required.SuccessThreshold)
+	setInt32(modified, &existing.FailureThreshold, required.FailureThreshold)
 
 	ensureProbeHandler(modified, &existing.Handler, required.Handler)
 }

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -359,6 +359,98 @@ func TestEnsurePodSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "modify container readiness probe",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						ReadinessProbe: &corev1.Probe{
+							InitialDelaySeconds: 1,
+							TimeoutSeconds:      2,
+							PeriodSeconds:       3,
+							SuccessThreshold:    4,
+							FailureThreshold:    5,
+						},
+					},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						ReadinessProbe: &corev1.Probe{
+							InitialDelaySeconds: 7,
+							TimeoutSeconds:      8,
+							PeriodSeconds:       9,
+							SuccessThreshold:    10,
+							FailureThreshold:    11,
+						},
+					},
+				},
+			},
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						ReadinessProbe: &corev1.Probe{
+							InitialDelaySeconds: 7,
+							TimeoutSeconds:      8,
+							PeriodSeconds:       9,
+							SuccessThreshold:    10,
+							FailureThreshold:    11,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "modify container liveness probe",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						LivenessProbe: &corev1.Probe{
+							InitialDelaySeconds: 1,
+							TimeoutSeconds:      2,
+							PeriodSeconds:       3,
+							SuccessThreshold:    4,
+							FailureThreshold:    5,
+						},
+					},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						LivenessProbe: &corev1.Probe{
+							InitialDelaySeconds: 7,
+							TimeoutSeconds:      8,
+							PeriodSeconds:       9,
+							SuccessThreshold:    10,
+							FailureThreshold:    11,
+						},
+					},
+				},
+			},
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						LivenessProbe: &corev1.Probe{
+							InitialDelaySeconds: 7,
+							TimeoutSeconds:      8,
+							PeriodSeconds:       9,
+							SuccessThreshold:    10,
+							FailureThreshold:    11,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Before this change, only the initialDelaySeconds field of probes could be
updated. This patch expands the set of supported fields to include all the
other int32 fields of probes so that CVO will roll out such changes.