### PR TITLE
Bug 1797123: pkg/cvo: Separate ConfigMap informer for openshift-config-managed

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -163,6 +163,7 @@ func New(
 	cvInformer configinformersv1.ClusterVersionInformer,
 	coInformer configinformersv1.ClusterOperatorInformer,
 	cmConfigInformer informerscorev1.ConfigMapInformer,
+	cmConfigManagedInformer informerscorev1.ConfigMapInformer,
 	proxyInformer configinformersv1.ProxyInformer,
 	client clientset.Interface,
 	kubeClient kubernetes.Interface,
@@ -208,7 +209,7 @@ func New(
 
 	optr.proxyLister = proxyInformer.Lister()
 	optr.cmConfigLister = cmConfigInformer.Lister().ConfigMaps(internal.ConfigNamespace)
-	optr.cmConfigManagedLister = cmConfigInformer.Lister().ConfigMaps(internal.ConfigManagedNamespace)
+	optr.cmConfigManagedLister = cmConfigManagedInformer.Lister().ConfigMaps(internal.ConfigManagedNamespace)
 
 	// make sure this is initialized after all the listers are initialized
 	optr.upgradeableChecks = optr.defaultUpgradeableChecks()


### PR DESCRIPTION
With c9fab435c1 (#311), I attempted to pivot to loading the TLS configration from the `openshift-config-managed` namespace.  But I hadn't realized that `cmConfigInformer` was scoped to the `openshift-config` namespace, so attempts to retrieve `trusted-ca-bundle` failed via the "not found" no-op path regardless of whether the ConfigMap actually existed.  With this commit, I create a new informer for the `openshift-config-managed` namespace, so we can successfully retrieve the ConfigMap when it exists.

An alternative approach would be to drop the `informers.WithNamespace` filter.  My impression is that having two namespace-filtered informers will be more efficient than a single unfiltered informer, but I'm not really sure.