### PR TITLE
Bug 1878163: Dockerfile.rhel: Bump to Go 1.15

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \


### PR DESCRIPTION
ART is [waffling][1] around the 1.14 <-> 1.15 transition, but we don't need to wait.  Let the future start today!

Replaces #456, but without the commit message `to mach` typo or the bogus link to an ocp-build-data branch where the CVO is currently reverted back to Go 1.14.

[1]: https://github.com/openshift/ocp-build-data/pull/665