### PR TITLE
pkg/cvo/status: Change "downloading update" to "downloading release image"

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -1140,7 +1140,7 @@ func TestOperator_sync(t *testing.T) {
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 							// we correct the message that was incorrect from the previous state
-							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "DownloadingUpdate", Message: "Working towards image/image:v4.0.1: downloading update"},
+							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "DownloadingUpdate", Message: "Working towards image/image:v4.0.1: downloading release image"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 						},
 					},

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -295,7 +295,7 @@ func (optr *Operator) syncStatus(original, config *configv1.ClusterVersion, stat
 				if len(reason) == 0 {
 					reason = "DownloadingUpdate"
 				}
-				message = fmt.Sprintf("Working towards %s: downloading update", version)
+				message = fmt.Sprintf("Working towards %s: downloading release image", version)
 			case skipFailure:
 				reason = progressReason
 				message = fmt.Sprintf("Working towards %s: %s", version, progressShortMessage)

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -894,7 +894,7 @@ func waitUntilUpgradeFails(t *testing.T, client clientset.Interface, ns string, 
 		if len(cv.Status.Desired.Version) == 0 {
 			// if we are downloading the next update, we're allowed to have an empty desired version because we
 			// haven't been able to load the payload
-			if c := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue && strings.Contains(c.Message, "downloading update") && c.Reason == "DownloadingUpdate" {
+			if c := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing); c != nil && c.Status == configv1.ConditionTrue && strings.Contains(c.Message, "downloading release image") && c.Reason == "DownloadingUpdate" {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Folks are seeing `downloading update` messages during install, [like][1]:

```
time="2020-06-05T15:01:43Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.5.0-0.nightly-2020-06-04-025914: 57% complete"
time="2020-06-05T15:02:53Z" level=debug msg="Still waiting for the cluster to initialize: Multiple errors are preventing progress:\n* Could not update oauthclient \"console\" (351 of 584): the server does not recognize this resource, check extension API servers\n* Could not update prometheusrule \"openshift-cloud-credential-operator/cloud-credential-operator-alerts\" (186 of 584): the server does not recognize this resource, check extension API servers"
time="2020-06-05T15:03:44Z" level=debug msg="Still waiting for the cluster to initialize: Multiple errors are preventing progress:\n* Could not update oauthclient \"console\" (351 of 584): the server does not recognize this resource, check extension API servers\n* Could not update prometheusrule \"openshift-cloud-credential-operator/cloud-credential-operator-alerts\" (186 of 584): the server does not recognize this resource, check extension API servers"
time="2020-06-05T15:10:44Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.5.0-0.nightly-2020-06-04-025914"
time="2020-06-05T15:10:44Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.5.0-0.nightly-2020-06-04-025914: downloading update"
time="2020-06-05T15:10:44Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.5.0-0.nightly-2020-06-04-025914"
time="2020-06-05T15:10:44Z" level=debug msg="Still waiting for the cluster to initialize: Working towards 4.5.0-0.nightly-2020-06-04-025914: 0% complete"
```

when the CVO pod is rescheduled and the new pod is initializing itself.  We might want to adjust things so we can skip that step when the target release image matches the CVO pod's release image, but regardless of whether we do that, using the more geneneric `release image` works for both updates and initial release images.  I'm leaving the `DownloadingUpdate` reason unchanged, because reasons are part of our committed API, and this seems like a minor enough change that I don't think we should break that API.  Messages, on the other hand, are for human consumption and [explicitly][2] not intended for machine matching.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1844529#c0
[2]: https://github.com/openshift/api/blob/eb651a5bb0ad41d771003d277a6d33b8ee307085/config/v1/types_cluster_operator.go#L133