### PR TITLE
Changes to verify package in preparation for move to library-go

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	informerscorev1 "k8s.io/client-go/informers/core/v1"
@@ -281,32 +279,20 @@ func (optr *Operator) InitializeFromPayload(restConfig *rest.Config, burstRestCo
 // package for more details on the algorithm for verification. If the annotation is set, a verifier or error
 // is always returned.
 func loadConfigMapVerifierDataFromUpdate(update *payload.Update, clientBuilder sigstore.HTTPClient, configMapClient coreclientsetv1.ConfigMapsGetter) (verify.Interface, *verify.StorePersister, error) {
-	configMapGVK := corev1.SchemeGroupVersion.WithKind("ConfigMap")
-	for _, manifest := range update.Manifests {
-		if manifest.GVK != configMapGVK {
-			continue
-		}
-		if _, ok := manifest.Obj.GetAnnotations()[verify.ReleaseAnnotationConfigMapVerifier]; !ok {
-			continue
-		}
-		src := fmt.Sprintf("the config map %s/%s", manifest.Obj.GetNamespace(), manifest.Obj.GetName())
-		data, _, err := unstructured.NestedStringMap(manifest.Obj.Object, "data")
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "%s is not valid: %v", src, err)
-		}
-		verifier, err := verify.NewFromConfigMapData(src, data, clientBuilder)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// allow the verifier to consult the cluster for signature data, and also configure
-		// a process that writes signatures back to that store
-		signatureStore := configmap.NewStore(configMapClient, nil)
-		verifier.Store = &serial.Store{Stores: []store.Store{signatureStore, verifier.Store}}
-		persister := verify.NewSignatureStorePersister(signatureStore, verifier)
-		return verifier, persister, nil
+	verifier, err := verify.NewFromManifests(update.Manifests, clientBuilder)
+	if err != nil {
+		return nil, nil, err
 	}
-	return nil, nil, nil
+	if verifier == nil {
+		return nil, nil, nil
+	}
+
+	// allow the verifier to consult the cluster for signature data, and also configure
+	// a process that writes signatures back to that store
+	signatureStore := configmap.NewStore(configMapClient, nil)
+	verifier.Store = &serial.Store{Stores: []store.Store{signatureStore, verifier.Store}}
+	persister := verify.NewSignatureStorePersister(signatureStore, verifier)
+	return verifier, persister, nil
 }
 
 // Run runs the cluster version operator until stopCh is completed. Workers is ignored for now.

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -1,6 +1,7 @@
 package cvo
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -20,7 +21,6 @@ import (
 	apiextclientv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -3272,190 +3272,97 @@ func fakeClientsetWithUpdates(obj *configv1.ClusterVersion) *fake.Clientset {
 }
 
 func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
-	redhatData, err := ioutil.ReadFile(filepath.Join("..", "verify", "testdata", "keyrings", "redhat.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	const (
+		ExpectedError    = "the config map openshift-config-managed/release-verification did not provide any signature stores to read from and cannot be used"
+		ExpectedVerifier = "All release image digests must have GPG signatures from verifier-public-key-redhat (567E347AD0044ADE55BA8A5F199E2F91FD431D51: Red Hat, Inc. (release key 2) <security@redhat.com>) - will check for signatures in containers/image format at serial signature store wrapping config maps in openshift-config-managed with label \"release.openshift.io/verification-signatures\", parallel signature store wrapping file:///verify/testdata/signatures"
+	)
 
 	tests := []struct {
-		name          string
-		update        *payload.Update
-		want          bool
-		wantErr       bool
-		wantVerifiers int
+		name             string
+		fileName         string
+		update           *payload.Update
+		expectedError    string
+		expectedVerifier string
+		expectStore      bool
 	}{
 		{
-			name:   "is a no-op when no objects are found",
-			update: &payload.Update{},
+			name:     "is a no-op when no objects are found",
+			fileName: "",
+			update:   &payload.Update{},
 		},
 		{
-			name: "requires data",
-			update: &payload.Update{
-				Manifests: []lib.Manifest{
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "release-verification",
-									"namespace": "openshift-config-managed",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
+			name:          "requires data",
+			fileName:      "requires-data.yaml",
+			update:        &payload.Update{},
+			expectedError: ExpectedError,
 		},
 		{
-			name: "requires stores",
-			update: &payload.Update{
-				Manifests: []lib.Manifest{
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "verification",
-									"namespace": "openshift-config",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-								"data": map[string]interface{}{
-									"verifier-public-key-redhat": string(redhatData),
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
+			name:          "requires stores",
+			fileName:      "requires-stores.yaml",
+			update:        &payload.Update{},
+			expectedError: ExpectedError,
 		},
 		{
-			name: "requires verifiers",
-			update: &payload.Update{
-				Manifests: []lib.Manifest{
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "release-verification",
-									"namespace": "openshift-config-managed",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-								"data": map[string]interface{}{
-									"store-local": "file://../verify/testdata/signatures",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
+			name:          "requires verifiers",
+			fileName:      "requires-verifiers.yaml",
+			update:        &payload.Update{},
+			expectedError: ExpectedError,
 		},
 		{
-			name: "loads valid configuration",
-			update: &payload.Update{
-				Manifests: []lib.Manifest{
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "release-verification",
-									"namespace": "openshift-config-managed",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-								"data": map[string]interface{}{
-									"verifier-public-key-redhat": string(redhatData),
-									"store-local":                "file://../verify/testdata/signatures",
-								},
-							},
-						},
-					},
-				},
-			},
-			want:          true,
-			wantVerifiers: 1,
+			name:             "loads valid configuration",
+			fileName:         "loads-valid.yaml",
+			update:           &payload.Update{},
+			expectedVerifier: ExpectedVerifier,
+			expectStore:      true,
 		},
 		{
-			name: "only the first valid configuration is used",
-			update: &payload.Update{
-				Manifests: []lib.Manifest{
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "release-verification",
-									"namespace": "openshift-config-managed",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-								"data": map[string]interface{}{
-									"verifier-public-key-redhat": string(redhatData),
-									"store-local":                "\nfile://../verify/testdata/signatures\n",
-								},
-							},
-						},
-					},
-					{
-						GVK: schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
-						Obj: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"metadata": map[string]interface{}{
-									"name":      "release-verificatio-2n",
-									"namespace": "openshift-config-managed",
-									"annotations": map[string]interface{}{
-										"release.openshift.io/verification-config-map": "",
-									},
-								},
-								"data": map[string]interface{}{
-									"verifier-public-key-redhat":   string(redhatData),
-									"verifier-public-key-redhat-2": string(redhatData),
-									"store-local":                  "file://../verify/testdata/signatures",
-								},
-							},
-						},
-					},
-				},
-			},
-			want:          true,
-			wantVerifiers: 1,
+			name:             "only the first valid configuration is used",
+			fileName:         "only-first-used.yaml",
+			update:           &payload.Update{},
+			expectedVerifier: ExpectedVerifier,
+			expectStore:      true,
 		},
 	}
 	for _, tt := range tests {
+		if tt.fileName != "" {
+			raw, err := ioutil.ReadFile(filepath.Join("..", "verify", "testdata", "manifests", tt.fileName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ms, err := lib.ParseManifests(bytes.NewReader(raw))
+			if err != nil {
+				t.Fatalf("failed to parse file %s as a manifest, error = %v", tt.fileName, err)
+			}
+			tt.update.Manifests = ms
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			f := kfake.NewSimpleClientset()
 			got, store, err := loadConfigMapVerifierDataFromUpdate(tt.update, sigstore.DefaultClient, f.CoreV1())
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("loadReleaseVerifierFromPayload() error = %v, wantErr %v", err, tt.wantErr)
+			if err == nil {
+				if tt.expectedError != "" {
+					t.Fatalf("loadReleaseVerifierFromPayload succeeded when we expected error \"%s\"", tt.expectedError)
+				}
+			} else if tt.expectedError == "" {
+				t.Fatalf("loadReleaseVerifierFromPayload failed when we expected success: %v", err)
+			} else if tt.expectedError != err.Error() {
+				t.Fatalf("loadReleaseVerifierFromPayload failed with \"%v\" (expected \"%s\")", err, tt.expectedError)
 			}
-			if (got != nil) != tt.want {
-				t.Fatal(got)
-			}
-			if tt.want && store == nil {
-				t.Fatalf("expected valid store")
-			}
-			if err != nil {
-				return
-			}
+
 			if got == nil {
-				return
+				if tt.expectedVerifier != "" {
+					t.Fatalf("loadReleaseVerifierFromPayload did not return a verifier when expected")
+				}
+			} else if tt.expectedVerifier == "" {
+				t.Fatalf("loadReleaseVerifierFromPayload returned a verifer when not expected")
+			} else {
+				rvString := got.(*verify.ReleaseVerifier).String()
+				if rvString != tt.expectedVerifier {
+					t.Fatalf("loadReleaseVerifierFromPayload returned \"%v\" when we expected \"%v\"", rvString, tt.expectedVerifier)
+				}
 			}
-			rv := got.(*verify.ReleaseVerifier)
-			if len(rv.Verifiers()) != tt.wantVerifiers {
-				t.Fatalf("unexpected release verifier: %#v", rv)
+
+			if tt.expectStore && store == nil {
+				t.Fatalf("loadReleaseVerifierFromPayload did not return a store when expected")
 			}
 		})
 	}

--- a/pkg/verify/configmap_test.go
+++ b/pkg/verify/configmap_test.go
@@ -58,7 +58,7 @@ func Test_loadReleaseVerifierFromConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewFromConfigMapData("from_test", tt.data, sigstore.DefaultClient)
+			got, err := newFromConfigMapData("from_test", tt.data, sigstore.DefaultClient)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("loadReleaseVerifierFromPayload() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/verify/store/sigstore/sigstore.go
+++ b/pkg/verify/store/sigstore/sigstore.go
@@ -21,11 +21,11 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"strings"
 
 	"k8s.io/klog"
 
 	"github.com/openshift/cluster-version-operator/pkg/verify/store"
+	"github.com/openshift/cluster-version-operator/pkg/verify/util"
 )
 
 // maxSignatureSearch prevents unbounded recursion on malicious signature stores (if
@@ -46,13 +46,10 @@ type Store struct {
 
 // Signatures fetches signatures for the provided digest.
 func (s *Store) Signatures(ctx context.Context, name string, digest string, fn store.Callback) error {
-	parts := strings.SplitN(digest, ":", 3)
-	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
-		return fmt.Errorf("the provided release image digest must be of the form ALGO:HASH")
+	equalDigest, err := util.DigestToKeyPrefix(digest, "=")
+	if err != nil {
+		return err
 	}
-	algo, hash := parts[0], parts[1]
-	equalDigest := fmt.Sprintf("%s=%s", algo, hash)
-
 	switch s.URI.Scheme {
 	case "http", "https":
 		client, err := s.HTTPClient()

--- a/pkg/verify/testdata/manifests/loads-valid.yaml
+++ b/pkg/verify/testdata/manifests/loads-valid.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""
+data:
+  verifier-public-key-redhat: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.5 (GNU/Linux)
+
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==
+    =zbHE
+    -----END PGP PUBLIC KEY BLOCK-----"
+  store-local: file://../verify/testdata/signatures

--- a/pkg/verify/testdata/manifests/only-first-used.yaml
+++ b/pkg/verify/testdata/manifests/only-first-used.yaml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""
+data:
+  verifier-public-key-redhat: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.5 (GNU/Linux)
+
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==
+    =zbHE
+    -----END PGP PUBLIC KEY BLOCK-----"
+  store-local: file://../verify/testdata/signatures
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification-2n
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""
+data:
+  verifier-public-key-redhat: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.5 (GNU/Linux)
+
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==
+    =zbHE
+    -----END PGP PUBLIC KEY BLOCK-----
+  verifier-public-key-redhat-2: |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.5 (GNU/Linux)
+
+    mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+    0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+    0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+    u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+    XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+    5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+    9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+    /DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+    PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+    HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+    buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+    tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+    LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+    CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+    2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+    C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+    un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+    0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+    IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+    8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+    Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+    JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+    OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+    dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==
+    =zbHE
+    -----END PGP PUBLIC KEY BLOCK-----
+  store-local: file://../verify/testdata/signatures

--- a/pkg/verify/testdata/manifests/requires-data.yaml
+++ b/pkg/verify/testdata/manifests/requires-data.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""

--- a/pkg/verify/testdata/manifests/requires-stores.yaml
+++ b/pkg/verify/testdata/manifests/requires-stores.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""
+  data:
+    verifier-public-key-redhat: "pub   4096R/FD431D51 2009-10-22
+      Key fingerprint = 567E 347A D004 4ADE 55BA  8A5F 199E 2F91 FD43 1D51
+uid                  Red Hat, Inc. (release key 2) <security@redhat.com>
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.4.5 (GNU/Linux)
+
+mQINBErgSTsBEACh2A4b0O9t+vzC9VrVtL1AKvUWi9OPCjkvR7Xd8DtJxeeMZ5eF
+0HtzIG58qDRybwUe89FZprB1ffuUKzdE+HcL3FbNWSSOXVjZIersdXyH3NvnLLLF
+0DNRB2ix3bXG9Rh/RXpFsNxDp2CEMdUvbYCzE79K1EnUTVh1L0Of023FtPSZXX0c
+u7Pb5DI5lX5YeoXO6RoodrIGYJsVBQWnrWw4xNTconUfNPk0EGZtEnzvH2zyPoJh
+XGF+Ncu9XwbalnYde10OCvSWAZ5zTCpoLMTvQjWpbCdWXJzCm6G+/hx9upke546H
+5IjtYm4dTIVTnc3wvDiODgBKRzOl9rEOCIgOuGtDxRxcQkjrC+xvg5Vkqn7vBUyW
+9pHedOU+PoF3DGOM+dqv+eNKBvh9YF9ugFAQBkcG7viZgvGEMGGUpzNgN7XnS1gj
+/DPo9mZESOYnKceve2tIC87p2hqjrxOHuI7fkZYeNIcAoa83rBltFXaBDYhWAKS1
+PcXS1/7JzP0ky7d0L6Xbu/If5kqWQpKwUInXtySRkuraVfuK3Bpa+X1XecWi24JY
+HVtlNX025xx1ewVzGNCTlWn1skQN2OOoQTV4C8/qFpTW6DTWYurd4+fE0OJFJZQF
+buhfXYwmRlVOgN5i77NTIJZJQfYFj38c/Iv5vZBPokO6mffrOTv3MHWVgQARAQAB
+tDNSZWQgSGF0LCBJbmMuIChyZWxlYXNlIGtleSAyKSA8c2VjdXJpdHlAcmVkaGF0
+LmNvbT6JAjYEEwECACAFAkrgSTsCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAK
+CRAZni+R/UMdUWzpD/9s5SFR/ZF3yjY5VLUFLMXIKUztNN3oc45fyLdTI3+UClKC
+2tEruzYjqNHhqAEXa2sN1fMrsuKec61Ll2NfvJjkLKDvgVIh7kM7aslNYVOP6BTf
+C/JJ7/ufz3UZmyViH/WDl+AYdgk3JqCIO5w5ryrC9IyBzYv2m0HqYbWfphY3uHw5
+un3ndLJcu8+BGP5F+ONQEGl+DRH58Il9Jp3HwbRa7dvkPgEhfFR+1hI+Btta2C7E
+0/2NKzCxZw7Lx3PBRcU92YKyaEihfy/aQKZCAuyfKiMvsmzs+4poIX7I9NQCJpyE
+IGfINoZ7VxqHwRn/d5mw2MZTJjbzSf+Um9YJyA0iEEyD6qjriWQRbuxpQXmlAJbh
+8okZ4gbVFv1F8MzK+4R8VvWJ0XxgtikSo72fHjwha7MAjqFnOq6eo6fEC/75g3NL
+Ght5VdpGuHk0vbdENHMC8wS99e5qXGNDued3hlTavDMlEAHl34q2H9nakTGRF5Ki
+JUfNh3DVRGhg8cMIti21njiRh7gyFI2OccATY7bBSr79JhuNwelHuxLrCFpY7V25
+OFktl15jZJaMxuQBqYdBgSay2G0U6D1+7VsWufpzd/Abx1/c3oi9ZaJvW22kAggq
+dzdA27UUYjWvx42w9menJwh/0jeQcTecIUd0d0rFcw/c1pvgMMl/Q73yzKgKYw==
+=zbHE
+-----END PGP PUBLIC KEY BLOCK-----"

--- a/pkg/verify/testdata/manifests/requires-verifiers.yaml
+++ b/pkg/verify/testdata/manifests/requires-verifiers.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: release-verification
+  namespace: openshift-config-managed
+  annotations:
+    release.openshift.io/verification-config-map: ""
+  data:
+    store-local: "file://../verify/testdata/signatures"

--- a/pkg/verify/util/encode.go
+++ b/pkg/verify/util/encode.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	coreScheme  = runtime.NewScheme()
+	coreCodecs  = serializer.NewCodecFactory(coreScheme)
+	coreEncoder runtime.Encoder
+)
+
+func init() {
+	if err := corev1.AddToScheme(coreScheme); err != nil {
+		panic(err)
+	}
+	coreEncoderCodecFactory := serializer.NewCodecFactory(coreScheme)
+	coreEncoder = coreEncoderCodecFactory.LegacyCodec(corev1.SchemeGroupVersion)
+}
+
+// ReadConfigMap reads config map object from bytes. nil is returned if
+// the object cannot be decoded as a config map.
+func ReadConfigMap(objBytes []byte) (*corev1.ConfigMap, error) {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, err
+	}
+	cm, ok := requiredObj.(*corev1.ConfigMap)
+	if ok {
+		return cm, nil
+	}
+	return nil, nil
+}
+
+// ConfigMapAsBytes returns given config map as bytes.
+func ConfigMapAsBytes(cm *corev1.ConfigMap) ([]byte, error) {
+	return runtime.Encode(coreEncoder, cm)
+}

--- a/pkg/verify/util/util.go
+++ b/pkg/verify/util/util.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DigestToKeyPrefix changes digest to use the provided newDivider in place of ':',
+// {algo}{newDivider}{hash} instead of {algo}:{hash}, because colons are not allowed
+// in various places such as ConfigMap keys.
+func DigestToKeyPrefix(digest string, newDivider string) (string, error) {
+	parts := strings.SplitN(digest, ":", 3)
+	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return "", fmt.Errorf("the provided digest must be of the form ALGO:HASH")
+	}
+	algo, hash := parts[0], parts[1]
+	return fmt.Sprintf("%s%s%s", algo, newDivider, hash), nil
+}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/openshift/cluster-version-operator/pkg/verify/store"
+	"github.com/openshift/cluster-version-operator/pkg/verify/util"
 )
 
 // Interface performs verification of the provided content. The default implementation
@@ -235,12 +236,10 @@ type fileStore struct {
 
 // Signatures reads signatures as "signature-1", "signature-2", etc. out of a digest-based subdirectory.
 func (s *fileStore) Signatures(ctx context.Context, name string, digest string, fn store.Callback) error {
-	parts := strings.SplitN(digest, ":", 3)
-	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
-		return fmt.Errorf("the provided release image digest must be of the form ALGO:HASH")
+	digestPathSegment, err := util.DigestToKeyPrefix(digest, "=")
+	if err != nil {
+		return err
 	}
-	algo, hash := parts[0], parts[1]
-	digestPathSegment := fmt.Sprintf("%s=%s", algo, hash)
 
 	base := filepath.Join(s.directory, digestPathSegment, "signature-")
 	for i := 1; i < maxSignatureSearch; i++ {


### PR DESCRIPTION
Changes to verify package in preparation for move to library-go
    
The CVO verify package will be moved to library-go for reuse by 'oc adm release mirror' and CVO. Changes are being made here in CVO before the move to provide a cleaner move to library-go.

Logic to create verifier was broken out into a new configmap method NewFromManifests. This method uses k8s encoding and as a result existing test cases had to be changed from creating manifests from from declarations within the test cases itself to creating them from config map files. In this manner the lib/Manifest object is properly created with its Raw bytes field populated.