### PR TITLE
Use context to add timeout to cincinnati HTTP request

### DIFF
--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -1,6 +1,7 @@
 package cincinnati
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -132,7 +133,7 @@ func TestGetUpdates(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			updates, err := c.GetUpdates(uri, arch, channelName, semver.MustParse(test.version))
+			updates, err := c.GetUpdates(context.Background(), uri, arch, channelName, semver.MustParse(test.version))
 			if test.err == "" {
 				if err != nil {
 					t.Fatalf("expected nil error, got: %v", err)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -256,7 +256,6 @@ func (c *fakeApiExtClient) Patch(ctx context.Context, name string, pt types.Patc
 }
 
 func TestOperator_sync(t *testing.T) {
-	ctx := context.Background()
 	id := uuid.Must(uuid.NewRandom()).String()
 
 	tests := []struct {
@@ -2271,6 +2270,7 @@ func TestOperator_sync(t *testing.T) {
 			}
 			optr.eventRecorder = record.NewFakeRecorder(100)
 
+			ctx := context.Background()
 			err := optr.sync(ctx, optr.queueKey())
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("Operator.sync() unexpected error: %v", err)
@@ -2651,7 +2651,8 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			}
 			old := optr.availableUpdates
 
-			err := optr.availableUpdatesSync(optr.queueKey())
+			ctx := context.Background()
+			err := optr.availableUpdatesSync(ctx, optr.queueKey())
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("Operator.sync() unexpected error: %v", err)
 			}
@@ -3143,7 +3144,8 @@ func TestOperator_upgradeableSync(t *testing.T) {
 			optr.upgradeableChecks = optr.defaultUpgradeableChecks()
 			optr.eventRecorder = record.NewFakeRecorder(100)
 
-			err := optr.upgradeableSync(optr.queueKey())
+			ctx := context.Background()
+			err := optr.upgradeableSync(ctx, optr.queueKey())
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("Operator.sync() unexpected error: %v", err)
 			}

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -146,12 +147,11 @@ func Test_statusWrapper_ReportGeneration(t *testing.T) {
 	}
 }
 func Test_runThrottledStatusNotifier(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	in := make(chan SyncWorkerStatus)
 	out := make(chan struct{}, 100)
 
-	go runThrottledStatusNotifier(stopCh, 30*time.Second, 1, in, func() { out <- struct{}{} })
+	ctx := context.Background()
+	go runThrottledStatusNotifier(ctx, 30*time.Second, 1, in, func() { out <- struct{}{} })
 
 	in <- SyncWorkerStatus{Actual: configv1.Update{Image: "test"}}
 	select {


### PR DESCRIPTION
Change CVO wait.Until instances to wait.UntilWithContext making top-level context available to the lower levels of the code. Use the added context to add a timeout to the remote cincinnati HTTP call which has the potential to hang the caller at the mercy of the target server.

The timeout has been set to an hour which was determined to be long enough to allow all expected well-behaved requests to complete but short enough to not be catastrophic if the calling thread were to hang.