### PR TITLE
pkg/cvo/internal/operatorstatus: Change nested message

### DIFF
--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -249,9 +249,9 @@ func waitForOperatorStatusToBeDone(ctx context.Context, interval time.Duration, 
 		}
 
 		lastErr = &payload.UpdateError{
-			Nested:       nestedMessage,
+			Nested:       fmt.Errorf("cluster operator is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
+			Reason:       "ClusterOperatorUpdating",
 			Message:      fmt.Sprintf("Cluster operator %s is updating versions", actual.Name),
 			Name:         actual.Name,
 		}

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -354,9 +354,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co conditions: available=true, progressing=true, degraded=true"),
+			Nested:       fmt.Errorf("cluster operator is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
+			Reason:       "ClusterOperatorUpdating",
 			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
@@ -444,9 +444,9 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co conditions: available=true, progressing=true, degraded=true"),
+			Nested:       fmt.Errorf("cluster operator is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
+			Reason:       "ClusterOperatorUpdating",
 			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},


### PR DESCRIPTION
to a different message for cluster operators that are available, not degraded, but not yet finished updating