### PR TITLE
Removing EnsureObjectMeta as it is called in ensurePodTemplateSpec()

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -8,7 +8,6 @@ import (
 // EnsureDeployment ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
 func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
-	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
 	if required.Spec.Replicas != nil && *required.Spec.Replicas != *existing.Spec.Replicas {
 		*modified = true


### PR DESCRIPTION
Removing EnsureObjectMeta as it is called in ensurePodTemplateSpec() again.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>