### PR TITLE
lib/resourcebuilder/apiext: Centralize b.modifier(crd) call

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -45,24 +45,22 @@ func (b *crdBuilder) WithModifier(f MetaV1ObjectModifierFunc) Interface {
 func (b *crdBuilder) Do(ctx context.Context) error {
 	crd := resourceread.ReadCustomResourceDefinitionOrDie(b.raw)
 
+	if b.modifier != nil {
+		b.modifier(crd)
+	}
+
 	var updated bool
 	var err error
 	var name string
 
 	switch crd := crd.(type) {
 	case *apiextv1beta1.CustomResourceDefinition:
-		if b.modifier != nil {
-			b.modifier(crd)
-		}
 		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1beta1(b.clientV1beta1, crd)
 		if err != nil {
 			return err
 		}
 		name = crd.Name
 	case *apiextv1.CustomResourceDefinition:
-		if b.modifier != nil {
-			b.modifier(crd)
-		}
 		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1(b.clientV1, crd)
 		if err != nil {
 			return err


### PR DESCRIPTION
No need to repeat this for every version, which is how we've had things since 4ee7b07e99 (#259).  Spun off from #400 at @smarterclayton's [request](https://github.com/openshift/cluster-version-operator/pull/400/#issuecomment-655152378).