### PR TITLE
pkg/cvo/cvo_scenarios_test: Fix "Retrive" -> "Retrieve" typo

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1111,7 +1111,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 	})
 }
 
-func TestCVO_UpgradeUnverifiedPayloadRetriveOnce(t *testing.T) {
+func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 	o, cvs, client, _, shutdownFn := setupCVOTest("testdata/payloadtest-2")
 
 	// Setup: a successful sync from a previous run, and the operator at the same image as before


### PR DESCRIPTION
Typo is from d06f4be481 (#244).