### PR TITLE
Improve metrics_test.go unit tests outputs

### DIFF
--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -675,12 +675,12 @@ func expectMetric(t *testing.T, metric prometheus.Metric, value float64, labels 
 	}
 	if d.Gauge != nil {
 		if value != *d.Gauge.Value {
-			t.Fatalf("incorrect value for %s: %s", metric.Desc().String(), d.String())
+			t.Fatalf("incorrect gauge value for %s:  got: %v, expected: %v", metric.Desc().String(), *d.Gauge.Value, value)
 		}
 	}
 	for _, label := range d.Label {
 		if labels[*label.Name] != *label.Value {
-			t.Fatalf("unexpected labels for %s: %s=%v", metric.Desc().String(), *label.Name, *label.Value)
+			t.Fatalf("unexpected labels for %s: got: %s=%v, expected: %s=%v", metric.Desc().String(), *label.Name, *label.Value, *label.Name, labels[*label.Name])
 		}
 		delete(labels, *label.Name)
 	}


### PR DESCRIPTION
 metrics_test.go:294: incorrect gauge value for Desc{fqName: "cluster_version", help: "Reports...'.\n.", constLabels: {}, variableLabels: [type version image from_version]}:  got: 2, expected: 1

 metrics_test.go:229: unexpected labels for Desc{fqName: "cluster_operator_up", help: "Reports key highlights of the active cluster operators.", constLabels: {}, variableLabels: [name version]}: got: name=, expected: name=test
