### PR TITLE
lib/resourcebuilder/apiext: Error on unrecognized CRD version

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -2,6 +2,7 @@ package resourcebuilder
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/klog"
 
@@ -49,25 +50,27 @@ func (b *crdBuilder) Do(ctx context.Context) error {
 	var err error
 	var name string
 
-	switch crd := crd.(type) {
+	switch typedCRD := crd.(type) {
 	case *apiextv1beta1.CustomResourceDefinition:
 		if b.modifier != nil {
-			b.modifier(crd)
+			b.modifier(typedCRD)
 		}
-		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1beta1(b.clientV1beta1, crd)
+		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1beta1(b.clientV1beta1, typedCRD)
 		if err != nil {
 			return err
 		}
-		name = crd.Name
+		name = typedCRD.Name
 	case *apiextv1.CustomResourceDefinition:
 		if b.modifier != nil {
-			b.modifier(crd)
+			b.modifier(typedCRD)
 		}
-		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1(b.clientV1, crd)
+		_, updated, err = resourceapply.ApplyCustomResourceDefinitionV1(b.clientV1, typedCRD)
 		if err != nil {
 			return err
 		}
-		name = crd.Name
+		name = typedCRD.Name
+	default:
+		return fmt.Errorf("unrecognized CustomResourceDefinition version: %T", crd)
 	}
 
 	if updated {


### PR DESCRIPTION
Error for unrecognized CRD version, because that will be easier to debug than trying to figure out why a CRD manifest is being silently ignored by the CVO (which is what we've done since the version switch landed in 4ee7b07e99, #259).  Split out from #400 at @smarterclayton's [request](https://github.com/openshift/cluster-version-operator/pull/400#issuecomment-655152378).