### PR TITLE
Bug 1872080: Dockerfile.rhel: Use a RHEL-version-agnostic filename

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,14 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-version-operator
+COPY . .
+RUN hack/build-go.sh; \
+    mkdir -p /tmp/build; \
+    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
+COPY install /manifests
+COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml /manifests/
+COPY bootstrap /bootstrap
+ENTRYPOINT ["/usr/bin/cluster-version-operator"]

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,14 +1,1 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
-WORKDIR /go/src/github.com/openshift/cluster-version-operator
-COPY . .
-RUN hack/build-go.sh; \
-    mkdir -p /tmp/build; \
-    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
-
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
-COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
-COPY install /manifests
-COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/
-COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml /manifests/
-COPY bootstrap /bootstrap
-ENTRYPOINT ["/usr/bin/cluster-version-operator"]
+Dockerfile.rhel


### PR DESCRIPTION
So we don't have a nominally-rhel7 Dockerfile building RHEL 8 images and also so we don't need to manually bump this filename when we bump RHEL versions.