### PR TITLE
Bug 1907329: Add cluster profile support

### DIFF
--- a/hack/cluster-version-util/task_graph.go
+++ b/hack/cluster-version-util/task_graph.go
@@ -30,7 +30,7 @@ func newTaskGraphCmd() *cobra.Command {
 
 func runTaskGraphCmd(cmd *cobra.Command, args []string) error {
 	manifestDir := args[0]
-	release, err := payload.LoadUpdate(manifestDir, "", "")
+	release, err := payload.LoadUpdate(manifestDir, "", "", payload.DefaultClusterProfile)
 	if err != nil {
 		return err
 	}

--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-cluster-version
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
   labels:
     name: openshift-cluster-version

--- a/install/0000_00_cluster-version-operator_02_roles.yaml
+++ b/install/0000_00_cluster-version-operator_02_roles.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-version-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cluster-version
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/install/0000_90_cluster-version-operator_00_prometheusrole.yaml
+++ b/install/0000_90_cluster-version-operator_00_prometheusrole.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-version
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
   - ""

--- a/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
+++ b/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cluster-version
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: openshift-cluster-version
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -32,6 +33,7 @@ metadata:
   namespace: openshift-cluster-version
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   groups:
   - name: cluster-version

--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -6,8 +6,9 @@ metadata:
   labels:
     k8s-app: cluster-version-operator
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert
+    include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert
 spec:
   type: ClusterIP
   selector:

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -78,6 +78,7 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 		cvLister:                    &clientCVLister{client: client},
 		exclude:                     "exclude-test",
 		eventRecorder:               record.NewFakeRecorder(100),
+		clusterProfile:              payload.DefaultClusterProfile,
 	}
 
 	dynamicScheme := runtime.NewScheme()
@@ -94,6 +95,7 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 		},
 		"exclude-test",
 		record.NewFakeRecorder(100),
+		o.clusterProfile,
 	)
 	o.configSync = worker
 
@@ -228,7 +230,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Generation:  1,
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -241,7 +243,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -255,7 +257,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Fraction:    float32(2) / 3,
 			Initial:     true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -269,7 +271,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -312,7 +314,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				// Because image and operator had mismatched versions, we get two entries (which shouldn't happen unless there is a bug in the CVO)
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -334,7 +336,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Generation:  1,
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -347,7 +349,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -360,7 +362,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -373,7 +375,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Reconciling: true,
 			Completed:   2,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -542,7 +544,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -555,7 +557,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -569,7 +571,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Fraction:    float32(2) / 3,
 			Initial:     true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -583,7 +585,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -627,7 +629,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				// Because image and operator had mismatched versions, we get two entries (which shouldn't happen unless there is a bug in the CVO)
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -648,7 +650,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -661,7 +663,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -674,7 +676,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -687,7 +689,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Completed:   2,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -847,7 +849,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -860,7 +862,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
 			Initial:     true,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -874,7 +876,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Fraction:    float32(2) / 3,
 			Initial:     true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -888,7 +890,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -932,7 +934,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				// Because image and operator had mismatched versions, we get two entries (which shouldn't happen unless there is a bug in the CVO)
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -953,7 +955,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -966,7 +968,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -979,7 +981,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -992,7 +994,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Reconciling: true,
 			Completed:   2,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -1041,7 +1043,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -1123,7 +1125,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1176,7 +1178,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1187,7 +1189,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1199,7 +1201,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1212,7 +1214,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1250,7 +1252,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 				Image:   "image/image:1",
 				URL:     configv1.URL("https://example.com/v1.0.1-abc"),
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1288,7 +1290,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -1370,7 +1372,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1423,7 +1425,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1434,7 +1436,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1446,7 +1448,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1459,7 +1461,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1497,7 +1499,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 				Image:   "image/image:1",
 				URL:     configv1.URL("https://example.com/v1.0.1-abc"),
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1517,7 +1519,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1529,7 +1531,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1541,7 +1543,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1553,7 +1555,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 			Reconciling: true,
 			Completed:   2,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1588,7 +1590,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -1664,7 +1666,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1721,7 +1723,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		},
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1732,7 +1734,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1744,7 +1746,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1757,7 +1759,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1795,7 +1797,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 				Image:   "image/image:1",
 				URL:     configv1.URL("https://example.com/v1.0.1-abc"),
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1834,7 +1836,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -1919,7 +1921,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 			ObservedGeneration: 1,
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1964,7 +1966,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		},
 		SyncWorkerStatus{
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1976,7 +1978,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -1989,7 +1991,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		SyncWorkerStatus{
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -2003,7 +2005,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version: "1.0.1-abc",
 				Image:   "image/image:1",
@@ -2042,7 +2044,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 				Image:   "image/image:1",
 				URL:     configv1.URL("https://example.com/v1.0.1-abc"),
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -2090,7 +2092,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				// TODO: this is wrong, should be single partial entry
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -2142,7 +2144,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2154,7 +2156,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2167,7 +2169,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2180,7 +2182,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Completed:   1,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2209,7 +2211,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2221,7 +2223,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2233,7 +2235,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2245,7 +2247,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 			Reconciling: true,
 			Completed:   2,
 			Fraction:    1,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2303,7 +2305,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -2348,7 +2350,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 		SyncWorkerStatus{
 			Reconciling: true,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2384,7 +2386,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(1) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2406,7 +2408,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			Reconciling: true,
 			Fraction:    float32(2) / 3,
 			Step:        "ApplyResources",
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Actual: configv1.Release{
 				Version:  "1.0.0-abc",
 				Image:    "image/image:1",
@@ -2439,7 +2441,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 			Reconciling: true,
 			Step:        "ApplyResources",
 			Fraction:    float32(2) / 3,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			Failure: &payload.UpdateError{
 				Nested:  fmt.Errorf("unable to proceed"),
 				Reason:  "UpdatePayloadFailed",
@@ -2482,7 +2484,7 @@ func TestCVO_ErrorDuringReconcile(t *testing.T) {
 				URL:      configv1.URL("https://example.com/v1.0.0-abc"),
 				Channels: []string{"channel-a", "channel-b", "channel-c"},
 			},
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
@@ -2577,7 +2579,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		SyncWorkerStatus{
 			Initial:     true,
 			Step:        "ApplyResources",
-			VersionHash: "7m-gGRrpkDU=",
+			VersionHash: "Gyh2W6qcDO4=",
 			Actual:      configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
 		},
 	)
@@ -2595,7 +2597,7 @@ func TestCVO_ParallelError(t *testing.T) {
 					Initial:     true,
 					Fraction:    status.Fraction,
 					Step:        "ApplyResources",
-					VersionHash: "7m-gGRrpkDU=",
+					VersionHash: "Gyh2W6qcDO4=",
 					Actual:      configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
 				}) {
 					t.Fatalf("unexpected status: %v", status)
@@ -2616,7 +2618,7 @@ func TestCVO_ParallelError(t *testing.T) {
 			Failure:      err,
 			Fraction:     float32(1) / 3,
 			Step:         "ApplyResources",
-			VersionHash:  "7m-gGRrpkDU=",
+			VersionHash:  "Gyh2W6qcDO4=",
 			Actual:       configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
 			LastProgress: status.LastProgress,
 		}) {
@@ -2649,7 +2651,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
-			VersionHash: "7m-gGRrpkDU=",
+			VersionHash: "Gyh2W6qcDO4=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 			},
@@ -2692,7 +2694,7 @@ func TestCVO_VerifyInitializingPayloadState(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 			},
@@ -2751,7 +2753,7 @@ func TestCVO_VerifyUpdatingPayloadState(t *testing.T) {
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
 			Desired:     desired,
-			VersionHash: "6GC9TkkG9PA=",
+			VersionHash: "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc.0", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -155,11 +155,13 @@ type SyncWorker struct {
 	// manifests should be excluded based on an annotation
 	// of the form exclude.release.openshift.io/<identifier>=true
 	exclude string
+
+	clusterProfile string
 }
 
 // NewSyncWorker initializes a ConfigSyncWorker that will retrieve payloads to disk, apply them via builder
 // to a server, and obey limits about how often to reconcile or retry on errors.
-func NewSyncWorker(retriever PayloadRetriever, builder payload.ResourceBuilder, reconcileInterval time.Duration, backoff wait.Backoff, exclude string, eventRecorder record.EventRecorder) *SyncWorker {
+func NewSyncWorker(retriever PayloadRetriever, builder payload.ResourceBuilder, reconcileInterval time.Duration, backoff wait.Backoff, exclude string, eventRecorder record.EventRecorder, clusterProfile string) *SyncWorker {
 	return &SyncWorker{
 		retriever:     retriever,
 		builder:       builder,
@@ -175,14 +177,16 @@ func NewSyncWorker(retriever PayloadRetriever, builder payload.ResourceBuilder, 
 		report: make(chan SyncWorkerStatus, 500),
 
 		exclude: exclude,
+
+		clusterProfile: clusterProfile,
 	}
 }
 
 // NewSyncWorkerWithPreconditions initializes a ConfigSyncWorker that will retrieve payloads to disk, apply them via builder
 // to a server, and obey limits about how often to reconcile or retry on errors.
 // It allows providing preconditions for loading payload.
-func NewSyncWorkerWithPreconditions(retriever PayloadRetriever, builder payload.ResourceBuilder, preconditions precondition.List, reconcileInterval time.Duration, backoff wait.Backoff, exclude string, eventRecorder record.EventRecorder) *SyncWorker {
-	worker := NewSyncWorker(retriever, builder, reconcileInterval, backoff, exclude, eventRecorder)
+func NewSyncWorkerWithPreconditions(retriever PayloadRetriever, builder payload.ResourceBuilder, preconditions precondition.List, reconcileInterval time.Duration, backoff wait.Backoff, exclude string, eventRecorder record.EventRecorder, clusterProfile string) *SyncWorker {
+	worker := NewSyncWorker(retriever, builder, reconcileInterval, backoff, exclude, eventRecorder, clusterProfile)
 	worker.preconditions = preconditions
 	return worker
 }
@@ -547,7 +551,7 @@ func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers in
 		}
 
 		w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeNormal, "VerifyPayload", "verifying payload version=%q image=%q", desired.Version, desired.Image)
-		payloadUpdate, err := payload.LoadUpdate(info.Directory, desired.Image, w.exclude)
+		payloadUpdate, err := payload.LoadUpdate(info.Directory, desired.Image, w.exclude, w.clusterProfile)
 		if err != nil {
 			w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeWarning, "VerifyPayloadFailed", "verifying payload failed version=%q image=%q failure=%v", desired.Version, desired.Image, err)
 			reporter.Report(SyncWorkerStatus{

--- a/pkg/cvo/testdata/manifests/loads-valid.yaml
+++ b/pkg/cvo/testdata/manifests/loads-valid.yaml
@@ -4,6 +4,7 @@ metadata:
   name: release-verification
   namespace: openshift-config-managed
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/verification-config-map: ""
 data:
   verifier-public-key-redhat: |

--- a/pkg/cvo/testdata/manifests/requires-data.yaml
+++ b/pkg/cvo/testdata/manifests/requires-data.yaml
@@ -4,4 +4,5 @@ metadata:
   name: release-verification
   namespace: openshift-config-managed
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/verification-config-map: ""

--- a/pkg/cvo/testdata/paralleltest/release-manifests/0000_10_a_file.yaml
+++ b/pkg/cvo/testdata/paralleltest/release-manifests/0000_10_a_file.yaml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: 10-a-file
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/paralleltest/release-manifests/0000_20_a_file.yaml
+++ b/pkg/cvo/testdata/paralleltest/release-manifests/0000_20_a_file.yaml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: 20-a-file
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/paralleltest/release-manifests/0000_20_b_file.yaml
+++ b/pkg/cvo/testdata/paralleltest/release-manifests/0000_20_b_file.yaml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: 20-b-file
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file
+++ b/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file
@@ -2,6 +2,9 @@
   "kind": "Test",
   "apiVersion": "v1",
   "metadata": {
-    "name": "file"
+    "name": "file",
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true"
+    }
   }
 }

--- a/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.json
+++ b/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.json
@@ -2,6 +2,9 @@
   "kind": "Test",
   "apiVersion": "v1",
   "metadata": {
-    "name": "file-json"
+    "name": "file-json",
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true"
+    }
   }
 }

--- a/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.yaml
+++ b/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.yaml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: file-yaml
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.yml
+++ b/pkg/cvo/testdata/payloadtest-2/release-manifests/0000_10_a_file.yml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: file-yml
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file
@@ -2,6 +2,9 @@
   "kind": "Test",
   "apiVersion": "v1",
   "metadata": {
-    "name": "file"
+    "name": "file",
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true"
+    }
   }
 }

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.json
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.json
@@ -2,6 +2,9 @@
   "kind": "Test",
   "apiVersion": "v1",
   "metadata": {
-    "name": "file-json"
+    "name": "file-json",
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true"
+    }
   }
 }

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.yaml
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.yaml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: file-yaml
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.yml
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_10_a_file.yml
@@ -2,3 +2,5 @@ kind: Test
 apiVersion: v1
 metadata:
   name: file-yml
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest/release-manifests/0000_20_a_exclude.yml
+++ b/pkg/cvo/testdata/payloadtest/release-manifests/0000_20_a_exclude.yml
@@ -3,4 +3,5 @@ apiVersion: v1
 metadata:
   name: file-20-yml
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/exclude-test: "true"

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -96,7 +96,7 @@ const (
 	cincinnatiJSONFile  = "release-metadata"
 	imageReferencesFile = "image-references"
 
-	defaultClusterProfile = "self-managed-high-availability"
+	DefaultClusterProfile = "self-managed-high-availability"
 )
 
 // Update represents the contents of a release image.
@@ -132,7 +132,7 @@ type metadata struct {
 	Metadata map[string]interface{}
 }
 
-func LoadUpdate(dir, releaseImage, excludeIdentifier string) (*Update, error) {
+func LoadUpdate(dir, releaseImage, excludeIdentifier, profile string) (*Update, error) {
 	payload, tasks, err := loadUpdatePayloadMetadata(dir, releaseImage)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string) (*Update, error) {
 			// Filter out manifests that should be excluded based on annotation
 			filteredMs := []manifest.Manifest{}
 			for _, manifest := range ms {
-				if shouldExclude(excludeIdentifier, &manifest) {
+				if shouldExclude(excludeIdentifier, profile, &manifest) {
 					continue
 				}
 				filteredMs = append(filteredMs, manifest)
@@ -213,10 +213,22 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string) (*Update, error) {
 	return payload, nil
 }
 
-func shouldExclude(excludeIdentifier string, manifest *manifest.Manifest) bool {
-	excludeAnnotation := fmt.Sprintf("exclude.release.openshift.io/%s", excludeIdentifier)
+func shouldExclude(excludeIdentifier, profile string, manifest *manifest.Manifest) bool {
 	annotations := manifest.Obj.GetAnnotations()
-	return annotations != nil && annotations[excludeAnnotation] == "true"
+	if annotations == nil {
+		return true
+	}
+
+	excludeAnnotation := fmt.Sprintf("exclude.release.openshift.io/%s", excludeIdentifier)
+	if annotations[excludeAnnotation] == "true" {
+		return true
+	}
+
+	profileAnnotation := fmt.Sprintf("include.release.openshift.io/%s", profile)
+	if val, ok := annotations[profileAnnotation]; ok && val == "true" {
+		return false
+	}
+	return true
 }
 
 // ValidateDirectory checks if a directory can be a candidate update by
@@ -283,7 +295,7 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage string) []payloadTasks {
 
 	mrc := manifestRenderConfig{
 		ReleaseImage:   releaseImage,
-		ClusterProfile: defaultClusterProfile,
+		ClusterProfile: DefaultClusterProfile,
 	}
 
 	return []payloadTasks{{

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -24,7 +24,7 @@ func Render(outputDir, releaseImage string) error {
 
 		renderConfig = manifestRenderConfig{
 			ReleaseImage:   releaseImage,
-			ClusterProfile: defaultClusterProfile,
+			ClusterProfile: DefaultClusterProfile,
 		}
 	)
 

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -487,7 +487,7 @@ func Test_TaskGraph_real(t *testing.T) {
 	if len(path) == 0 {
 		t.Skip("TEST_GRAPH_PATH unset")
 	}
-	p, err := LoadUpdate(path, "arbitrary/image:1", "")
+	p, err := LoadUpdate(path, "arbitrary/image:1", "", DefaultClusterProfile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/cluster-version-operator/pkg/autoupdate"
 	"github.com/openshift/cluster-version-operator/pkg/cvo"
 	"github.com/openshift/cluster-version-operator/pkg/internal"
+	"github.com/openshift/cluster-version-operator/pkg/payload"
 	"github.com/openshift/library-go/pkg/crypto"
 )
 
@@ -70,6 +71,8 @@ type Options struct {
 	// exclude.release.openshift.io/<identifier>=true
 	Exclude string
 
+	ClusterProfile string
+
 	// for testing only
 	Name            string
 	Namespace       string
@@ -103,6 +106,7 @@ func NewOptions() *Options {
 		PayloadOverride: os.Getenv("PAYLOAD_OVERRIDE"),
 		ResyncInterval:  minResyncPeriod,
 		Exclude:         os.Getenv("EXCLUDE_MANIFESTS"),
+		ClusterProfile:  defaultEnv("CLUSTER_PROFILE", payload.DefaultClusterProfile),
 	}
 }
 
@@ -435,6 +439,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			cb.ClientOrDie(o.Namespace),
 			cb.KubeClientOrDie(o.Namespace, useProtobuf),
 			o.Exclude,
+			o.ClusterProfile,
 		),
 	}
 	if o.EnableAutoUpdate {

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	"github.com/openshift/cluster-version-operator/pkg/cvo"
+	"github.com/openshift/cluster-version-operator/pkg/payload"
 )
 
 func init() {
@@ -58,7 +59,10 @@ var (
 				"kind": "ImageStream",
 				"apiVersion": "image.openshift.io/v1",
 				"metadata": {
-					"name": "0.0.1"
+					"name": "0.0.1",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				}
 			}
 			`,
@@ -69,7 +73,10 @@ var (
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "config2",
-					"namespace": "$(NAMESPACE)"
+					"namespace": "$(NAMESPACE)",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.1",
@@ -86,7 +93,10 @@ var (
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "config1",
-					"namespace": "$(NAMESPACE)"
+					"namespace": "$(NAMESPACE)",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.1",
@@ -119,7 +129,10 @@ var (
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "config2",
-					"namespace": "$(NAMESPACE)"
+					"namespace": "$(NAMESPACE)",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.2",
@@ -135,7 +148,10 @@ var (
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "config1",
-					"namespace": "$(NAMESPACE)"
+					"namespace": "$(NAMESPACE)",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.2",
@@ -170,7 +186,10 @@ var (
 				"metadata": {
 					"name": "config2",
 					"namespace": "$(NAMESPACE)",
-					"labels": {"": ""}
+					"labels": {"": ""},
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.2",
@@ -186,7 +205,10 @@ var (
 				"apiVersion": "v1",
 				"metadata": {
 					"name": "config1",
-					"namespace": "$(NAMESPACE)"
+					"namespace": "$(NAMESPACE)",
+					"annotations": {
+					  "include.release.openshift.io/self-managed-high-availability": "true"
+					}
 				},
 				"data": {
 					"version": "0.0.2",
@@ -264,7 +286,7 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	options.PayloadOverride = filepath.Join(dir, "ignored")
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100))
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -426,7 +448,7 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	options.ResyncInterval = 3 * time.Second
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Duration: time.Second, Factor: 1.2}, "", record.NewFakeRecorder(100))
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Duration: time.Second, Factor: 1.2}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -541,7 +563,7 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	options.NodeName = "test-node"
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(&mapPayloadRetriever{}, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100))
+	worker := cvo.NewSyncWorker(&mapPayloadRetriever{}, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -728,7 +750,7 @@ metadata:
 		t.Fatal(err)
 	}
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100))
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)


### PR DESCRIPTION
Implementation of https://github.com/openshift/enhancements/pull/200

This adds a CLUSTER_PROFILE env variable that is used to determine which manifests to apply based on the `include.release.openshift.io/` annotation.

It is exactly what is written in the enhancement, not more.

This env. variable is not used by any components and, as it is empty, it defaults to the value of the default profile `self-managed-high-availability`. 