### PR TITLE
Bug 1903382: pkg/payload/task_graph: Require firstIncompleteNode to have tasks

### DIFF
--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -536,7 +536,7 @@ func RunGraph(ctx context.Context, graph *TaskGraph, maxParallelism int, fn func
 	incompleteCount := 0
 	for i, result := range results {
 		if result == nil {
-			if firstIncompleteNode == nil {
+			if firstIncompleteNode == nil && len(graph.Nodes[i].Tasks) > 0 {
 				firstIncompleteNode = graph.Nodes[i]
 			}
 			incompleteCount++


### PR DESCRIPTION
Our graph has some nodes without tasks, e.g. nodes which create a choke point between two sets of parallel nodes.  Ideally we give all nodes descriptive names (#435), but until we have that, require at least one entry in `Tasks` before we store a node as `firstIncompleteNode`.
This avoids the chance of panicking during the subsequent:

```go
fmt.Errorf("%d incomplete task nodes, beginning with %s", incompleteCount, firstIncompleteNode.Tasks[0])
```