### PR TITLE
Bug 1809195: Remove '-' from servicemonitor spec

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-  - interval: 30s
+    interval: 30s
     port: metrics
     scheme: https
     tlsConfig:


### PR DESCRIPTION
During modifications for
https://github.com/openshift/cluster-version-operator/pull/358/ a new first
line of spec was added and therefore next line should not contain '-'.