### PR TITLE
Bug 1884209: Moving the go version to 1.15 as the Dockerfile.rhel already on it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \


### PR DESCRIPTION

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>