### PR TITLE
Bug 1907313: Don't create ClusterOperator during precreation step if it's present in overrides

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -678,6 +678,11 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 				if task.Manifest.GVK != configv1.SchemeGroupVersion.WithKind("ClusterOperator") {
 					continue
 				}
+				ov, ok := getOverrideForManifest(work.Overrides, task.Manifest)
+				if ok && ov.Unmanaged {
+					klog.V(4).Infof("Skipping precreation of %s as unmanaged", task)
+					continue
+				}
 				if err := w.builder.Apply(ctx, task.Manifest, payload.PrecreatingPayload); err != nil {
 					klog.V(2).Infof("Unable to precreate resource %s: %v", task, err)
 					continue


### PR DESCRIPTION
Using the installer, if a cluster operator is in overrides list, it is
still created during the precreation step.
When both the cluster operator and the deployment of an operator are
overridden, the CVO (and the installer) waits for ever the end of the
end of the provisioning.

---

I faced this when I tried to disable monitoring for CRC

```
I1210 20:28:04.418715       1 sync_worker.go:687] Precreated resource clusteroperator "monitoring" (317 of 617)
I1210 20:28:32.633406       1 sync_worker.go:701] Running sync for clusteroperator "monitoring" (317 of 617)
I1210 20:28:32.633423       1 sync_worker.go:705] Skipping clusteroperator "monitoring" (317 of 617) as unmanaged
```

It means that we can't disable fully an operator with overrides. It has to be deployed once.