### PR TITLE
Bug 1886900: pkg/cvo/sync_worker: Drop "Manifest: ..." logging

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -699,7 +699,6 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 			cr.Update()
 
 			klog.V(4).Infof("Running sync for %s", task)
-			klog.V(5).Infof("Manifest: %s", string(task.Manifest.Raw))
 
 			ov, ok := getOverrideForManifest(work.Overrides, task.Manifest)
 			if ok && ov.Unmanaged {


### PR DESCRIPTION
This line is descended from logging we grew way back in 847f71bcef (#14).  But we triggered it recently with 88c222c954 (#448).  Drop the line, because it's noisy spew in the log files, and we can get the manifest content via:

```console
$ oc adm release extract --to=manifests $PULLSPEC
```