### PR TITLE
hack/log-explainer: Don't crash if run on truncated logs

### DIFF
--- a/hack/log-explainer.py
+++ b/hack/log-explainer.py
@@ -92,10 +92,10 @@ def parse_lines(lines):
             sync['lines'] = []
             sync['manifests'] = {}
             metadata['syncs'].append(sync)
-        if sync:
-            sync['lines'].append(line)
-        else:
+        if not sync:
             logging.warning('sync worker line outside of sync: {}'.format(line))
+            continue
+        sync['lines'].append(line)
         if line['message'].startswith(end_of_sync_cycle_prefix):
             sync['results'] = {
                 'result': line['message'][len(end_of_sync_cycle_prefix):],


### PR DESCRIPTION
Avoid crashing on undefined `sync` if someone pushes in logs from a pod that has been running for so long that we no longer have the lines that start the opening sync.  Instead, just throw that partially-logged sync out.