### PR TITLE
Bug 1879976: pkg/cvo: Compare Cincinnati data by digest when merging metadata

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -215,7 +215,7 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, prox
 		}
 	}
 
-	cvoCurrent, err = convertRetreivedUpdateToRelease(current)
+	cvoCurrent, err = convertRetrievedUpdateToRelease(current)
 	if err != nil {
 		return cvoCurrent, nil, configv1.ClusterOperatorStatusCondition{
 			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "ResponseInvalid",
@@ -225,7 +225,7 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, prox
 
 	var cvoUpdates []configv1.Release
 	for _, update := range updates {
-		cvoUpdate, err := convertRetreivedUpdateToRelease(update)
+		cvoUpdate, err := convertRetrievedUpdateToRelease(update)
 		if err != nil {
 			return cvoCurrent, nil, configv1.ClusterOperatorStatusCondition{
 				Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "ResponseInvalid",
@@ -243,7 +243,7 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, prox
 	}
 }
 
-func convertRetreivedUpdateToRelease(update cincinnati.Update) (configv1.Release, error) {
+func convertRetrievedUpdateToRelease(update cincinnati.Update) (configv1.Release, error) {
 	cvoUpdate := configv1.Release{
 		Version: update.Version.String(),
 		Image:   update.Image,

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -614,11 +614,11 @@ func (optr *Operator) mergeReleaseMetadata(release configv1.Release) configv1.Re
 		availableUpdates := optr.getAvailableUpdates()
 		if availableUpdates != nil {
 			var update *configv1.Release
-			if merged.Image == availableUpdates.Current.Image {
+			if equalDigest(merged.Image, availableUpdates.Current.Image) {
 				update = &availableUpdates.Current
 			} else {
 				for _, u := range availableUpdates.Updates {
-					if u.Image == merged.Image {
+					if equalDigest(u.Image, merged.Image) {
 						update = &u
 						break
 					}


### PR DESCRIPTION
Fixing [rbhz#1879976][1], where clusters installed with pullspecs like:

    registry.svc.ci.openshift.org/ocp/release@sha256:c7e8f18e8116356701bd23ae3a23fb9892dd5ea66c8300662ef30563d7104f39

would not pick up channel metadata that Cincinnati was associating with canonical pullspecs like:

    quay.io/openshift-release-dev/ocp-release@sha256:c7e8f18e8116356701bd23ae3a23fb9892dd5ea66c8300662ef30563d7104f39

I really wish source-repo "hints" were not part of pullspecs, and these images were purely content-addressable.  But wishing doesn't make it true ;).

I'm not using the new `equalDigest` for some of our "is this change an update?" logic, because [we want to go through "updates" on repository changes][2] to ensure that the release content is still available when accessed via the new pullspec (although the presence of `ImageContentSourcePolicies` may mean that even with a change to the repository portion of the pullspec, we still end up actually pulling the release from the same location we were initially using).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1879976
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1879963#c4