### PR TITLE
pkg/cvo/internal: Do not block on Degraded=True ClusterOperator

### DIFF
--- a/docs/user/reconciliation.md
+++ b/docs/user/reconciliation.md
@@ -135,7 +135,6 @@ The ClusterOperator builder only monitors the in-cluster object and blocks until
     would block until the in-cluster ClusterOperator reported `operator` at version 4.1.0.
 
     The progressing check is deprecated and will be removed once all operators are reporting versions.
-* Not degraded (except during initialization, where we ignore the degraded status)
 
 ### CustomResourceDefinition
 

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -315,9 +315,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
-			Reason:  "ClusterOperatorDegraded",
-			Message: "Cluster operator test-co is reporting a failure: random error",
+			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=false, progressing=true, degraded=true"),
+			Reason:  "ClusterOperatorNotAvailable",
+			Message: "Cluster operator test-co has not yet reported success",
 			Name:    "test-co",
 		},
 	}, {
@@ -343,12 +343,6 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=true, progressing=true, degraded=true"),
-			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co has not yet reported success",
-			Name:    "test-co",
-		},
 	}, {
 		name: "cluster operator reporting available=true degraded=true",
 		actual: &configv1.ClusterOperator{
@@ -371,12 +365,6 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 					Name: "operand-1", Version: "v1",
 				}},
 			},
-		},
-		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
-			Reason:  "ClusterOperatorDegraded",
-			Message: "Cluster operator test-co is reporting a failure: random error",
-			Name:    "test-co",
 		},
 	}, {
 		name: "cluster operator reporting available=true progressing=true degraded=true",
@@ -401,12 +389,6 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is reporting a failure: random error"),
-			Reason:  "ClusterOperatorDegraded",
-			Message: "Cluster operator test-co is reporting a failure: random error",
-			Name:    "test-co",
-		},
 	}, {
 		name: "cluster operator reporting available=true no progressing or degraded",
 		actual: &configv1.ClusterOperator{
@@ -429,12 +411,6 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 					Name: "operand-1", Version: "v1",
 				}},
 			},
-		},
-		expErr: &payload.UpdateError{
-			Nested:  fmt.Errorf("cluster operator test-co is not done; it is available=true, progressing=true, degraded=true"),
-			Reason:  "ClusterOperatorNotAvailable",
-			Message: "Cluster operator test-co has not yet reported success",
-			Name:    "test-co",
 		},
 	}, {
 		name: "cluster operator reporting available=true progressing=false degraded=false",

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -195,11 +195,6 @@ func SummaryForReason(reason, name string) string {
 	case "UpgradePreconditionCheckFailed":
 		return "it may not be safe to apply this update"
 
-	case "ClusterOperatorDegraded":
-		if len(name) > 0 {
-			return fmt.Sprintf("the cluster operator %s is degraded", name)
-		}
-		return "a cluster operator is degraded"
 	case "ClusterOperatorNotAvailable":
 		if len(name) > 0 {
 			return fmt.Sprintf("the cluster operator %s has not yet successfully rolled out", name)


### PR DESCRIPTION
We have blocking on this condition since 545c3424aa (#31) when it was `Failing`.  We'd softened our install-time handling to act this way back in b0b4902fce (#136), [motivated by install speed][1].  And a degraded operator may slow dependent components in their own transitions.  But as long as the operator/operand are available at all, it should not block depndent components from transitioning, so this commit removes the `Degraded=True` block from the remaining modes.

We still have the critical `ClusterOperatorDegraded` waking admins up when an operator goes `Degraded=True` for a while, we will just no longer block updates at that point.  We won't block `ReconcilingMode` manifest application either, but since that's already flattened and permuted, and `ClusterOperator` tend to be towards the end of their `TaskNode`, the impact on `ReconcilingMode` is minimal (except that we will no longer go `Failing=True` in `ClusterVersion` when the only issue is some `Degraded=True` ClusterOperator).

CC @abhinavdahiya, @deads2k, @smarterclayton as folks who were involved in the logic I'm removing here.

[1]: https://github.com/openshift/cluster-version-operator/pull/136#issue-260160975