### PR TITLE
Bug 1873900: install/0000_00_cluster-version-operator_03_deployment: Bump to --v=5

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -15,7 +15,7 @@ spec:
       - "--release-image={{.ReleaseImage}}"
       - "--enable-auto-update=false"
       - "--enable-default-cluster-version=false"
-      - "--v=4"
+      - "--v=5"
       - "--kubeconfig=/etc/kubernetes/kubeconfig"
     securityContext:
       privileged: true

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - "--enable-default-cluster-version=true"
           - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
           - "--serving-key-file=/etc/tls/serving-cert/tls.key"
-          - "--v=4"
+          - "--v=5"
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
To pick up all the `.V(5)` logging in `pkg/cvo/sync_worker.go`.  I'm especially interested in the main select loop in `SyncWorker.Start`, because we have one recent cluster where the sync worker loop [apparently goes to sleep][1] for no clear reason.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1873900