### PR TITLE
Bug 1866554: lib/resourcemerge/core: set ShareProcessNamespace, DNSConfig and TerminationGracePeriodSeconds

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -59,6 +59,7 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 	ensureTolerations(modified, &existing.Tolerations, required.Tolerations)
 	setStringIfSet(modified, &existing.PriorityClassName, required.PriorityClassName)
 	setInt32Ptr(modified, &existing.Priority, required.Priority)
+	setBoolPtr(modified, &existing.ShareProcessNamespace, required.ShareProcessNamespace)
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -61,6 +61,7 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 	setInt32Ptr(modified, &existing.Priority, required.Priority)
 	setBoolPtr(modified, &existing.ShareProcessNamespace, required.ShareProcessNamespace)
 	ensureDNSPolicy(modified, &existing.DNSPolicy, required.DNSPolicy)
+	setInt64Ptr(modified, &existing.TerminationGracePeriodSeconds, required.TerminationGracePeriodSeconds)
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -60,6 +60,7 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 	setStringIfSet(modified, &existing.PriorityClassName, required.PriorityClassName)
 	setInt32Ptr(modified, &existing.Priority, required.Priority)
 	setBoolPtr(modified, &existing.ShareProcessNamespace, required.ShareProcessNamespace)
+	ensureDNSPolicy(modified, &existing.DNSPolicy, required.DNSPolicy)
 }
 
 func ensureContainers(modified *bool, existing *[]corev1.Container, required []corev1.Container) {
@@ -517,6 +518,13 @@ func ensureResourceList(modified *bool, existing *corev1.ResourceList, required 
 	if !equality.Semantic.DeepEqual(existing, required) {
 		*modified = true
 		required.DeepCopyInto(existing)
+	}
+}
+
+func ensureDNSPolicy(modified *bool, existing *corev1.DNSPolicy, required corev1.DNSPolicy) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
 	}
 }
 


### PR DESCRIPTION
Ensure ShareProcessNamespace, DNSConfig and TerminationGracePeriodSeconds are copied during resource merge.

Not sure if this needs a test case - looks pretty straightforward to me