### PR TITLE
pkg/cvo/metrics: Log metrics-server shutdown

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -179,6 +179,7 @@ func RunMetrics(runContext context.Context, shutdownContext context.Context, lis
 		}
 	}
 
+	klog.Infof("Graceful shutdown complete for metrics server: %s", loopError)
 	return loopError
 }
 


### PR DESCRIPTION
Following cc1921d186 (#424), which logs overall shutdown in `cmd/start.go`, this commit will make it extremely clear in the CVO logs when the metrics goroutine is wrapping up.