### PR TITLE
*: Replace registry.svc.ci.openshift.org with registry.ci.openshift.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ podman run --rm -ti \
         --release-image="<release image>"
 ```
 
-`<release image>` can be personal release image generated using [this](#building-release-image-using-local-cvo) or Origin's release image like `registry.svc.ci.openshift.org/openshift/origin-release:v4.0`.
+`<release image>` can be personal release image generated using [this](#building-release-image-using-local-cvo) or Origin's release image like `registry.ci.openshift.org/openshift/origin-release:v4.0`.
 
 ## Running CVO tests
 

--- a/docs/dev/clusterversion.md
+++ b/docs/dev/clusterversion.md
@@ -9,7 +9,7 @@ You can extract the current update image from the `ClusterVersion` object:
 
 ```console
 $ oc get clusterversion -o jsonpath='{.status.desired.image}{"\n"}' version
-registry.svc.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833
+registry.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833
 ```
 
 ## Setting objects unmanaged
@@ -18,7 +18,7 @@ For testing operators, it is sometimes helpful to disable CVO management so you 
 To get a list of objects managed by the CVO, run:
 
 ```console
-$ oc adm release extract --from=registry.svc.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833 --to=release-image
+$ oc adm release extract --from=registry.ci.openshift.org/openshift/origin-release@sha256:c1f11884c72458ffe91708a4f85283d591b42483c2325c3d379c3d32c6ac6833 --to=release-image
 $ ls release-image | head -n5
 0000_07_cluster-network-operator_00_namespace.yaml
 0000_07_cluster-network-operator_01_crd.yaml

--- a/docs/dev/operators.md
+++ b/docs/dev/operators.md
@@ -152,7 +152,7 @@ spec:
 The release tooling will read image-references and do the following operations:
 
 Verify that the tags `ingress-operator` and `haproxy-router` exist from the release / CI tooling (in the image stream `openshift/origin-v4.0` on api.ci).  If they don’t exist, you’ll get a build error.
-Do a find and replace in your manifests (effectively a sed)  that replaces `quay.io/openshift/origin-haproxy-router(:.*|@:.*)` with `registry.svc.ci.openshift.org/openshift/origin-v4.0@sha256:<latest SHA for :haproxy-router>`
+Do a find and replace in your manifests (effectively a sed)  that replaces `quay.io/openshift/origin-haproxy-router(:.*|@:.*)` with `registry.ci.openshift.org/openshift/origin-v4.0@sha256:<latest SHA for :haproxy-router>`
 Store the fact that operator ingress-operator uses both of those images in a metadata file alongside the manifests
 Bundle up your manifests and the metadata file as a docker image and push them to a registry
 

--- a/docs/user/reconciliation.md
+++ b/docs/user/reconciliation.md
@@ -37,7 +37,7 @@ $ cat /tmp/release/release-manifests/image-references
     "creationTimestamp": "2019-06-03T14:49:14Z",
     "annotations": {
       "release.openshift.io/from-image-stream": "ocp/4.1-art-latest-2019-05-31-174150",
-      "release.openshift.io/from-release": "registry.svc.ci.openshift.org/ocp/release:4.1.0-0.nightly-2019-05-31-174150"
+      "release.openshift.io/from-release": "registry.ci.openshift.org/ocp/release:4.1.0-0.nightly-2019-05-31-174150"
     }
   },
   "spec": {


### PR DESCRIPTION
The canonical registry URI has been updated, see openshift/release@f6ac0408e0 (openshift/release#14726) and similar.  Generated with:

```console
$ sed -i 's/registry.svc.ci.openshift.org/registry.ci.openshift.org/g' $(git grep -l registry.svc.ci.openshift.org)
```

Like #496, but for 4.6 to replace #494.