### PR TITLE
pkg/cincinnati/cincinnati: Change "installed" -> "reconciling" for VersionNotFound

### DIFF
--- a/docs/user/status.md
+++ b/docs/user/status.md
@@ -117,9 +117,9 @@ It could also be caused by response corruption, e.g. if the configured `upstream
 
 ### VersionNotFound
 
-The currently installed version was not found in the configured `channel`.
+The currently reconciling cluster version was not found in the configured `channel`.
 
-This usually means that the configured `channel` is known to Cincinnati, but the cluster's current version is not found in that channel's graph.
+This usually means that the configured `channel` is known to Cincinnati, but the version the cluster is currently applying is not found in that channel's graph.
 Fix by setting `channel` to [a valid value][channels], e.g. `stable-4.3`.
 
 If this error occurs because you forced an update to a release that is not in any channel, fix by updating back to a release that occurs in a channel, although you are on your own to determine a safe update path.

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -126,7 +126,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 	if !found {
 		return current, nil, &Error{
 			Reason:  "VersionNotFound",
-			Message: fmt.Sprintf("currently installed version %s not found in the %q channel", version, channel),
+			Message: fmt.Sprintf("currently reconciling cluster version %s not found in the %q channel", version, channel),
 		}
 	}
 

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -54,7 +54,7 @@ func TestGetUpdates(t *testing.T) {
 		name:          "unknown version",
 		version:       "4.0.0-3",
 		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.0.0-3",
-		err:           "VersionNotFound: currently installed version 4.0.0-3 not found in the \"test-channel\" channel",
+		err:           "VersionNotFound: currently reconciling cluster version 4.0.0-3 not found in the \"test-channel\" channel",
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When you initiate an update from A -> B, if B is not found in the current channel, the cluster would start reporting VersionNotFound after it's first attempt to retrieve recommended updates for B.  That usually happens before the update completes, and the old "currently installed version" wasn't a very accurate description of B mid-update.  The new wording relaxes our claim about the cluster state (maybe it has been reconciled, maybe not) and just talks about the version we're attempting to reconcile.