### PR TITLE
Bug 1873900: pkg/payload/task_graph: Avoid deadlocking on cancel with workCh queue

### DIFF
--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -832,6 +832,26 @@ func TestRunGraph(t *testing.T) {
 			},
 		},
 		{
+			name: "mid-task cancellation with work in queue does not deadlock",
+			nodes: []*TaskNode{
+				{Tasks: tasks("a1", "a2", "a3")},
+				{Tasks: tasks("b")},
+			},
+			sleep:    time.Millisecond,
+			parallel: 1,
+			errorOn: func(t *testing.T, name string, ctx context.Context, cancelFn func()) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if name == "a2" {
+					cancelFn()
+				}
+				return nil
+			},
+			want:     []string{"a1", "a2"},
+			wantErrs: []string{"context canceled"},
+		},
+		{
 			name: "task errors in parallel nodes both reported",
 			nodes: []*TaskNode{
 				{Tasks: tasks("a"), Out: []int{1}},


### PR DESCRIPTION
Before 55ef3d3027 (#264, new in 4.6), `RunGraph` had a separate goroutine that managed the work queue, with results fed into `errCh` to be collected by the main `RunGraph` goroutine.  It didn't matter if that work queue goroutine hung; as long as all the worker goroutines exited, `RunGraph` would collect their errors from `errCh` and return.  In 55ef3d3027, I removed the queue goroutine and moved queue management into the main `RunGraph` goroutine.  With that change, we became exposed to the following race:

1. Main goroutine pushes work into `workCh`.
2. Context canceled.
3. Workers exit via the `Canceled worker...` case, so they don't pick the work out of `workCh`.
4. Main goroutine deadlocks because there is work in flight, but nothing in `resultCh`, and no longer any workers to feed `resultCh`.

In logs, this looks like "[sync-worker goroutine has gone to sleep, and is no longer synchronizing manifests][1]".

With this commit, we drain results when they are available, but we also respect the context to allow the `resultCh` read to be canceled.  When we have been canceled with work in flight, we also attempt a non-blocking read from `workCh` to drain out anything there that has not yet been picked up by a worker.  Because `done` will not be set true, we'll call `getNextNode` again and come in with a fresh pass through the for loop.  `ctx.Err()` will no longer be `nil`, but if the `workCh` drain worked, we may now have `inflight == 0`, and we'll end up in the case that sets `done` true, and break out of the for loop on that round.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1873900