### PR TITLE
WIP: *: Unify terminology around "upgrades" instead of "updates"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ go test ./...
 export KUBECONFIG=<admin kubeconfig>
 TEST_INTEGRATION=1 go test ./... -test.run=^TestIntegration
 ```
+
+## Terminology
+
+The CVO manages release upgrades.
+While some folks try to distinguish between bugfix "updates" and new-feature "upgrades", the CVO does not make that distinction.
+When we are not constrained by existing APIs, we prefer to use the more generic "upgrades" terminology.

--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -13,7 +13,7 @@ spec:
     args:
       - "start"
       - "--release-image={{.ReleaseImage}}"
-      - "--enable-auto-update=false"
+      - "--enable-auto-upgrade=false"
       - "--enable-default-cluster-version=false"
       - "--v=4"
       - "--kubeconfig=/etc/kubernetes/kubeconfig"

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -12,7 +12,7 @@ import (
 var (
 	imageCmd = &cobra.Command{
 		Use:     "image",
-		Short:   "Returns image for requested short-name from UpdatePayload",
+		Short:   "Returns image for requested short-name from UpgradePayload",
 		Long:    "",
 		Example: "%[1] image <short-name>",
 		Run:     runImageCmd,

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -12,7 +12,7 @@ import (
 var (
 	renderCmd = &cobra.Command{
 		Use:   "render",
-		Short: "Renders the UpdatePayload to disk.",
+		Short: "Renders the UpgradePayload to disk.",
 		Long:  "",
 		Run:   runRenderCmd,
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,7 +27,7 @@ func init() {
 	cmd.PersistentFlags().StringVar(&opts.ListenAddr, "listen", opts.ListenAddr, "Address to listen on for metrics")
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", opts.Kubeconfig, "Kubeconfig file to access a remote cluster (testing only)")
 	cmd.PersistentFlags().StringVar(&opts.NodeName, "node-name", opts.NodeName, "kubernetes node name CVO is scheduled on.")
-	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpdate, "enable-auto-update", opts.EnableAutoUpdate, "Enables the autoupdate controller.")
+	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpgrade, "enable-auto-upgrade", opts.EnableAutoUpgrade, "Enables the autoupgrade controller.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableDefaultClusterVersion, "enable-default-cluster-version", opts.EnableDefaultClusterVersion, "Allows the operator to create a ClusterVersion object if one does not already exist.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The Openshift release image url.")
 	cmd.PersistentFlags().StringVar(&opts.ServingCertFile, "serving-cert-file", opts.ServingCertFile, "The X.509 certificate file for serving metrics over HTTPS.  You must set both --serving-cert-file and --serving-key-file, or neither.")

--- a/docs/dev/clusteroperator.md
+++ b/docs/dev/clusteroperator.md
@@ -66,17 +66,17 @@ expectations around the outcome and have specific guarantees that apply.
 Of note, in the docs below we use the word `operand` to describe the "thing the operator manages", which might be:
 
 * A deployment or daemonset, like a cluster networking provider
-* An API exposed via a CRD and the operator updates other API objects, like a secret generator
+* An API exposed via a CRD and the operator upgrades other API objects, like a secret generator
 * Just some controller loop invariant that the operator manages, like "all certificate signing requests coming from valid machines are approved"
 
-An operand doesn't have to be code running on cluster - that might be the operator. When we say "is the operand available" that might mean "the new code is rolled out" or "all old API objects have been updated" or "we're able to sign certificate requests"
+An operand doesn't have to be code running on cluster - that might be the operator. When we say "is the operand available" that might mean "the new code is rolled out" or "all old API objects have been upgraded" or "we're able to sign certificate requests"
 
 Here are the guarantees components can get when they follow the rules we define:
 
 1. Cause an installation to fail because a component is not able to become available for use
 2. Cause an upgrade to hang because a component is not able to successfully reach the new upgrade
 3. Prevent a user from clicking the upgrade button because components have one or more preflight criteria that are not met (e.g. nodes are at version 4.0 so the control plane can't be upgraded to 4.2 and break N-1 compat)
-4. Ensure other components are upgraded *after* your component (guarantee "happens before" in upgrades, such as kube-apiserver being updated before kube-controller-manager)
+4. Ensure other components are upgraded *after* your component (guarantee "happens before" in upgrades, such as kube-apiserver being upgraded before kube-controller-manager)
 
 There are a set of guarantees components are expected to honor in return:
 
@@ -139,7 +139,7 @@ status:
 
 #### Version reporting during an upgrade
 
-When your operator begins rolling out a new version it must continue to report the previous operator version in its ClusterOperator status. While any of your operands are still running software from the previous version then you are in a mixed version state, and you should continue to report the previous version. As soon as you can guarantee you are not and will not run any old versions of your operands, you can update the operator version on your ClusterOperator status.
+When your operator begins rolling out a new version it must continue to report the previous operator version in its ClusterOperator status. While any of your operands are still running software from the previous version then you are in a mixed version state, and you should continue to report the previous version. As soon as you can guarantee you are not and will not run any old versions of your operands, you can upgrade the operator version on your ClusterOperator status.
 
 ### Conditions
 
@@ -148,7 +148,7 @@ Refer [the godocs](https://godoc.org/github.com/openshift/api/config/v1#ClusterS
 In general, ClusterOperators should contain at least three core conditions:
 
 * `Progressing` must be true if the operator is actually making change to the operand.
-The change may be anything: desired user state, desired user configuration, observed configuration, version update, etc.
+The change may be anything: desired user state, desired user configuration, observed configuration, version upgrade, etc.
 If this is false, it means the operator is not trying to apply any new state.
 If it remains true for an extended period of time, it suggests something is wrong in the cluster.  It can probably wait until Monday.
 * `Available` must be true if the operand is functional and available in the cluster at the level in status.
@@ -173,7 +173,7 @@ If the controller reaches 4.0.1, the conditions might be:
 
 If an error blocks reaching 4.0.1, the conditions might be:
 
-* `Degraded` is true with a detailed message `Unable to apply 4.0.1: could not update 0000_70_network_deployment.yaml because the resource type NetworkConfig has not been installed on the server.`
+* `Degraded` is true with a detailed message `Unable to apply 4.0.1: could not upgrade 0000_70_network_deployment.yaml because the resource type NetworkConfig has not been installed on the server.`
 * `Available` is true with message `Cluster has deployed 4.0.0`
 * `Progressing` is true with message `Unable to apply 4.0.1: a required object is missing`
 

--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -3,9 +3,9 @@
 The `ClusterVersion` is a custom resource object which holds the current version of the cluster.
 This object is used by the administrator to declare their target cluster state, which the cluster-version operator (CVO) then works to transition the cluster to that target state.
 
-## Finding your current update image
+## Finding your current release image
 
-You can extract the current update image from the `ClusterVersion` object:
+You can extract the current release image from the `ClusterVersion` object:
 
 ```console
 $ oc get clusterversion -o jsonpath='{.status.current.image}{"\n"}' version
@@ -81,7 +81,7 @@ EOF
 $ oc patch clusterversion version --type json -p "$(cat version-patch.yaml)"
 ```
 
-You can verify the update with:
+You can verify the upgrade with:
 
 ```console
 $ oc get -o json clusterversion version | jq .spec.overrides

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -11,7 +11,7 @@ The cluster version is reported as seconds since the epoch with labels for `vers
 * `failure` - if the failure condition is set, reports the last transition time for the condition.
 * `desired` - reported if different from current as the most recent timestamp on the cluster version
 * `completed` - the time the most recent version was completely applied, or absent if not reached
-* `updating` - if the operator is moving to a new version, the time the update started
+* `updating` - if the operator is moving to a new version, the time the upgrade started
 
 The `from_version` label is set where appropriate and is the previous completed version for the provided `type`. Empty for
 `initial`, and otherwise empty if there was no previous completed version (still installing).

--- a/docs/dev/operators.md
+++ b/docs/dev/operators.md
@@ -2,9 +2,9 @@
 
 The CVO installs other operators onto a cluster. It is responsible for applying the manifests each
 operator uses (without any parameterization) and for ensuring an order that installation and
-updates follow.
+upgrades follow.
 
-## What is the order that resources get created/updated in?
+## What is the order that resources get created/upgraded in?
 
 The CVO will load a release image and look at the contents of two directories: `/manifests` and
 `/release-manifests` within that image. The `/manifests` directory is part of the CVO image and
@@ -31,8 +31,8 @@ components that have the same run level - for instance, `0000_70_cluster-monitor
 preserving the order of tasks within the component.
 
 Ordering is only applied during upgrades, where some components rely on another component
-being updated first. As a convenience, the CVO guarantees that components at an earlier
-run level will be created or updated before your component is invoked. Note however that
+being upgraded first. As a convenience, the CVO guarantees that components at an earlier
+run level will be created or upgraded before your component is invoked. Note however that
 components without `ClusterOperator` objects defined may not be fully deployed when your
 component is executed, so always ensure your prerequisites know that they must correctly
 obey the `ClusterOperator` protocol to be available. More sophisticated components should
@@ -98,7 +98,7 @@ When your manifests are added to the release image, they’ll be given a prefix 
 
 Only manifests with the extensions `.yaml`, `.yml`, or `.json` will be applied, like `kubectl create -f DIR`.
 
-### What if I only want the CVO to create my resource, but never update it?
+### What if I only want the CVO to create my resource, but never upgrade it?
 
 This is only applicable to cases where the contents of a resource are not managed, but the presence is required for
 usability.  Today the only known use-case is config.openshift.io, so that `oc edit foo.config.openshift.io` "just works".

--- a/docs/dev/upgrades.md
+++ b/docs/dev/upgrades.md
@@ -12,7 +12,7 @@ During upgrade we bias towards predictable ordering for operators that lack soph
 
 Currently, upgrades proceed in operator order without distinguishing between node and control plane components. Future improvements may allow nodes to upgrade independently and at different schedules to reduce production impact. This in turn complicates the investment operator teams must make in testing and understanding how to version their control plane components independently of node infrastructure.
 
-All components must be N-1 minor version (4.y and 4.y-1) compatible - a component must update its operator first, then its dependents.  All operators and control plane components MUST handle running with their dependents at a N-1 minor version for extended periods and test in that scenario.
+All components must be N-1 minor version (4.y and 4.y-1) compatible - a component must upgrade its operator first, then its dependents.  All operators and control plane components MUST handle running with their dependents at a N-1 minor version for extended periods and test in that scenario.
 
 ## Generalized ordering
 
@@ -55,5 +55,5 @@ Which in practice can be described in runlevels:
 0000_60_*: reserved
 0000_70_*: disruptive node-level components: dns, sdn, multus
 0000_80_*: machine operators
-0000_90_*: reserved for any post-machine updates
+0000_90_*: reserved for any post-machine upgrades
 ```

--- a/docs/user/reconciliation.md
+++ b/docs/user/reconciliation.md
@@ -145,7 +145,7 @@ After pushing the merged CustomResourceDefinition into the cluster, the builder 
 
 The builder does not block after an initial DaemonSet push (when the in-cluster object has generation 1).
 
-For subsequent updates, the builder blocks until:
+For subsequent upgrades, the builder blocks until:
 
 * The in-cluster object's observed generation catches up with the specified generation.
 * Pods with the release-image-specified configuration are scheduled on each node.
@@ -155,7 +155,7 @@ For subsequent updates, the builder blocks until:
 
 The builder does not block after an initial Deployment push (when the in-cluster object has generation 1).
 
-For subsequent updates, the builder blocks until:
+For subsequent upgrades, the builder blocks until:
 
 * The in-cluster object's observed generation catches up with the specified generation.
 * Sufficient pods with the release-image-specified configuration are scheduled to fulfill the requested `replicas`.
@@ -167,7 +167,7 @@ After pushing the merged Job into the cluster, the builder blocks until the Job 
 
 The cluster-version operator will panic if spec.selector is set because there are no clear use-cases for setting it in release manifests.
 
-Subsequent updates:
+Subsequent upgrades:
 
 * The cluster-version operator is currently unable to delete and recreate a Job to track changes in release manifests. Please avoid making changes to Job manifests until the cluster-version operator supports Job delete/recreate.
-* A Job's spec.selector will never be updated because spec.selector is immutable.
+* A Job's spec.selector will never be upgraded because spec.selector is immutable.

--- a/docs/user/status.md
+++ b/docs/user/status.md
@@ -5,13 +5,13 @@ This document describes those conditions and, where appropriate, suggests possib
 
 ## RetrievedUpdates
 
-When `RetrievedUpdates` is `True`, the CVO is succesfully retrieving updates, which is good.
+When `RetrievedUpdates` is `True`, the CVO is succesfully retrieving upgrades, which is good.
 When `RetrievedUpdates` is `False`, `reason` will be set to explain why, as discussed in the following subsections.
-In all cases, the impact is that the cluster will not be able to retrieve recommended updates, so cluster admins will need to monitor for available updates on their own or risk falling behind on security or other bugfixes.
+In all cases, the impact is that the cluster will not be able to retrieve recommended upgrades, so cluster admins will need to monitor for available upgrades on their own or risk falling behind on security or other bugfixes.
 
 ### NoUpstream
 
-No `upstream` server has been set to retrieve updates.
+No `upstream` server has been set to retrieve upgrades.
 
 Fix by setting `spec.upstream` in ClusterVersion to point to a [Cincinnati][] server, for example https://api.openshift.com/api/upgrades_info/v1/graph .
 
@@ -27,7 +27,7 @@ The configured `clusterID` is not a valid UUID.
 
 Fix by setting `spec.clusterID` to a valid UUID.
 The UUID should be unique to a given cluster, because it is the default value used for reporting Telemetry and Insights.
-It may also be used by the CVO when making Cincinnati requests, so that Cincinnati can return update recommentations tailored to the specific cluster.
+It may also be used by the CVO when making Cincinnati requests, so that Cincinnati can return upgrade recommendations tailored to the specific cluster.
 
 ### NoArchitecture
 
@@ -38,7 +38,7 @@ There is no mitigation short of updating to a new release image with a fixed CVO
 
 #### Impact
 
-The cluster will not be able to retrieve recommended updates, so cluster admins will need to monitor for available updates on their own or risk falling behind on security or other bugfixes.
+The cluster will not be able to retrieve recommended upgrades, so cluster admins will need to monitor for available upgrades on their own or risk falling behind on security or other bugfixes.
 
 If this happens it is a CVO coding error.
 There is no mitigation short of updating to a new release image with a fixed CVO.
@@ -52,7 +52,7 @@ There is no mitigation short of updating to a new release image with fixed metad
 
 ### NoChannel
 
-The update `channel` has not been configured.
+The upgrade `channel` has not been configured.
 
 Fix by setting `channel` to [a valid value][channels], e.g. `stable-4.3`.
 
@@ -100,7 +100,7 @@ The currently installed version was not found in the configured `channel`.
 This usually means that the configured `channel` is known to Cincinnati, but the cluster's current version is not found in that channel's graph.
 Fix by setting `channel` to [a valid value][channels], e.g. `stable-4.3`.
 
-If this error occurs because you forced an update to a release that is not in any channel, fix by updating back to a release that occurs in a channel, although you are on your own to determine a safe update path.
+If this error occurs because you forced an upgrade to a release that is not in any channel, fix by updating back to a release that occurs in a channel, although you are on your own to determine a safe upgrade path.
 
 ### Unknown
 

--- a/hack/cluster-version-util/task_graph.go
+++ b/hack/cluster-version-util/task_graph.go
@@ -30,7 +30,7 @@ func newTaskGraphCmd() *cobra.Command {
 
 func runTaskGraphCmd(cmd *cobra.Command, args []string) error {
 	manifestDir := args[0]
-	release, err := payload.LoadUpdate(manifestDir, "", "")
+	release, err := payload.LoadUpgrade(manifestDir, "", "")
 	if err != nil {
 		return err
 	}

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -24,7 +24,7 @@ spec:
         args:
           - "start"
           - "--release-image={{.ReleaseImage}}"
-          - "--enable-auto-update=false"
+          - "--enable-auto-upgrade=false"
           - "--enable-default-cluster-version=true"
           - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
           - "--serving-key-file=/etc/tls/serving-cert/tls.key"
@@ -38,8 +38,8 @@ spec:
           - mountPath: /etc/ssl/certs
             name: etc-ssl-certs
             readOnly: true
-          - mountPath: /etc/cvo/updatepayloads
-            name: etc-cvo-updatepayloads
+          - mountPath: /etc/cvo/upgradepayloads
+            name: etc-cvo-upgradepayloads
             readOnly: true
           - mountPath: /etc/tls/serving-cert
             name: serving-cert
@@ -82,9 +82,9 @@ spec:
         - name: etc-ssl-certs
           hostPath:
             path: /etc/ssl/certs
-        - name: etc-cvo-updatepayloads
+        - name: etc-cvo-upgradepayloads
           hostPath:
-            path: /etc/cvo/updatepayloads
+            path: /etc/cvo/upgradepayloads
         - name: serving-cert
           secret:
             secretName: cluster-version-operator-serving-cert

--- a/lib/resourceapply/core.go
+++ b/lib/resourceapply/core.go
@@ -37,7 +37,7 @@ func ApplyNamespace(client coreclientv1.NamespacesGetter, required *corev1.Names
 }
 
 // ApplyService merges objectmeta and requires
-// TODO, since this cannot determine whether changes are due to legitimate actors (api server) or illegitimate ones (users), we cannot update
+// TODO, since this cannot determine whether changes are due to legitimate actors (api server) or illegitimate ones (users), we cannot upgrade
 // TODO I've special cased the selector for now
 func ApplyService(client coreclientv1.ServicesGetter, required *corev1.Service) (*corev1.Service, bool, error) {
 	existing, err := client.Services(required.Namespace).Get(required.Name, metav1.GetOptions{})
@@ -63,7 +63,7 @@ func ApplyService(client coreclientv1.ServicesGetter, required *corev1.Service) 
 		return nil, false, nil
 	}
 	existing.Spec.Selector = required.Spec.Selector
-	existing.Spec.Type = required.Spec.Type // if this is different, the update will fail.  Status will indicate it.
+	existing.Spec.Type = required.Spec.Type // if this is different, the upgrade will fail.  Status will indicate it.
 
 	actual, err := client.Services(required.Namespace).Update(existing)
 	return actual, true, err

--- a/lib/resourceapply/interface.go
+++ b/lib/resourceapply/interface.go
@@ -6,13 +6,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CreateOnlyAnnotation means that this resource should be created if it does not exist, but should not be updated
+// CreateOnlyAnnotation means that this resource should be created if it does not exist, but should not be upgraded
 // if it already exists.  It is uniformly respected across all resources, but the first known use-cases are for
 // empty config.openshift.io and initial low-level operator resources.
 // Set .metadata.annotations["release.openshift.io/create-only"]="true" to have a create-only resource.
 const CreateOnlyAnnotation = "release.openshift.io/create-only"
 
-// IsCreateOnly takes metadata and returns true if the resource should only be created, not updated.
+// IsCreateOnly takes metadata and returns true if the resource should only be created, not upgraded.
 func IsCreateOnly(metadata metav1.Object) bool {
 	return strings.EqualFold(metadata.GetAnnotations()[CreateOnlyAnnotation], "true")
 }

--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -45,7 +45,7 @@ func (b *crdBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 func (b *crdBuilder) Do(ctx context.Context) error {
 	crd := resourceread.ReadCustomResourceDefinitionOrDie(b.raw)
 
-	var updated bool
+	var upgraded bool
 	var err error
 	var name string
 
@@ -54,7 +54,7 @@ func (b *crdBuilder) Do(ctx context.Context) error {
 		if b.modifier != nil {
 			b.modifier(crd)
 		}
-		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1beta1(b.clientV1beta1, crd)
+		_, upgraded, err = resourceapply.ApplyCustomResourceDefinitionV1beta1(b.clientV1beta1, crd)
 		if err != nil {
 			return err
 		}
@@ -63,14 +63,14 @@ func (b *crdBuilder) Do(ctx context.Context) error {
 		if b.modifier != nil {
 			b.modifier(crd)
 		}
-		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1(b.clientV1, crd)
+		_, upgraded, err = resourceapply.ApplyCustomResourceDefinitionV1(b.clientV1, crd)
 		if err != nil {
 			return err
 		}
 		name = crd.Name
 	}
 
-	if updated {
+	if upgraded {
 		return waitForCustomResourceDefinitionCompletion(ctx, b.clientV1beta1, name)
 	}
 	return nil

--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -45,11 +45,11 @@ func (b *jobBuilder) Do(ctx context.Context) error {
 	if b.modifier != nil {
 		b.modifier(job)
 	}
-	_, updated, err := resourceapply.ApplyJob(b.client, job)
+	_, upgraded, err := resourceapply.ApplyJob(b.client, job)
 	if err != nil {
 		return err
 	}
-	if updated && b.mode != InitializingMode {
+	if upgraded && b.mode != InitializingMode {
 		return WaitForJobCompletion(ctx, b.client, job)
 	}
 	return nil

--- a/lib/resourcebuilder/podspec.go
+++ b/lib/resourcebuilder/podspec.go
@@ -6,9 +6,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// updatePodSpecWithProxy mutates the input podspec with proxy env vars for all init containers and containers
+// upgradePodSpecWithProxy mutates the input podspec with proxy env vars for all init containers and containers
 // matching the container names.
-func updatePodSpecWithProxy(podSpec *corev1.PodSpec, containerNames []string, httpProxy, httpsProxy, noProxy string) error {
+func upgradePodSpecWithProxy(podSpec *corev1.PodSpec, containerNames []string, httpProxy, httpsProxy, noProxy string) error {
 	hasProxy := len(httpsProxy) > 0 || len(httpProxy) > 0 || len(noProxy) > 0
 	if !hasProxy {
 		return nil

--- a/lib/resourcebuilder/podspec_test.go
+++ b/lib/resourcebuilder/podspec_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestUpdatePodSpecWithProxy(t *testing.T) {
+func TestUpgradePodSpecWithProxy(t *testing.T) {
 	tests := []struct {
 		name string
 
@@ -93,7 +93,7 @@ func TestUpdatePodSpecWithProxy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := updatePodSpecWithProxy(test.input, test.containerNames, test.httpProxy, test.httpsProxy, test.noProxy)
+			err := upgradePodSpecWithProxy(test.input, test.containerNames, test.httpProxy, test.httpsProxy, test.noProxy)
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
 			case err != nil && len(test.expectedErr) == 0:

--- a/lib/resourcemerge/apiext.go
+++ b/lib/resourcemerge/apiext.go
@@ -11,7 +11,7 @@ import (
 )
 
 // EnsureCustomResourceDefinitionV1beta1 ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureCustomResourceDefinitionV1beta1(modified *bool, existing *apiextv1beta1.CustomResourceDefinition, required apiextv1beta1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
@@ -46,7 +46,7 @@ func EnsureCustomResourceDefinitionV1beta1(modified *bool, existing *apiextv1bet
 }
 
 // EnsureCustomResourceDefinitionV1 ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextv1.CustomResourceDefinition, required apiextv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 

--- a/lib/resourcemerge/apireg.go
+++ b/lib/resourcemerge/apireg.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnsureAPIService ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureAPIService(modified *bool, existing *apiregv1.APIService, required apiregv1.APIService) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 

--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnsureDeployment ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
@@ -28,7 +28,7 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 }
 
 // EnsureDaemonSet ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureDaemonSet(modified *bool, existing *appsv1.DaemonSet, required appsv1.DaemonSet) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 

--- a/lib/resourcemerge/batch.go
+++ b/lib/resourcemerge/batch.go
@@ -5,7 +5,7 @@ import (
 )
 
 // EnsureJob ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureJob(modified *bool, existing *batchv1.Job, required batchv1.Job) {
 
 	if required.Spec.Selector != nil {

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -8,7 +8,7 @@ import (
 )
 
 // EnsureConfigMap ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1.ConfigMap) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
@@ -16,7 +16,7 @@ func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1
 }
 
 // ensurePodTemplateSpec ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func ensurePodTemplateSpec(modified *bool, existing *corev1.PodTemplateSpec, required corev1.PodTemplateSpec) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnsureObjectMeta ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required metav1.ObjectMeta) {
 	setStringIfSet(modified, &existing.Namespace, required.Namespace)
 	setStringIfSet(modified, &existing.Name, required.Name)

--- a/lib/resourcemerge/rbac.go
+++ b/lib/resourcemerge/rbac.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnsureClusterRoleBinding ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureClusterRoleBinding(modified *bool, existing *rbacv1.ClusterRoleBinding, required rbacv1.ClusterRoleBinding) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	if !equality.Semantic.DeepEqual(existing.Subjects, required.Subjects) {
@@ -20,7 +20,7 @@ func EnsureClusterRoleBinding(modified *bool, existing *rbacv1.ClusterRoleBindin
 }
 
 // EnsureClusterRole ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureClusterRole(modified *bool, existing *rbacv1.ClusterRole, required rbacv1.ClusterRole) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	if !equality.Semantic.DeepEqual(existing.Rules, required.Rules) {
@@ -30,7 +30,7 @@ func EnsureClusterRole(modified *bool, existing *rbacv1.ClusterRole, required rb
 }
 
 // EnsureRoleBinding ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureRoleBinding(modified *bool, existing *rbacv1.RoleBinding, required rbacv1.RoleBinding) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	if !equality.Semantic.DeepEqual(existing.Subjects, required.Subjects) {
@@ -44,7 +44,7 @@ func EnsureRoleBinding(modified *bool, existing *rbacv1.RoleBinding, required rb
 }
 
 // EnsureRole ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureRole(modified *bool, existing *rbacv1.Role, required rbacv1.Role) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	if !equality.Semantic.DeepEqual(existing.Rules, required.Rules) {

--- a/lib/resourcemerge/security.go
+++ b/lib/resourcemerge/security.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnsureSecurityContextConstraints ensures that the existing matches the required.
-// modified is set to true when existing had to be updated with required.
+// modified is set to true when existing had to be upgraded with required.
 func EnsureSecurityContextConstraints(modified *bool, existing *securityv1.SecurityContextConstraints, required securityv1.SecurityContextConstraints) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	setInt32Ptr(modified, &existing.Priority, required.Priority)

--- a/lib/validation/validation.go
+++ b/lib/validation/validation.go
@@ -39,7 +39,7 @@ func ValidateClusterVersion(config *configv1.ClusterVersion) field.ErrorList {
 		case len(u.Version) > 0 && len(u.Image) == 0:
 			switch countPayloadsForVersion(config, u.Version) {
 			case 0:
-				errs = append(errs, field.Invalid(field.NewPath("spec", "desiredUpdate", "version"), u.Version, "when image is empty the update must be a previous version or an available update"))
+				errs = append(errs, field.Invalid(field.NewPath("spec", "desiredUpdate", "version"), u.Version, "when image is empty the upgrade must be a previous version or an available upgrade"))
 			case 1:
 			default:
 				errs = append(errs, field.Invalid(field.NewPath("spec", "desiredUpdate", "version"), u.Version, "there are multiple possible payloads for this version, specify the exact image"))
@@ -51,8 +51,8 @@ func ValidateClusterVersion(config *configv1.ClusterVersion) field.ErrorList {
 
 func countPayloadsForVersion(config *configv1.ClusterVersion, version string) int {
 	count := 0
-	for _, update := range config.Status.AvailableUpdates {
-		if update.Version == version && len(update.Image) > 0 {
+	for _, upgrade := range config.Status.AvailableUpdates {
+		if upgrade.Version == version && len(upgrade.Image) > 0 {
 			count++
 		}
 	}
@@ -70,9 +70,9 @@ func countPayloadsForVersion(config *configv1.ClusterVersion, version string) in
 }
 
 func hasAmbiguousPayloadForVersion(config *configv1.ClusterVersion, version string) bool {
-	for _, update := range config.Status.AvailableUpdates {
-		if update.Version == version {
-			return len(update.Image) > 0
+	for _, upgrade := range config.Status.AvailableUpdates {
+		if upgrade.Version == version {
+			return len(upgrade.Image) > 0
 		}
 	}
 	for _, history := range config.Status.History {
@@ -93,7 +93,7 @@ func ClearInvalidFields(config *configv1.ClusterVersion, errs field.ErrorList) *
 		case strings.HasPrefix(err.Field, "spec.desiredUpdate."):
 			copied.Spec.DesiredUpdate = nil
 		case err.Field == "spec.upstream":
-			// TODO: invalid means, don't fetch updates
+			// TODO: invalid means, don't fetch upgrades
 			copied.Spec.Upstream = ""
 		case err.Field == "spec.clusterID":
 			copied.Spec.ClusterID = ""

--- a/pkg/autoupgrade/autoupgrade_test.go
+++ b/pkg/autoupgrade/autoupgrade_test.go
@@ -1,4 +1,4 @@
-package autoupdate
+package autoupgrade
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 )
 
-func TestNextUpdate(t *testing.T) {
+func TestNextUpgrade(t *testing.T) {
 	tests := []struct {
 		avail []string
 		want  string
@@ -29,12 +29,12 @@ func TestNextUpdate(t *testing.T) {
 	}}
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("test: #%d", idx), func(t *testing.T) {
-			ups := []v1.Update{}
+			ups := []v1.Upgrade{}
 			for _, v := range test.avail {
-				ups = append(ups, v1.Update{Version: v})
+				ups = append(ups, v1.Upgrade{Version: v})
 			}
 
-			got := nextUpdate(ups)
+			got := nextUpgrade(ups)
 			if got.Version != test.want {
 				t.Fatalf("mismatch: got %v want: %v", got, test.want)
 			}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -15,7 +15,7 @@ import (
 	_ "k8s.io/klog" // integration tests set glog flags.
 )
 
-func TestGetUpdates(t *testing.T) {
+func TestGetUpgrades(t *testing.T) {
 	clientID := uuid.Must(uuid.Parse("01234567-0123-0123-0123-0123456789ab"))
 	arch := "test-arch"
 	channelName := "test-channel"
@@ -24,25 +24,25 @@ func TestGetUpdates(t *testing.T) {
 		version string
 
 		expectedQuery string
-		available     []Update
+		available     []Upgrade
 		err           string
 	}{{
-		name:          "one update available",
+		name:          "one upgrade available",
 		version:       "4.0.0-4",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-4",
-		available: []Update{
+		available: []Upgrade{
 			{semver.MustParse("4.0.0-5"), "quay.io/openshift-release-dev/ocp-release:4.0.0-5"},
 		},
 	}, {
-		name:          "two updates available",
+		name:          "two upgrades available",
 		version:       "4.0.0-5",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-5",
-		available: []Update{
+		available: []Upgrade{
 			{semver.MustParse("4.0.0-6"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6"},
 			{semver.MustParse("4.0.0-6+2"), "quay.io/openshift-release-dev/ocp-release:4.0.0-6+2"},
 		},
 	}, {
-		name:          "no updates available",
+		name:          "no upgrades available",
 		version:       "4.0.0-0.okd-0",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-0.okd-0",
 	}, {
@@ -132,13 +132,13 @@ func TestGetUpdates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			updates, err := c.GetUpdates(uri, arch, channelName, semver.MustParse(test.version))
+			upgrades, err := c.GetUpgrades(uri, arch, channelName, semver.MustParse(test.version))
 			if test.err == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)
 				}
-				if !reflect.DeepEqual(updates, test.available) {
-					t.Fatalf("expected %v, got: %v", test.available, updates)
+				if !reflect.DeepEqual(upgrades, test.available) {
+					t.Fatalf("expected %v, got: %v", test.available, upgrades)
 				}
 			} else {
 				if err == nil || err.Error() != test.err {

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -293,7 +293,7 @@ func TestOperator_sync(t *testing.T) {
 				Step:        "Moving",
 				Reconciling: false,
 				Actual:      configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-				Failure: &payload.UpdateError{
+				Failure: &payload.UpgradeError{
 					Reason:  "UpdatePayloadIntegrity",
 					Message: "unable to apply object",
 				},
@@ -303,7 +303,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage:   "image/image:v4.0.1",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -334,7 +334,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -343,15 +343,15 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "unable to apply object"},
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "Unable to apply 0.0.1-abc: the contents of the update are invalid"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "Unable to apply 0.0.1-abc: the contents of the upgrade are invalid"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},
@@ -370,13 +370,13 @@ func TestOperator_sync(t *testing.T) {
 						Step:        "Moving",
 						Reconciling: true,
 						Actual:      configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-						Failure: &payload.UpdateError{
+						Failure: &payload.UpgradeError{
 							Reason:  "UpdatePayloadIntegrity",
 							Message: "unable to apply object",
 						},
 					},
 				},
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -407,7 +407,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -416,15 +416,15 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "unable to apply object"},
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadIntegrity", Message: "Error while reconciling 0.0.1-abc: the contents of the update are invalid"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadIntegrity", Message: "Error while reconciling 0.0.1-abc: the contents of the upgrade are invalid"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},
@@ -444,13 +444,13 @@ func TestOperator_sync(t *testing.T) {
 						Reconciling: true,
 						Completed:   2,
 						Actual:      configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-						Failure: &payload.UpdateError{
+						Failure: &payload.UpgradeError{
 							Reason:  "UpdatePayloadIntegrity",
 							Message: "unable to apply object",
 						},
 					},
 				},
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -481,7 +481,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -490,15 +490,15 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:     configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 0.0.1-abc"},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "unable to apply object"},
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadIntegrity", Message: "Error while reconciling 0.0.1-abc: the contents of the update are invalid"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "UpdatePayloadIntegrity", Message: "Error while reconciling 0.0.1-abc: the contents of the upgrade are invalid"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},
@@ -551,7 +551,7 @@ func TestOperator_sync(t *testing.T) {
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
 				// syncing config status
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -561,8 +561,8 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						Desired: configv1.Update{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{Time: time.Unix(0, 0)}, CompletionTime: &defaultCompletionTime},
+							{State: configv1.PartialUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{Time: time.Unix(0, 0)}, CompletionTime: &defaultCompletionTime},
 						},
 						VersionHash: "foo",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -604,7 +604,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -614,7 +614,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
 						},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -668,7 +668,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -679,7 +679,7 @@ func TestOperator_sync(t *testing.T) {
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						History: []configv1.UpdateHistory{
 							// we populate state, but not startedTime
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{time.Unix(0, 0)}},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{time.Unix(0, 0)}},
 						},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -702,7 +702,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -721,7 +721,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -733,7 +733,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "", // we don't know our image yet and releaseVersion is unset
 								StartedTime: defaultStartedTime,
@@ -761,7 +761,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "4.0.2",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -774,7 +774,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "", // we didn't know our image before
 								StartedTime: defaultStartedTime,
@@ -798,7 +798,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -810,13 +810,13 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.2",
 								Version:     "4.0.2",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "",
 								StartedTime:    defaultStartedTime,
@@ -836,13 +836,13 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "when user cancels desired update, clear status desired",
+			name: "when user cancels desired upgrade, clear status desired",
 			syncStatus: &SyncWorkerStatus{
 				// TODO: we can't actually react to spec changes in a single sync round
-				// because the sync worker updates desired state and cancels under the
+				// because the sync worker upgrades desired state and cancels under the
 				// lock, so the sync worker loop will never report the status of the
-				// update unless we add some sort of delay - which might make clearing status
-				// slightly more useful to the user (instead of two status updates you get
+				// upgrade unless we add some sort of delay - which might make clearing status
+				// slightly more useful to the user (instead of two status upgrades you get
 				// one).
 				Actual: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
@@ -851,7 +851,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "4.0.1",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -864,13 +864,13 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.2",
 								Version:     "4.0.2",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -895,7 +895,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -907,20 +907,20 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "4.0.1",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.2",
 								Version:        "4.0.2",
 								StartedTime:    defaultStartedTime,
 								CompletionTime: &defaultCompletionTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -944,7 +944,7 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "after desired update is cancelled, revert to progressing",
+			name: "after desired upgrade is cancelled, revert to progressing",
 			syncStatus: &SyncWorkerStatus{
 				Actual:   configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 				Fraction: 0.334,
@@ -954,7 +954,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "4.0.1",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -967,20 +967,20 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "4.0.1",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.2",
 								Version:        "4.0.2",
 								StartedTime:    defaultStartedTime,
 								CompletionTime: &defaultCompletionTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -1006,7 +1006,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -1018,20 +1018,20 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "4.0.1",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.2",
 								Version:        "4.0.2",
 								StartedTime:    defaultStartedTime,
 								CompletionTime: &defaultCompletionTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -1062,7 +1062,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "4.0.1",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -1075,14 +1075,14 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.2",
 								Version:        "4.0.2",
 								StartedTime:    defaultStartedTime,
 								CompletionTime: &defaultCompletionTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -1102,7 +1102,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -1114,20 +1114,20 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								Version:     "",
 								StartedTime: defaultStartedTime,
 							},
 							{
-								State:          configv1.PartialUpdate,
+								State:          configv1.PartialUpgrade,
 								Image:          "image/image:v4.0.2",
 								Version:        "4.0.2",
 								StartedTime:    defaultStartedTime,
 								CompletionTime: &defaultCompletionTime,
 							},
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "4.0.1",
 								StartedTime:    defaultStartedTime,
@@ -1140,7 +1140,7 @@ func TestOperator_sync(t *testing.T) {
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 							// we correct the message that was incorrect from the previous state
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "DownloadingUpdate", Message: "Working towards image/image:v4.0.1: downloading update"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "DownloadingUpgrade", Message: "Working towards image/image:v4.0.1: downloading upgrade"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},
@@ -1157,7 +1157,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -1170,7 +1170,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:       configv1.PartialUpdate,
+								State:       configv1.PartialUpgrade,
 								Image:       "image/image:v4.0.1",
 								StartedTime: defaultStartedTime,
 							},
@@ -1194,7 +1194,7 @@ func TestOperator_sync(t *testing.T) {
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
 				// will use the version from content1 (the image) when we set the progressing condition
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -1205,7 +1205,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Image: "image/image:v4.0.1", Version: "0.0.1-abc", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Image: "image/image:v4.0.1", Version: "0.0.1-abc", StartedTime: defaultStartedTime},
 						},
 						Desired:     configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						VersionHash: "xyz",
@@ -1233,7 +1233,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "0.0.1-abc",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       "default",
@@ -1247,7 +1247,7 @@ func TestOperator_sync(t *testing.T) {
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
 								{
-									State:          configv1.CompletedUpdate,
+									State:          configv1.CompletedUpgrade,
 									Image:          "image/image:v4.0.1",
 									Version:        "0.0.1-abc",
 									CompletionTime: &defaultStartedTime,
@@ -1279,7 +1279,7 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "new available updates, version is live and was recently synced, sync",
+			name: "new available upgrades, version is live and was recently synced, sync",
 			syncStatus: &SyncWorkerStatus{
 				Generation:  2,
 				Reconciling: true,
@@ -1290,10 +1290,10 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				availableUpdates: &availableUpdates{
+				availableUpgrades: &availableUpgrades{
 					Upstream: "http://localhost:8080/graph",
 					Channel:  "fast",
-					Updates: []configv1.Update{
+					Upgrades: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
 					},
@@ -1302,7 +1302,7 @@ func TestOperator_sync(t *testing.T) {
 						Status: configv1.ConditionTrue,
 					},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1330,7 +1330,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1346,7 +1346,7 @@ func TestOperator_sync(t *testing.T) {
 							{Version: "4.0.3", Image: "test/image:2"},
 						},
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1379,7 +1379,7 @@ func TestOperator_sync(t *testing.T) {
 						{Type: configv1.ClusterStatusConditionType("UpgradeableB"), Status: configv1.ConditionFalse},
 					},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1407,7 +1407,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1419,7 +1419,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1454,7 +1454,7 @@ func TestOperator_sync(t *testing.T) {
 						{Type: configv1.ClusterStatusConditionType("UpgradeableB"), Status: configv1.ConditionFalse},
 					},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1483,7 +1483,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1495,7 +1495,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1526,7 +1526,7 @@ func TestOperator_sync(t *testing.T) {
 				upgradeable: &upgradeable{
 					Conditions: []configv1.ClusterOperatorStatusCondition{},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1557,7 +1557,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1569,7 +1569,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1584,7 +1584,7 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "new available updates for the default upstream URL, client has no upstream",
+			name: "new available upgrades for the default upstream URL, client has no upstream",
 			syncStatus: &SyncWorkerStatus{
 				Generation:  2,
 				Reconciling: true,
@@ -1596,10 +1596,10 @@ func TestOperator_sync(t *testing.T) {
 				namespace:             "test",
 				name:                  "default",
 				defaultUpstreamServer: "http://localhost:8080/graph",
-				availableUpdates: &availableUpdates{
+				availableUpgrades: &availableUpgrades{
 					Upstream: "",
 					Channel:  "fast",
-					Updates: []configv1.Update{
+					Upgrades: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
 					},
@@ -1608,7 +1608,7 @@ func TestOperator_sync(t *testing.T) {
 						Status: configv1.ConditionTrue,
 					},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1636,7 +1636,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1652,7 +1652,7 @@ func TestOperator_sync(t *testing.T) {
 							{Version: "4.0.3", Image: "test/image:2"},
 						},
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1667,7 +1667,7 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "new available updates but for a different channel",
+			name: "new available upgrades but for a different channel",
 			syncStatus: &SyncWorkerStatus{
 				Generation:  2,
 				Reconciling: true,
@@ -1678,10 +1678,10 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				availableUpdates: &availableUpdates{
+				availableUpgrades: &availableUpgrades{
 					Upstream: "http://localhost:8080/graph",
 					Channel:  "fast",
-					Updates: []configv1.Update{
+					Upgrades: []configv1.Update{
 						{Version: "4.0.2", Image: "test/image:1"},
 						{Version: "4.0.3", Image: "test/image:2"},
 					},
@@ -1690,7 +1690,7 @@ func TestOperator_sync(t *testing.T) {
 						Status: configv1.ConditionTrue,
 					},
 				},
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1718,7 +1718,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1730,7 +1730,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						ObservedGeneration: 2,
@@ -1756,7 +1756,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 3,
@@ -1779,7 +1779,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 3,
@@ -1792,7 +1792,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired:            configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						ObservedGeneration: 2,
@@ -1807,7 +1807,7 @@ func TestOperator_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "user requested a version that isn't in the updates or history",
+			name: "user requested a version that isn't in the upgrades or history",
 			syncStatus: &SyncWorkerStatus{
 				Generation:  2,
 				Reconciling: true,
@@ -1818,7 +1818,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 3,
@@ -1845,7 +1845,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 3,
@@ -1853,14 +1853,14 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						// The object passed to status update is the one with desired update cleared
+						// The object passed to status upgrade is the one with desired upgrade cleared
 						// DesiredUpdate: &configv1.Update{
 						// 	Version: "4.0.4",
 						// },
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						AvailableUpdates: []configv1.Update{
@@ -1869,7 +1869,7 @@ func TestOperator_sync(t *testing.T) {
 						},
 						ObservedGeneration: 2,
 						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{Type: ClusterVersionInvalid, Status: configv1.ConditionTrue, Reason: "InvalidClusterVersion", Message: "The cluster version is invalid: spec.desiredUpdate.version: Invalid value: \"4.0.4\": when image is empty the update must be a previous version or an available update"},
+							{Type: ClusterVersionInvalid, Status: configv1.ConditionTrue, Reason: "InvalidClusterVersion", Message: "The cluster version is invalid: spec.desiredUpdate.version: Invalid value: \"4.0.4\": when image is empty the upgrade must be a previous version or an available upgrade"},
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 4.0.1"},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 							{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Reason: "InvalidClusterVersion", Message: "Stopped at 4.0.1: the cluster version is invalid"},
@@ -1891,7 +1891,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1919,7 +1919,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -1927,7 +1927,7 @@ func TestOperator_sync(t *testing.T) {
 					Spec: configv1.ClusterVersionSpec{
 						ClusterID: configv1.ClusterID(id),
 						Upstream:  configv1.URL("http://localhost:8080/graph"),
-						// The object passed to status update is the one with desired update cleared
+						// The object passed to status upgrade is the one with desired upgrade cleared
 						// DesiredUpdate: &configv1.Update{
 						// 	Version: "4.0.4",
 						// },
@@ -1935,7 +1935,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						ObservedGeneration: 2,
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired: configv1.Update{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						AvailableUpdates: []configv1.Update{
@@ -1968,7 +1968,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseVersion: "0.0.1-abc",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       "default",
@@ -1983,7 +1983,7 @@ func TestOperator_sync(t *testing.T) {
 							History: []configv1.UpdateHistory{
 								// loads the version from the image on disk
 								{
-									State:          configv1.CompletedUpdate,
+									State:          configv1.CompletedUpgrade,
 									Image:          "image/image:v4.0.1",
 									Version:        "0.0.1-abc",
 									CompletionTime: &defaultCompletionTime,
@@ -2043,7 +2043,7 @@ func TestOperator_sync(t *testing.T) {
 							History: []configv1.UpdateHistory{
 								// loads the version from the image on disk
 								{
-									State:          configv1.CompletedUpdate,
+									State:          configv1.CompletedUpgrade,
 									Image:          "image/image:v4.0.1",
 									Version:        "0.0.1-abc",
 									CompletionTime: &defaultCompletionTime,
@@ -2072,7 +2072,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %s", len(act), spew.Sdump(act))
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "default",
 						Generation: 2,
@@ -2084,7 +2084,7 @@ func TestOperator_sync(t *testing.T) {
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
 							{
-								State:          configv1.CompletedUpdate,
+								State:          configv1.CompletedUpgrade,
 								Image:          "image/image:v4.0.1",
 								Version:        "0.0.1-abc",
 								CompletionTime: &defaultCompletionTime,
@@ -2116,7 +2116,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -2135,7 +2135,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -2148,7 +2148,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.CompletedUpdate, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+							{State: configv1.CompletedUpgrade, Version: "0.0.1-abc", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 						},
 						Desired: configv1.Update{
 							Version: "0.0.1-abc", Image: "image/image:v4.0.1",
@@ -2175,7 +2175,7 @@ func TestOperator_sync(t *testing.T) {
 				releaseImage: "image/image:v4.0.1",
 				namespace:    "test",
 				name:         "default",
-				client: fakeClientsetWithUpdates(&configv1.ClusterVersion{
+				client: fakeClientsetWithUpgrades(&configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -2212,7 +2212,7 @@ func TestOperator_sync(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "default",
 						ResourceVersion: "1",
@@ -2226,7 +2226,7 @@ func TestOperator_sync(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Image: "image/image:v4.0.1", Version: "0.0.1-abc", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Image: "image/image:v4.0.1", Version: "0.0.1-abc", StartedTime: defaultStartedTime},
 						},
 						Desired:     configv1.Update{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 						VersionHash: "",
@@ -2273,16 +2273,16 @@ func TestOperator_sync(t *testing.T) {
 				tt.wantActions(t, optr)
 			}
 			if tt.wantSync != nil {
-				actual := optr.configSync.(*fakeSyncRecorder).Updates
+				actual := optr.configSync.(*fakeSyncRecorder).Upgrades
 				if !reflect.DeepEqual(tt.wantSync, actual) {
-					t.Fatalf("Unexpected updates: %#v", actual)
+					t.Fatalf("Unexpected upgrades: %#v", actual)
 				}
 			}
 		})
 	}
 }
 
-func TestOperator_availableUpdatesSync(t *testing.T) {
+func TestOperator_availableUpgradesSync(t *testing.T) {
 	id := uuid.Must(uuid.NewRandom()).String()
 
 	tests := []struct {
@@ -2291,7 +2291,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		handler     http.HandlerFunc
 		optr        Operator
 		wantErr     func(*testing.T, error)
-		wantUpdates *availableUpdates
+		wantUpgrades *availableUpgrades
 	}{
 		{
 			name: "when version is missing, do nothing (other loops should create it)",
@@ -2330,14 +2330,14 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
 					Reason:  "NoUpstream",
-					Message: "No upstream server has been set to retrieve updates.",
+					Message: "No upstream server has been set to retrieve upgrades.",
 				},
 			},
 		},
@@ -2369,14 +2369,14 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
 					Reason:  "NoChannel",
-					Message: "The update channel has not been configured.",
+					Message: "The upgrade channel has not been configured.",
 				},
 			},
 		},
@@ -2408,7 +2408,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
@@ -2452,19 +2452,19 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
 					Reason:  "ResponseFailed",
-					Message: "Unable to retrieve available updates: unexpected HTTP status: 500 Internal Server Error",
+					Message: "Unable to retrieve available upgrades: unexpected HTTP status: 500 Internal Server Error",
 				},
 			},
 		},
 		{
-			name: "set available updates and clear error state when success and empty",
+			name: "set available upgrades and clear error state when success and empty",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				fmt.Fprintf(w, `
 				{
@@ -2498,13 +2498,13 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 								{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying image/image:v4.0.1"},
 								{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 								{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
-								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available updates: unexpected HTTP status: 500 Internal Server Error"},
+								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available upgrades: unexpected HTTP status: 500 Internal Server Error"},
 							},
 						},
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
@@ -2514,7 +2514,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 		},
 		{
-			name: "calculate available update edges",
+			name: "calculate available upgrade edges",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				fmt.Fprintf(w, `
 				{
@@ -2554,16 +2554,16 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 								{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying image/image:v4.0.1"},
 								{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 								{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
-								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available updates: unexpected HTTP status: 500 Internal Server Error"},
+								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available upgrades: unexpected HTTP status: 500 Internal Server Error"},
 							},
 						},
 					},
 				),
 			},
-			wantUpdates: &availableUpdates{
+			wantUpgrades: &availableUpgrades{
 				Upstream: "",
 				Channel:  "fast",
-				Updates: []configv1.Update{
+				Upgrades: []configv1.Update{
 					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
 				},
@@ -2580,8 +2580,8 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: Operator{
 				defaultUpstreamServer:      "http://localhost:8080/graph",
-				minimumUpdateCheckInterval: 1 * time.Minute,
-				availableUpdates:    &availableUpdates{
+				minimumUpgradeCheckInterval: 1 * time.Minute,
+				availableUpgrades:    &availableUpgrades{
 					Upstream:    "http://localhost:8080/graph",
 					Channel:     "fast",
 					LastAttempt: time.Now(),
@@ -2610,7 +2610,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 								{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying image/image:v4.0.1"},
 								{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 								{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
-								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available updates: unexpected HTTP status: 500 Internal Server Error"},
+								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "RemoteFailed", Message: "Unable to retrieve available upgrades: unexpected HTTP status: 500 Internal Server Error"},
 							},
 						},
 					},
@@ -2632,13 +2632,13 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				if optr.defaultUpstreamServer == "http://localhost:8080/graph" {
 					optr.defaultUpstreamServer = s.URL
 				}
-				if optr.availableUpdates != nil && optr.availableUpdates.Upstream == "http://localhost:8080/graph" {
-					optr.availableUpdates.Upstream = s.URL
+				if optr.availableUpgrades != nil && optr.availableUpgrades.Upstream == "http://localhost:8080/graph" {
+					optr.availableUpgrades.Upstream = s.URL
 				}
 			}
-			old := optr.availableUpdates
+			old := optr.availableUpgrades
 
-			err := optr.availableUpdatesSync(optr.queueKey())
+			err := optr.availableUpgradesSync(optr.queueKey())
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("Operator.sync() unexpected error: %v", err)
 			}
@@ -2649,22 +2649,22 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				return
 			}
 
-			if optr.availableUpdates == old {
-				optr.availableUpdates = nil
+			if optr.availableUpgrades == old {
+				optr.availableUpgrades = nil
 			}
 
-			if optr.availableUpdates != nil {
-				if optr.availableUpdates.Upstream == optr.defaultUpstreamServer && len(optr.defaultUpstreamServer) > 0 {
-					optr.availableUpdates.Upstream = "<default>"
+			if optr.availableUpgrades != nil {
+				if optr.availableUpgrades.Upstream == optr.defaultUpstreamServer && len(optr.defaultUpstreamServer) > 0 {
+					optr.availableUpgrades.Upstream = "<default>"
 				}
-				optr.availableUpdates.Condition.LastTransitionTime = metav1.Time{}
-				optr.availableUpdates.LastAttempt = time.Time{}
-				optr.availableUpdates.LastSyncOrConfigChange = time.Time{}
+				optr.availableUpgrades.Condition.LastTransitionTime = metav1.Time{}
+				optr.availableUpgrades.LastAttempt = time.Time{}
+				optr.availableUpgrades.LastSyncOrConfigChange = time.Time{}
 			}
-			if !reflect.DeepEqual(optr.availableUpdates, tt.wantUpdates) {
-				t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(tt.wantUpdates, optr.availableUpdates))
+			if !reflect.DeepEqual(optr.availableUpgrades, tt.wantUpgrades) {
+				t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(tt.wantUpgrades, optr.availableUpgrades))
 			}
-			if (optr.queue.Len() > 0) != (optr.availableUpdates != nil) {
+			if (optr.queue.Len() > 0) != (optr.availableUpgrades != nil) {
 				t.Fatalf("unexpected queue")
 			}
 		})
@@ -3175,14 +3175,14 @@ func expectCreate(t *testing.T, a ktesting.Action, resource, namespace string, o
 	expectMutation(t, a, "create", resource, "", namespace, obj)
 }
 
-func expectUpdate(t *testing.T, a ktesting.Action, resource, namespace string, obj interface{}) {
+func expectUpgrade(t *testing.T, a ktesting.Action, resource, namespace string, obj interface{}) {
 	t.Helper()
-	expectMutation(t, a, "update", resource, "", namespace, obj)
+	expectMutation(t, a, "upgrade", resource, "", namespace, obj)
 }
 
-func expectUpdateStatus(t *testing.T, a ktesting.Action, resource, namespace string, obj interface{}) {
+func expectUpgradeStatus(t *testing.T, a ktesting.Action, resource, namespace string, obj interface{}) {
 	t.Helper()
-	expectMutation(t, a, "update", resource, "status", namespace, obj)
+	expectMutation(t, a, "upgrade", resource, "status", namespace, obj)
 }
 
 func expectMutation(t *testing.T, a ktesting.Action, verb string, resource, subresource, namespace string, obj interface{}) {
@@ -3235,18 +3235,18 @@ func expectMutation(t *testing.T, a ktesting.Action, verb string, resource, subr
 	}
 }
 
-func fakeClientsetWithUpdates(obj *configv1.ClusterVersion) *fake.Clientset {
+func fakeClientsetWithUpgrades(obj *configv1.ClusterVersion) *fake.Clientset {
 	client := &fake.Clientset{}
 	client.AddReactor("*", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetVerb() == "get" {
 			return true, obj.DeepCopy(), nil
 		}
-		if action.GetVerb() == "update" && action.GetSubresource() == "status" {
-			update := action.(ktesting.UpdateAction).GetObject().(*configv1.ClusterVersion)
-			obj.Status = update.Status
-			rv, _ := strconv.Atoi(update.ResourceVersion)
+		if action.GetVerb() == "upgrade" && action.GetSubresource() == "status" {
+			upgrade := action.(ktesting.UpgradeAction).GetObject().(*configv1.ClusterVersion)
+			obj.Status = upgrade.Status
+			rv, _ := strconv.Atoi(upgrade.ResourceVersion)
 			obj.ResourceVersion = strconv.Itoa(rv + 1)
-			klog.V(5).Infof("updated object to %#v", obj)
+			klog.V(5).Infof("upgraded object to %#v", obj)
 			return true, obj.DeepCopy(), nil
 		}
 		return false, nil, fmt.Errorf("unrecognized")
@@ -3262,18 +3262,18 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		update        *payload.Update
+		upgrade        *payload.Upgrade
 		want          bool
 		wantErr       bool
 		wantVerifiers int
 	}{
 		{
 			name:   "is a no-op when no objects are found",
-			update: &payload.Update{},
+			upgrade: &payload.Upgrade{},
 		},
 		{
 			name: "requires data",
-			update: &payload.Update{
+			upgrade: &payload.Upgrade{
 				Manifests: []lib.Manifest{
 					{
 						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
@@ -3295,7 +3295,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 		},
 		{
 			name: "requires stores",
-			update: &payload.Update{
+			upgrade: &payload.Upgrade{
 				Manifests: []lib.Manifest{
 					{
 						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
@@ -3320,7 +3320,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 		},
 		{
 			name: "requires verifiers",
-			update: &payload.Update{
+			upgrade: &payload.Upgrade{
 				Manifests: []lib.Manifest{
 					{
 						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
@@ -3345,7 +3345,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 		},
 		{
 			name: "loads valid configuration",
-			update: &payload.Update{
+			upgrade: &payload.Upgrade{
 				Manifests: []lib.Manifest{
 					{
 						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
@@ -3372,7 +3372,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 		},
 		{
 			name: "only the first valid configuration is used",
-			update: &payload.Update{
+			upgrade: &payload.Upgrade{
 				Manifests: []lib.Manifest{
 					{
 						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
@@ -3420,7 +3420,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := kfake.NewSimpleClientset()
-			got, store, err := loadConfigMapVerifierDataFromUpdate(tt.update, verify.DefaultClient, f.CoreV1())
+			got, store, err := loadConfigMapVerifierDataFromUpgrade(tt.upgrade, verify.DefaultClient, f.CoreV1())
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("loadReleaseVerifierFromPayload() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -57,7 +57,7 @@ func applyUnstructured(client dynamic.ResourceInterface, required *unstructured.
 		existing.Object[k] = v
 	}
 
-	actual, err := client.Update(existing, metav1.UpdateOptions{})
+	actual, err := client.Upgrade(existing, metav1.UpgradeOptions{})
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/cvo/internal/generic_test.go
+++ b/pkg/cvo/internal/generic_test.go
@@ -40,7 +40,7 @@ func TestCreateOnlyCreate(t *testing.T) {
 	}
 }
 
-func TestCreateOnlyUpdate(t *testing.T) {
+func TestCreateOnlyUpgrade(t *testing.T) {
 	feature := `{
   "kind": "FeatureGate",
   "apiVersion": "config.openshift.io/v1",
@@ -79,6 +79,6 @@ func TestCreateOnlyUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if modified {
-		t.Error("should not have updated")
+		t.Error("should not have upgraded")
 	}
 }

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -42,7 +42,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  apierrors.NewNotFound(schema.GroupResource{"", "clusteroperator"}, "test-co"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co has not yet reported success",
@@ -61,7 +61,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -82,7 +82,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -108,7 +108,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -136,7 +136,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -164,7 +164,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -196,7 +196,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -228,7 +228,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is still updating"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co is still updating",
@@ -256,7 +256,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=false, progressing=true, degraded=true"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co has not yet reported success",
@@ -285,7 +285,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=false, progressing=true, degraded=true"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co has not yet reported success",
@@ -314,7 +314,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
 			Reason:  "ClusterOperatorDegraded",
 			Message: "Cluster operator test-co is reporting a failure: random error",
@@ -343,7 +343,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=true, progressing=true, degraded=true"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co has not yet reported success",
@@ -372,7 +372,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
 			Reason:  "ClusterOperatorDegraded",
 			Message: "Cluster operator test-co is reporting a failure: random error",
@@ -401,7 +401,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
 			Reason:  "ClusterOperatorDegraded",
 			Message: "Cluster operator test-co is reporting a failure: random error",
@@ -430,7 +430,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
+		expErr: &payload.UpgradeError{
 			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=true, progressing=true, degraded=true"),
 			Reason:  "ClusterOperatorNotAvailable",
 			Message: "Cluster operator test-co has not yet reported success",

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -67,8 +67,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
-									{State: configv1.PartialUpdate, Version: "0.0.2", Image: "test/image:1", StartedTime: metav1.Time{Time: time.Unix(2, 0)}},
-									{State: configv1.CompletedUpdate, Version: "0.0.1", Image: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
+									{State: configv1.PartialUpgrade, Version: "0.0.2", Image: "test/image:1", StartedTime: metav1.Time{Time: time.Unix(2, 0)}},
+									{State: configv1.CompletedUpgrade, Version: "0.0.1", Image: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
 								},
 							},
 						},
@@ -103,9 +103,9 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
-									{State: configv1.PartialUpdate, Version: "0.0.3", Image: "test/image:2", StartedTime: metav1.Time{Time: time.Unix(2, 0)}},
-									{State: configv1.CompletedUpdate, Version: "0.0.2", Image: "test/image:1", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
-									{State: configv1.CompletedUpdate, Version: "0.0.1", Image: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
+									{State: configv1.PartialUpgrade, Version: "0.0.3", Image: "test/image:2", StartedTime: metav1.Time{Time: time.Unix(2, 0)}},
+									{State: configv1.CompletedUpgrade, Version: "0.0.2", Image: "test/image:1", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
+									{State: configv1.CompletedUpgrade, Version: "0.0.1", Image: "test/image:0", CompletionTime: &([]metav1.Time{{Time: time.Unix(4, 0)}}[0])},
 								},
 							},
 						},
@@ -140,7 +140,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
-									{State: configv1.PartialUpdate, CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
+									{State: configv1.PartialUpgrade, CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
 								},
 							},
 						},
@@ -225,7 +225,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 		},
 		{
-			name: "collects available updates",
+			name: "collects available upgrades",
 			optr: &Operator{
 				name: "test",
 				cvLister: &cvLister{
@@ -257,7 +257,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 		},
 		{
-			name: "collects available updates and reports 0 when updates fetched",
+			name: "collects available upgrades and reports 0 when upgrades fetched",
 			optr: &Operator{
 				name: "test",
 				cvLister: &cvLister{
@@ -290,7 +290,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 		},
 		{
-			name: "collects update",
+			name: "collects upgrade",
 			optr: &Operator{
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
@@ -327,7 +327,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 			},
 		},
 		{
-			name: "collects failing update",
+			name: "collects failing upgrade",
 			optr: &Operator{
 				releaseVersion: "0.0.2",
 				releaseImage:   "test/image:1",
@@ -345,7 +345,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterVersionStatus{
 								History: []configv1.UpdateHistory{
-									{State: configv1.CompletedUpdate, Version: "0.0.2", Image: "test/image:1", CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
+									{State: configv1.CompletedUpgrade, Version: "0.0.2", Image: "test/image:1", CompletionTime: &([]metav1.Time{{Time: time.Unix(2, 0)}}[0])},
 								},
 								Conditions: []configv1.ClusterOperatorStatusCondition{
 									{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Time{Time: time.Unix(4, 0)}, Reason: "Because stuff"},

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -65,11 +65,11 @@ func Test_pruneStatusHistory(t *testing.T) {
 	obj := &configv1.ClusterVersion{
 		Status: configv1.ClusterVersionStatus{
 			History: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.PartialUpdate, Version: "0.0.9"},
-				{State: configv1.PartialUpdate, Version: "0.0.8"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
-				{State: configv1.PartialUpdate, Version: "0.0.6"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.PartialUpgrade, Version: "0.0.9"},
+				{State: configv1.PartialUpgrade, Version: "0.0.8"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.6"},
 			},
 		},
 	}
@@ -83,49 +83,49 @@ func Test_pruneStatusHistory(t *testing.T) {
 			config:     obj.DeepCopy(),
 			maxHistory: 2,
 			want: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
 			},
 		},
 		{
 			config:     obj.DeepCopy(),
 			maxHistory: 3,
 			want: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.PartialUpdate, Version: "0.0.9"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.PartialUpgrade, Version: "0.0.9"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
 			},
 		},
 		{
 			config:     obj.DeepCopy(),
 			maxHistory: 4,
 			want: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.PartialUpdate, Version: "0.0.9"},
-				{State: configv1.PartialUpdate, Version: "0.0.8"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.PartialUpgrade, Version: "0.0.9"},
+				{State: configv1.PartialUpgrade, Version: "0.0.8"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
 			},
 		},
 		{
 			config:     obj.DeepCopy(),
 			maxHistory: 5,
 			want: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.PartialUpdate, Version: "0.0.9"},
-				{State: configv1.PartialUpdate, Version: "0.0.8"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
-				{State: configv1.PartialUpdate, Version: "0.0.6"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.PartialUpgrade, Version: "0.0.9"},
+				{State: configv1.PartialUpgrade, Version: "0.0.8"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.6"},
 			},
 		},
 		{
 			config:     obj.DeepCopy(),
 			maxHistory: 6,
 			want: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Version: "0.0.10"},
-				{State: configv1.PartialUpdate, Version: "0.0.9"},
-				{State: configv1.PartialUpdate, Version: "0.0.8"},
-				{State: configv1.CompletedUpdate, Version: "0.0.7"},
-				{State: configv1.PartialUpdate, Version: "0.0.6"},
+				{State: configv1.PartialUpgrade, Version: "0.0.10"},
+				{State: configv1.PartialUpgrade, Version: "0.0.9"},
+				{State: configv1.PartialUpgrade, Version: "0.0.8"},
+				{State: configv1.CompletedUpgrade, Version: "0.0.7"},
+				{State: configv1.PartialUpgrade, Version: "0.0.6"},
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 				releaseImage:   "image/image:v4.0.1",
 				namespace:      "test",
 				name:           "default",
-				client: fakeClientsetWithUpdates(
+				client: fakeClientsetWithUpgrades(
 					&configv1.ClusterVersion{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -197,7 +197,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 					t.Fatalf("unknown actions: %d %#v", len(act), act)
 				}
 				expectGet(t, act[0], "clusterversions", "", "default")
-				expectUpdateStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
+				expectUpgradeStatus(t, act[1], "clusterversions", "", &configv1.ClusterVersion{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
@@ -206,7 +206,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 					},
 					Status: configv1.ClusterVersionStatus{
 						History: []configv1.UpdateHistory{
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
+							{State: configv1.PartialUpgrade, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: defaultStartedTime},
 						},
 						Desired:     configv1.Update{Version: "4.0.1", Image: "image/image:v4.0.1"},
 						VersionHash: "",

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -117,7 +117,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 				manifests = append(manifests, m)
 			}
 
-			up := &payload.Update{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
+			up := &payload.Upgrade{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
 			r := &recorder{}
 			testMapper := resourcebuilder.NewResourceMapper()
 			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, newTestBuilder(r, test.reactors))
@@ -309,7 +309,7 @@ func Test_SyncWorker_apply_generic(t *testing.T) {
 			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, &unstructured.Unstructured{})
 			dynamicClient := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
 
-			up := &payload.Update{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
+			up := &payload.Upgrade{ReleaseImage: "test", ReleaseVersion: "v0.0.0", Manifests: manifests}
 			worker := &SyncWorker{}
 			worker.backoff.Steps = 1
 			worker.builder = &testResourceBuilder{
@@ -378,7 +378,7 @@ func newAction(gvk schema.GroupVersionKind, namespace, name string) action {
 
 type fakeSyncRecorder struct {
 	Returns *SyncWorkerStatus
-	Updates []configv1.Update
+	Upgrades []configv1.Update
 }
 
 func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
@@ -389,8 +389,8 @@ func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
 
 func (r *fakeSyncRecorder) Start(ctx context.Context, maxWorkers int) {}
 
-func (r *fakeSyncRecorder) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
-	r.Updates = append(r.Updates, desired)
+func (r *fakeSyncRecorder) Upgrade(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
+	r.Upgrades = append(r.Upgrades, desired)
 	return r.Returns
 }
 
@@ -418,7 +418,7 @@ func (r *fakeDirectoryRetriever) Set(info PayloadInfo, err error) {
 	r.Err = err
 }
 
-func (r *fakeDirectoryRetriever) RetrievePayload(ctx context.Context, update configv1.Update) (PayloadInfo, error) {
+func (r *fakeDirectoryRetriever) RetrievePayload(ctx context.Context, upgrade configv1.Update) (PayloadInfo, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	return r.Info, r.Err

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -17,7 +17,7 @@ func Test_statusWrapper_ReportProgress(t *testing.T) {
 		wantProgress bool
 	}{
 		{
-			name:     "skip updates that clear an error and are at an earlier fraction",
+			name:     "skip upgrades that clear an error and are at an earlier fraction",
 			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Update{Image: "testing"}, Fraction: 0.1},
 			next:     SyncWorkerStatus{Actual: configv1.Update{Image: "testing"}},
 			want:     false,

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -20,11 +20,11 @@ import (
 )
 
 // syncUpgradeable. The status is only checked if it has been more than
-// the minimumUpdateCheckInterval since the last check.
+// the minimumUpgradeCheckInterval since the last check.
 func (optr *Operator) syncUpgradeable(config *configv1.ClusterVersion) error {
-	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
+	// upgrades are only checked at most once per minimumUpgradeCheckInterval or if the generation changes
 	u := optr.getUpgradeable()
-	if u != nil && u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
+	if u != nil && u.RecentlyChanged(optr.minimumUpgradeCheckInterval) {
 		klog.V(4).Infof("Upgradeable conditions were recently checked, will try later.")
 		return nil
 	}
@@ -76,7 +76,7 @@ func (u *upgradeable) RecentlyChanged(interval time.Duration) bool {
 	return u.At.After(time.Now().Add(-interval))
 }
 
-func (u *upgradeable) NeedsUpdate(original *configv1.ClusterVersion) *configv1.ClusterVersion {
+func (u *upgradeable) NeedsUpgrade(original *configv1.ClusterVersion) *configv1.ClusterVersion {
 	if u == nil {
 		return nil
 	}
@@ -109,7 +109,7 @@ func collectUpgradeableConditions(conditions []configv1.ClusterOperatorStatusCon
 	return ret
 }
 
-// setUpgradeable updates the currently calculated status of Upgradeable
+// setUpgradeable upgrades the currently calculated status of Upgradeable
 func (optr *Operator) setUpgradeable(u *upgradeable) {
 	if u != nil {
 		u.At = time.Now()

--- a/pkg/payload/image.go
+++ b/pkg/payload/image.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ImageForShortName returns the image using the updatepayload embedded in
+// ImageForShortName returns the image using the upgradepayload embedded in
 // the Operator.
 func ImageForShortName(name string) (string, error) {
 	if err := ValidateDirectory(DefaultPayloadDir); err != nil {
@@ -30,5 +30,5 @@ func ImageForShortName(name string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("error: Unknown name requested, could not find %s in UpdatePayload", name)
+	return "", fmt.Errorf("error: Unknown name requested, could not find %s in UpgradePayload", name)
 }

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/cluster-version-operator/lib"
 )
 
-func Test_loadUpdatePayload(t *testing.T) {
+func Test_loadUpgradePayload(t *testing.T) {
 	type args struct {
 		dir          string
 		releaseImage string
@@ -24,7 +24,7 @@ func Test_loadUpdatePayload(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *Update
+		want    *Upgrade
 		wantErr bool
 	}{
 		{
@@ -33,7 +33,7 @@ func Test_loadUpdatePayload(t *testing.T) {
 				dir:          filepath.Join("..", "cvo", "testdata", "payloadtest"),
 				releaseImage: "image:1",
 			},
-			want: &Update{
+			want: &Upgrade{
 				ReleaseImage:   "image:1",
 				ReleaseVersion: "1.0.0-abc",
 				ImageRef: &imagev1.ImageStream{
@@ -104,13 +104,13 @@ func Test_loadUpdatePayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := LoadUpdate(tt.args.dir, tt.args.releaseImage, "exclude-test")
+			got, err := LoadUpgrade(tt.args.dir, tt.args.releaseImage, "exclude-test")
 			if (err != nil) != tt.wantErr {
-				t.Errorf("loadUpdatePayload() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("loadUpgradePayload() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("loadUpdatePayload() = %s", diff.ObjectReflectDiff(tt.want, got))
+				t.Errorf("loadUpgradePayload() = %s", diff.ObjectReflectDiff(tt.want, got))
 			}
 		})
 	}

--- a/pkg/payload/precondition/precondition.go
+++ b/pkg/payload/precondition/precondition.go
@@ -28,7 +28,7 @@ func (e *Error) Cause() error {
 	return e.Nested
 }
 
-// ReleaseContext holds information about the update being considered
+// ReleaseContext holds information about the upgrade being considered
 type ReleaseContext struct {
 	// DesiredVersion is the version of the payload being considered.
 	// While this might be a semantic version, consumers should not
@@ -82,7 +82,7 @@ func Summarize(errs []error) error {
 	} else {
 		msg = fmt.Sprintf("Multiple precondition checks failed:\n* %s", strings.Join(msgs, "\n* "))
 	}
-	return &payload.UpdateError{
+	return &payload.UpgradeError{
 		Nested:  nil,
 		Reason:  "UpgradePreconditionCheckFailed",
 		Message: msg,

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -93,7 +93,7 @@ func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder
 		case <-time.After(d):
 			continue
 		case <-ctx.Done():
-			if uerr, ok := lastErr.(*UpdateError); ok {
+			if uerr, ok := lastErr.(*UpgradeError); ok {
 				uerr.Task = st.Copy()
 				return uerr
 			}
@@ -101,10 +101,10 @@ func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder
 			if len(cause) > 0 {
 				cause = ": " + cause
 			}
-			return &UpdateError{
+			return &UpgradeError{
 				Nested:  lastErr,
 				Reason:  reason,
-				Message: fmt.Sprintf("Could not update %s%s", st, cause),
+				Message: fmt.Sprintf("Could not upgrade %s%s", st, cause),
 
 				Task: st.Copy(),
 			}
@@ -112,8 +112,8 @@ func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder
 	}
 }
 
-// UpdateError is a wrapper for errors that occur during a payload sync.
-type UpdateError struct {
+// UpgradeError is a wrapper for errors that occur during a payload sync.
+type UpgradeError struct {
 	Nested  error
 	Reason  string
 	Message string
@@ -122,40 +122,40 @@ type UpdateError struct {
 	Task *Task
 }
 
-func (e *UpdateError) Error() string {
+func (e *UpgradeError) Error() string {
 	return e.Message
 }
 
-func (e *UpdateError) Cause() error {
+func (e *UpgradeError) Cause() error {
 	return e.Nested
 }
 
-// reasonForUpdateError provides a succint explanation of a known error type for use in a human readable
-// message during update. Since all objects in the image should be successfully applied, messages
+// reasonForUpgradeError provides a succint explanation of a known error type for use in a human readable
+// message during upgrade. Since all objects in the image should be successfully applied, messages
 // should direct the reader (likely a cluster administrator) to a possible cause in their own config.
 func reasonForPayloadSyncError(err error) (string, string) {
 	err = errors.Cause(err)
 	switch {
 	case apierrors.IsNotFound(err), apierrors.IsAlreadyExists(err):
-		return "UpdatePayloadResourceNotFound", "resource may have been deleted"
+		return "UpgradePayloadResourceNotFound", "resource may have been deleted"
 	case apierrors.IsConflict(err):
-		return "UpdatePayloadResourceConflict", "someone else is updating this resource"
+		return "UpgradePayloadResourceConflict", "someone else is updating this resource"
 	case apierrors.IsTimeout(err), apierrors.IsServiceUnavailable(err), apierrors.IsUnexpectedServerError(err):
-		return "UpdatePayloadClusterDown", "the server is down or not responding"
+		return "UpgradePayloadClusterDown", "the server is down or not responding"
 	case apierrors.IsInternalError(err):
-		return "UpdatePayloadClusterError", "the server is reporting an internal error"
+		return "UpgradePayloadClusterError", "the server is reporting an internal error"
 	case apierrors.IsInvalid(err):
-		return "UpdatePayloadResourceInvalid", "the object is invalid, possibly due to local cluster configuration"
+		return "UpgradePayloadResourceInvalid", "the object is invalid, possibly due to local cluster configuration"
 	case apierrors.IsUnauthorized(err):
-		return "UpdatePayloadClusterUnauthorized", "could not authenticate to the server"
+		return "UpgradePayloadClusterUnauthorized", "could not authenticate to the server"
 	case apierrors.IsForbidden(err):
-		return "UpdatePayloadResourceForbidden", "the server has forbidden updates to this resource"
+		return "UpgradePayloadResourceForbidden", "the server has forbidden upgrades to this resource"
 	case apierrors.IsServerTimeout(err), apierrors.IsTooManyRequests(err):
-		return "UpdatePayloadClusterOverloaded", "the server is overloaded and is not accepting updates"
+		return "UpgradePayloadClusterOverloaded", "the server is overloaded and is not accepting upgrades"
 	case meta.IsNoMatchError(err):
-		return "UpdatePayloadResourceTypeMissing", "the server does not recognize this resource, check extension API servers"
+		return "UpgradePayloadResourceTypeMissing", "the server does not recognize this resource, check extension API servers"
 	default:
-		return "UpdatePayloadFailed", ""
+		return "UpgradePayloadFailed", ""
 	}
 }
 
@@ -163,37 +163,37 @@ func SummaryForReason(reason, name string) string {
 	switch reason {
 
 	// likely temporary errors
-	case "UpdatePayloadResourceNotFound", "UpdatePayloadResourceConflict":
-		return "some resources could not be updated"
-	case "UpdatePayloadClusterDown":
+	case "UpgradePayloadResourceNotFound", "UpgradePayloadResourceConflict":
+		return "some resources could not be upgraded"
+	case "UpgradePayloadClusterDown":
 		return "the control plane is down or not responding"
-	case "UpdatePayloadClusterError":
+	case "UpgradePayloadClusterError":
 		return "the control plane is reporting an internal error"
-	case "UpdatePayloadClusterOverloaded":
-		return "the control plane is overloaded and is not accepting updates"
-	case "UpdatePayloadClusterUnauthorized":
+	case "UpgradePayloadClusterOverloaded":
+		return "the control plane is overloaded and is not accepting upgrades"
+	case "UpgradePayloadClusterUnauthorized":
 		return "could not authenticate to the server"
-	case "UpdatePayloadRetrievalFailed":
-		return "could not download the update"
+	case "UpgradePayloadRetrievalFailed":
+		return "could not download the upgrade"
 
 	// likely a policy or other configuration error due to end user action
-	case "UpdatePayloadResourceForbidden":
-		return "the server is rejecting updates"
+	case "UpgradePayloadResourceForbidden":
+		return "the server is rejecting upgrades"
 
 	// the image may not be correct, or the cluster may be in an unexpected
 	// state
-	case "UpdatePayloadResourceTypeMissing":
-		return "a required extension is not available to update"
-	case "UpdatePayloadResourceInvalid":
+	case "UpgradePayloadResourceTypeMissing":
+		return "a required extension is not available to upgrade"
+	case "UpgradePayloadResourceInvalid":
 		return "some cluster configuration is invalid"
 	case "UpdatePayloadIntegrity":
-		return "the contents of the update are invalid"
+		return "the contents of the target release image are invalid"
 
 	case "ImageVerificationFailed":
 		return "the image may not be safe to use"
 
 	case "UpgradePreconditionCheckFailed":
-		return "it may not be safe to apply this update"
+		return "it may not be safe to apply this upgrade"
 
 	case "ClusterOperatorDegraded":
 		if len(name) > 0 {
@@ -219,8 +219,8 @@ func SummaryForReason(reason, name string) string {
 		return "a workload cannot roll out"
 	}
 
-	if strings.HasPrefix(reason, "UpdatePayload") {
-		return "the update could not be applied"
+	if strings.HasPrefix(reason, "UpgradePayload") {
+		return "the upgrade could not be applied"
 	}
 
 	if len(name) > 0 {

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -487,7 +487,7 @@ func Test_TaskGraph_real(t *testing.T) {
 	if len(path) == 0 {
 		t.Skip("TEST_GRAPH_PATH unset")
 	}
-	p, err := LoadUpdate(path, "arbitrary/image:1", "")
+	p, err := LoadUpgrade(path, "arbitrary/image:1", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -36,7 +36,7 @@ import (
 
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	externalversions "github.com/openshift/client-go/config/informers/externalversions"
-	"github.com/openshift/cluster-version-operator/pkg/autoupdate"
+	"github.com/openshift/cluster-version-operator/pkg/autoupgrade"
 	"github.com/openshift/cluster-version-operator/pkg/cvo"
 	"github.com/openshift/cluster-version-operator/pkg/internal"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -63,7 +63,7 @@ type Options struct {
 	NodeName   string
 	ListenAddr string
 
-	EnableAutoUpdate            bool
+	EnableAutoUpgrade            bool
 	EnableDefaultClusterVersion bool
 
 	// Exclude is used to determine whether to exclude
@@ -384,7 +384,7 @@ func useProtobuf(config *rest.Config) {
 // Context holds the controllers for this operator and exposes a unified start command.
 type Context struct {
 	CVO        *cvo.Operator
-	AutoUpdate *autoupdate.Controller
+	AutoUpgrade *autoupgrade.Controller
 
 	CVInformerFactory              externalversions.SharedInformerFactory
 	OpenshiftConfigInformerFactory informers.SharedInformerFactory
@@ -426,8 +426,8 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			o.Exclude,
 		),
 	}
-	if o.EnableAutoUpdate {
-		ctx.AutoUpdate = autoupdate.New(
+	if o.EnableAutoUpgrade {
+		ctx.AutoUpgrade = autoupgrade.New(
 			o.Namespace, o.Name,
 			cvInformer.Config().V1().ClusterVersions(),
 			sharedInformers.Config().V1().ClusterOperators(),
@@ -443,8 +443,8 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 func (c *Context) Start(ctx context.Context) {
 	ch := ctx.Done()
 	go c.CVO.Run(ctx, 2)
-	if c.AutoUpdate != nil {
-		go c.AutoUpdate.Run(2, ch)
+	if c.AutoUpgrade != nil {
+		go c.AutoUpgrade.Run(2, ch)
 	}
 	c.CVInformerFactory.Start(ch)
 	c.OpenshiftConfigInformerFactory.Start(ch)

--- a/pkg/verify/configmap.go
+++ b/pkg/verify/configmap.go
@@ -22,7 +22,7 @@ const ReleaseAnnotationConfigMapVerifier = "release.openshift.io/verification-co
 // first payload item in lexographic order will be considered - all others are ignored. The
 // verifier returned by this method
 //
-// The presence of one or more config maps instructs the CVO to verify updates before they are
+// The presence of one or more config maps instructs the CVO to verify upgrades before they are
 // downloaded.
 //
 // The keys within the config map in the data field define how verification is performed:

--- a/pkg/verify/verifyconfigmap/store.go
+++ b/pkg/verify/verifyconfigmap/store.go
@@ -166,9 +166,9 @@ func (s *Store) Store(ctx context.Context, signaturesByDigest map[string][][]byt
 			existing.Labels = cm.Labels
 			existing.BinaryData = cm.BinaryData
 			existing.Data = cm.Data
-			_, err = s.client.ConfigMaps(s.ns).Update(existing)
+			_, err = s.client.ConfigMaps(s.ns).Upgrade(existing)
 			if err != nil {
-				klog.V(4).Infof("update signature cache config map %s in namespace %s with %d signatures", cm.ObjectMeta.Name, s.ns, count)
+				klog.V(4).Infof("upgrade signature cache config map %s in namespace %s with %d signatures", cm.ObjectMeta.Name, s.ns, count)
 			}
 			return err
 		},


### PR DESCRIPTION
We were not very consistent before, which can be confusing for folks who wonder if we are attempting to make a distinction between the two terms.  While some folks try to distinguish between bugfix updates and new-feature upgrades, the CVO does not make that distinction.  This commit moves us to the "upgrades" where we can do so without breaking APIs.  For example, it does not change:

* The `cluster_version_available_updates` metric.
* The `RetrievedUpdates` condition type and its reasons like `UpdatePayloadIntegrity`.
* External API's like `ClusterVersion`'s `desiredUpdate`, `availableUpdates`, and `updateHistory`.

To avoid slippery slopes, all internal handlers for those external APIs are being changed to use "upgrades", to minimize confusion about where boundaries should be drawn between the external API and internal naming.

I am not changing `update-codegen.sh` or `update-vendor.sh`, since those are internal tools that are distinct from cluster upgrades.

I am changing `--enable-auto-update` -> `--enable-auto-upgrade`, because while that is technically an external API, the only consumers who could possibly touch it today are folks who are overriding the CVO deployment, and those folks are unlikely to be upgrading anyway.

WIP while I work any remaining kinds out of overly-broad `sed`s ;).