### PR TITLE
Bug 1802553: Adding upgradeable = false when an upgrade in progress

### DIFF
--- a/pkg/payload/precondition/precondition.go
+++ b/pkg/payload/precondition/precondition.go
@@ -51,7 +51,7 @@ type Precondition interface {
 // List is a list of precondition checks.
 type List []Precondition
 
-// RunAll runs all the reflight checks in order, returning a list of errors if any.
+// RunAll runs all the preflight checks in order, returning a list of errors if any.
 // All checks are run, regardless if any one precondition fails.
 func (pfList List) RunAll(ctx context.Context, releaseContext ReleaseContext, cv *configv1.ClusterVersion) []error {
 	var errs []error

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -192,6 +192,9 @@ func SummaryForReason(reason, name string) string {
 	case "ImageVerificationFailed":
 		return "the image may not be safe to use"
 
+	case "UpgradeInProgress":
+		return "an upgrade is in progress"
+
 	case "UpgradePreconditionCheckFailed":
 		return "it may not be safe to apply this update"
 


### PR DESCRIPTION
CVO must not start another upgrade process if an upgrade is already
 in progress for a minor version (Y stream). We have a similar check in oc adm command. But an user
 can start the upgrade through the web console too.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>