### PR TITLE
Use profile from the installer to render CVO manifests

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -36,6 +36,8 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: spec.nodeName
+      - name: CLUSTER_PROFILE
+        value: {{ .ClusterProfile }}
   hostNetwork: true
   terminationGracePeriodSeconds: 130
   volumes:

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -39,7 +40,15 @@ func runRenderCmd(cmd *cobra.Command, args []string) {
 	if renderOpts.releaseImage == "" {
 		klog.Fatalf("missing --release-image flag, it is required")
 	}
-	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage); err != nil {
+	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, clusterProfile()); err != nil {
 		klog.Fatalf("Render command failed: %v", err)
 	}
+}
+
+func clusterProfile() string {
+	profile, ok := os.LookupEnv("CLUSTER_PROFILE")
+	if !ok {
+		return payload.DefaultClusterProfile
+	}
+	return profile
 }

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -54,6 +54,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: CLUSTER_PROFILE
+            value: {{ .ClusterProfile }}
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -133,7 +133,7 @@ type metadata struct {
 }
 
 func LoadUpdate(dir, releaseImage, excludeIdentifier, profile string) (*Update, error) {
-	payload, tasks, err := loadUpdatePayloadMetadata(dir, releaseImage)
+	payload, tasks, err := loadUpdatePayloadMetadata(dir, releaseImage, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ type payloadTasks struct {
 	skipFiles  sets.String
 }
 
-func loadUpdatePayloadMetadata(dir, releaseImage string) (*Update, []payloadTasks, error) {
+func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Update, []payloadTasks, error) {
 	klog.V(4).Infof("Loading updatepayload from %q", dir)
 	if err := ValidateDirectory(dir); err != nil {
 		return nil, nil, err
@@ -281,7 +281,7 @@ func loadUpdatePayloadMetadata(dir, releaseImage string) (*Update, []payloadTask
 		return nil, nil, fmt.Errorf("Version from %s (%s) differs from %s (%s)", imageReferencesFile, imageRef.Name, cincinnatiJSONFile, release.Version)
 	}
 
-	tasks := getPayloadTasks(releaseDir, cvoDir, releaseImage)
+	tasks := getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile)
 
 	return &Update{
 		Release:  release,
@@ -289,13 +289,13 @@ func loadUpdatePayloadMetadata(dir, releaseImage string) (*Update, []payloadTask
 	}, tasks, nil
 }
 
-func getPayloadTasks(releaseDir, cvoDir, releaseImage string) []payloadTasks {
+func getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []payloadTasks {
 	cjf := filepath.Join(releaseDir, cincinnatiJSONFile)
 	irf := filepath.Join(releaseDir, imageReferencesFile)
 
 	mrc := manifestRenderConfig{
 		ReleaseImage:   releaseImage,
-		ClusterProfile: DefaultClusterProfile,
+		ClusterProfile: clusterProfile,
 	}
 
 	return []payloadTasks{{

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Render renders all the manifests from /manifests to outputDir.
-func Render(outputDir, releaseImage string) error {
+func Render(outputDir, releaseImage, clusterProfile string) error {
 	var (
 		manifestsDir  = filepath.Join(DefaultPayloadDir, CVOManifestDir)
 		oManifestsDir = filepath.Join(outputDir, "manifests")
@@ -24,7 +24,7 @@ func Render(outputDir, releaseImage string) error {
 
 		renderConfig = manifestRenderConfig{
 			ReleaseImage:   releaseImage,
-			ClusterProfile: DefaultClusterProfile,
+			ClusterProfile: clusterProfile,
 		}
 	)
 


### PR DESCRIPTION
This also propagates the CLUSTER_PROFILE to the next generation of CVO

---

This is the final part of cluster profile. Now that 4.7 CVOs know about this new {{ .ClusterProfile }} template variable. We can use it. 

Tested with registry.svc.ci.openshift.org/ocp/release:4.8.0-0.ci-2021-02-17-015150 + single-node-developer profile, works great!