### PR TITLE
Bug 1931025: pkg/cvo: Use shutdownContext for final status synchronization

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -187,7 +187,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock *resourc
 					resultChannelCount++
 					go func() {
 						defer utilruntime.HandleCrash()
-						err := controllerCtx.CVO.Run(runContext, 2)
+						err := controllerCtx.CVO.Run(runContext, shutdownContext, 2)
 						resultChannel <- asyncResult{name: "main operator", error: err}
 					}()
 
@@ -402,17 +402,4 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 		}
 	}
 	return ctx
-}
-
-// Start launches the controllers in the provided context and any supporting
-// infrastructure. When ch is closed the controllers will be shut down.
-func (c *Context) Start(ctx context.Context) {
-	ch := ctx.Done()
-	go c.CVO.Run(ctx, 2)
-	if c.AutoUpdate != nil {
-		go c.AutoUpdate.Run(ctx, 2)
-	}
-	c.CVInformerFactory.Start(ch)
-	c.OpenshiftConfigInformerFactory.Start(ch)
-	c.InformerFactory.Start(ch)
 }


### PR DESCRIPTION
This commit picks c4ddf03bec (#517) back to 4.5.  It's not a clean pick, because we're missing changes like:

* b72e843974 (Bug 1822844: Block z level upgrades if ClusterVersionOverridesSet set, 2020-04-30, #364).
* 1d1de3ba1a (Use context to add timeout to cincinnati HTTP request, 2019-01-15, #410).

which also touched these lines.  But we've gotten this far without backporting rhbz#1822844, and #410 was never associated with a bug in the first place, so instead of pulling back more of 4.6 to get a clean pick, I've just manually reconciled the pick conflicts.

/assign @jottofar