### PR TITLE
Bug 1926310: install/0000_90_cluster-version-operator_02_servicemonitor.yaml: adjust "CannotRetrieveUpdates" to "warning"

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -52,7 +52,7 @@ spec:
       expr: |
         (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 and ignoring(condition, name, reason) cluster_operator_conditions{name="version", condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"}
       labels:
-        severity: critical
+        severity: warning
     - alert: UpdateAvailable
       annotations:
         message: Your upstream update recommendation service recommends you update your cluster.  For more information refer to 'oc adm upgrade'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.


### PR DESCRIPTION
SRE-P has commited to feed findings and changes in regards to alerts back to upstream, this change is a follow up to https://issues.redhat.com/browse/OSD-6327

We are obeying the following standards for alert levels and recommend every component team to do so to:
```

    Critical: An issue, that needs to page a person to take instant action
    Warning: An issue, that needs to be worked on but in the regular work queue or for during office hours rather than paging the oncall
    Info: Is meant to support a trouble shooting process by informing about a non-normal situation for one or more systems but not worth a page or ticket on its own.

```
[reference](https://github.com/kubernetes-monitoring/kubernetes-mixin#alert-severities)

This therefore is a `warning` level alert. No one should be paged for it in the middle of the night but we still want cluster owners to eventually fix this.

/cc @jewzaam @wking @cblecker 