### PR TITLE
Add ClusterProfile template variable

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -95,6 +95,8 @@ const (
 
 	cincinnatiJSONFile  = "release-metadata"
 	imageReferencesFile = "image-references"
+
+	defaultClusterProfile = "self-managed-high-availability"
 )
 
 // Update represents the contents of a release image.
@@ -279,7 +281,10 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage string) []payloadTasks {
 	cjf := filepath.Join(releaseDir, cincinnatiJSONFile)
 	irf := filepath.Join(releaseDir, imageReferencesFile)
 
-	mrc := manifestRenderConfig{ReleaseImage: releaseImage}
+	mrc := manifestRenderConfig{
+		ReleaseImage:   releaseImage,
+		ClusterProfile: defaultClusterProfile,
+	}
 
 	return []payloadTasks{{
 		idir:       cvoDir,

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -22,7 +22,10 @@ func Render(outputDir, releaseImage string) error {
 		bootstrapDir  = "/bootstrap"
 		oBootstrapDir = filepath.Join(outputDir, "bootstrap")
 
-		renderConfig = manifestRenderConfig{ReleaseImage: releaseImage}
+		renderConfig = manifestRenderConfig{
+			ReleaseImage:   releaseImage,
+			ClusterProfile: defaultClusterProfile,
+		}
 	)
 
 	tasks := []struct {
@@ -102,7 +105,8 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, skipFiles s
 }
 
 type manifestRenderConfig struct {
-	ReleaseImage string
+	ReleaseImage   string
+	ClusterProfile string
 }
 
 // renderManifest Executes go text template from `manifestBytes` with `config`.


### PR DESCRIPTION
This allows future CVO manifests to use {{ .ClusterProfile }}.

Example, futur CVO might look like:
```
apiVersion: v1
kind: Pod
metadata:
  name: bootstrap-cluster-version-operator
  namespace: openshift-cluster-version
...
    env:
      - name: CLUSTER_PROFILE
        value: "{{.ClusterProfile}}"
```



This implements phase 1 of https://github.com/openshift/enhancements/pull/543.

Default value is the one decided in https://github.com/openshift/enhancements/pull/510