### PR TITLE
pkg/cvo: Add logging to track ClusterVersion

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -620,12 +620,14 @@ func (optr *Operator) rememberLastUpdate(config *configv1.ClusterVersion) {
 func (optr *Operator) getOrCreateClusterVersion(ctx context.Context, enableDefault bool) (*configv1.ClusterVersion, bool, error) {
 	obj, err := optr.cvLister.Get(optr.name)
 	if err == nil {
+		klog.V(4).Infof("getOrCreateClusterVersion obj: %v", obj)
 		// if we are waiting to see a newer cached version, just exit
 		if optr.isOlderThanLastUpdate(obj) {
 			return nil, true, nil
 		}
 		return obj, false, nil
 	}
+	klog.V(4).Infof("getOrCreateClusterVersion Get error: %v", err)
 
 	if !apierrors.IsNotFound(err) {
 		return nil, false, err
@@ -655,6 +657,11 @@ func (optr *Operator) getOrCreateClusterVersion(ctx context.Context, enableDefau
 	}
 
 	actual, _, err := resourceapply.ApplyClusterVersionFromCache(ctx, optr.cvLister, optr.client.ConfigV1(), config)
+	if err == nil {
+		klog.V(4).Infof("getOrCreateClusterVersion actual: %v", actual)
+	} else {
+		klog.V(4).Infof("getOrCreateClusterVersion Apply error: %v", err)
+	}
 	if apierrors.IsAlreadyExists(err) {
 		return nil, true, nil
 	}

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -346,6 +346,7 @@ func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1
 	if klog.V(6).Enabled() {
 		klog.Infof("Apply config: %s", diff.ObjectReflectDiff(original, config))
 	}
+	klog.V(4).Infof("orig: %v\nconf: %v", original, config)
 	updated, err := applyClusterVersionStatus(ctx, optr.client.ConfigV1(), config, original)
 	optr.rememberLastUpdate(updated)
 	return err
@@ -455,7 +456,11 @@ func applyClusterVersionStatus(ctx context.Context, client configclientv1.Cluste
 	if original != nil && equality.Semantic.DeepEqual(&original.Status, &required.Status) {
 		return required, nil
 	}
+	klog.V(4).Info("applyClusterVersionStatus: updating status")
 	actual, err := client.ClusterVersions().UpdateStatus(ctx, required, metav1.UpdateOptions{})
+	if err != nil {
+		klog.V(4).Infof("applyClusterVersionStatus: error: %v", err)
+	}
 	if apierrors.IsConflict(err) {
 		existing, cErr := client.ClusterVersions().Get(ctx, required.Name, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
This is temporary logging to help debug an issue during CI testing. Most if not all will be removed once the issue has been identified.