### PR TITLE
pkg/cvo/internal/operatorstatus: Drop deprecated failing/progressing handling

### DIFF
--- a/docs/user/reconciliation.md
+++ b/docs/user/reconciliation.md
@@ -117,7 +117,7 @@ Instead, the operators create ClusterOperator themselves.
 The ClusterOperator builder only monitors the in-cluster object and blocks until it is:
 
 * Available
-* Either not progressing or, when the release image manifest has `status.versions` entries, listing at least the versions given in that manifest.
+* The ClusterOperator contains at least the versions listed in the associated release image manifest.
     For example, an OpenShift API server ClusterOperator entry in the release image like:
 
     ```yaml
@@ -133,8 +133,6 @@ The ClusterOperator builder only monitors the in-cluster object and blocks until
     ```
 
     would block until the in-cluster ClusterOperator reported `operator` at version 4.1.0.
-
-    The progressing check is deprecated and will be removed once all operators are reporting versions.
 * Not degraded (except during initialization, where we ignore the degraded status)
 
 ### CustomResourceDefinition

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -49,9 +49,15 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting no versions with no operands",
+		name: "cluster operator reporting available=true and degraded=false, but no versions",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
+			},
 		},
 		exp: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
@@ -62,16 +68,22 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting no versions",
+		name: "cluster operator reporting available=true, degraded=false, but no versions, while expecting an operator version",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
+			},
 		},
 		exp: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
@@ -84,17 +96,21 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting no versions for operand",
+		name: "cluster operator reporting available=true and degraded=false, but no versions for operand",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
 				Versions: []configv1.OperandVersion{{
 					Name: "operator", Version: "v0",
 				}},
@@ -111,17 +127,21 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting old versions",
+		name: "cluster operator reporting available=true and degraded=false, but old versions",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
 				Versions: []configv1.OperandVersion{{
 					Name: "operator", Version: "v0",
 				}, {
@@ -140,21 +160,25 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting mix of desired and old versions",
+		name: "cluster operator reporting available=true and degraded=false, but mix of desired and old versions",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
 				Versions: []configv1.OperandVersion{{
-					Name: "operator", Version: "v1",
+					Name: "operator", Version: "v0",
 				}, {
-					Name: "operand-1", Version: "v0",
+					Name: "operand-1", Version: "v1",
 				}},
 			},
 		},
@@ -169,17 +193,21 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting desired operator and old versions for 2 operands",
+		name: "cluster operator reporting available=true, degraded=false, and desired operator, but old versions for 2 operands",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
 				Versions: []configv1.OperandVersion{{
 					Name: "operator", Version: "v1",
 				}, {
@@ -202,17 +230,21 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting desired operator and mix of old and desired versions for 2 operands",
+		name: "cluster operator reporting available=true, degraded=false, and desired operator, but mix of old and desired versions for 2 operands",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				},
 				Versions: []configv1.OperandVersion{{
 					Name: "operator", Version: "v1",
 				}, {
@@ -235,10 +267,10 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is still updating"),
+			Nested:       fmt.Errorf("cluster operator test-co is available and not degraded but has not finished updating to target version"),
 			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co is still updating",
+			Reason:       "ClusterOperatorUpdating",
+			Message:      "Cluster operator test-co is updating versions",
 			Name:         "test-co",
 		},
 	}, {
@@ -264,7 +296,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co conditions: available=false, progressing=true, degraded=true"),
+			Nested:       fmt.Errorf("cluster operator test-co: available=false, progressing=true, degraded=true, undone="),
 			UpdateEffect: payload.UpdateEffectFail,
 			Reason:       "ClusterOperatorNotAvailable",
 			Message:      "Cluster operator test-co is not available",
@@ -294,7 +326,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co conditions: available=false, progressing=true, degraded=true"),
+			Nested:       fmt.Errorf("cluster operator test-co: available=false, progressing=true, degraded=true, undone="),
 			UpdateEffect: payload.UpdateEffectFail,
 			Reason:       "ClusterOperatorNotAvailable",
 			Message:      "Cluster operator test-co is not available",
@@ -324,14 +356,14 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co conditions: available=false, progressing=true, degraded=true"),
+			Nested:       fmt.Errorf("cluster operator test-co: available=false, progressing=true, degraded=true, undone="),
 			UpdateEffect: payload.UpdateEffectFail,
 			Reason:       "ClusterOperatorNotAvailable",
 			Message:      "Cluster operator test-co is not available",
 			Name:         "test-co",
 		},
 	}, {
-		name: "cluster operator reporting available=true progressing=true",
+		name: "cluster operator reporting available=true, degraded=false, and progressing=true",
 		actual: &configv1.ClusterOperator{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-co"},
 			Status: configv1.ClusterOperatorStatus{
@@ -340,7 +372,11 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}, {
 					Name: "operand-1", Version: "v1",
 				}},
-				Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue}, {Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue}},
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+					{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue},
+				},
 			},
 		},
 		exp: &configv1.ClusterOperator{
@@ -352,13 +388,6 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 					Name: "operand-1", Version: "v1",
 				}},
 			},
-		},
-		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator is available and not degraded but has not finished updating to target version"),
-			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorUpdating",
-			Message:      "Cluster operator test-co is updating versions",
-			Name:         "test-co",
 		},
 	}, {
 		name: "cluster operator reporting available=true degraded=true",
@@ -370,7 +399,10 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}, {
 					Name: "operand-1", Version: "v1",
 				}},
-				Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue}, {Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, Message: "random error"}},
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, Reason: "RandomReason", Message: "random error"},
+				},
 			},
 		},
 		exp: &configv1.ClusterOperator{
@@ -384,7 +416,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is reporting a message: random error"),
+			Nested:       fmt.Errorf("cluster operator test-co is Degraded=True: RandomReason, random error"),
 			UpdateEffect: payload.UpdateEffectFailAfterInterval,
 			Reason:       "ClusterOperatorDegraded",
 			Message:      "Cluster operator test-co is degraded",
@@ -400,7 +432,11 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				}, {
 					Name: "operand-1", Version: "v1",
 				}},
-				Conditions: []configv1.ClusterOperatorStatusCondition{{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue}, {Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue}, {Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, Message: "random error"}},
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue},
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue, Reason: "RandomReason", Message: "random error"},
+				},
 			},
 		},
 		exp: &configv1.ClusterOperator{
@@ -414,7 +450,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator test-co is reporting a message: random error"),
+			Nested:       fmt.Errorf("cluster operator test-co is Degraded=True: RandomReason, random error"),
 			UpdateEffect: payload.UpdateEffectFailAfterInterval,
 			Reason:       "ClusterOperatorDegraded",
 			Message:      "Cluster operator test-co is degraded",
@@ -444,10 +480,10 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       fmt.Errorf("cluster operator is available and not degraded but has not finished updating to target version"),
-			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorUpdating",
-			Message:      "Cluster operator test-co is updating versions",
+			Nested:       fmt.Errorf("cluster operator test-co: available=true, progressing=true, degraded=true, undone="),
+			UpdateEffect: payload.UpdateEffectFailAfterInterval,
+			Reason:       "ClusterOperatorDegraded",
+			Message:      "Cluster operator test-co is degraded",
 			Name:         "test-co",
 		},
 	}, {

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -534,7 +535,8 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !reflect.DeepEqual(test.expErr, err) {
-				t.Fatalf("Incorrect value returned -\nexpected: %#v\nreturned: %#v", test.expErr, err)
+				spew.Config.DisableMethods = true
+				t.Fatalf("Incorrect value returned -\nexpected: %s\nreturned: %s", spew.Sdump(test.expErr), spew.Sdump(err))
 			}
 		})
 	}

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -180,8 +180,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterOperatorStatus{
 								Versions: []configv1.OperandVersion{
-									{Version: "10.1.5-1"},
-									{Version: "10.1.5-2"},
+									{Name: "operator", Version: "10.1.5-1"},
+									{Name: "operand", Version: "10.1.5-2"},
 								},
 								Conditions: []configv1.ClusterOperatorStatusCondition{
 									{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},


### PR DESCRIPTION
Also simplify the `undone` type from a map to a slice of strings.  The only consumers are length checks and `nestedMessage` formatting, so we don't need to preserve structured access to the current and expected values.

I've also dropped the old, early "Cluster operator %s is still updating" guard.  If the ClusterOperator is degraded or unavailable, those are much more serious than being behind in version, so we want those guards coming first.  The undone guard is now only the final fallback for available, non-degraded operators that aren't completely satisfactory (and I've pivoted to use `ClusterOperatorUpdating` for that reason).

I'm also now keeping any available condition data, and including that status, reason, and message in the nested message, because it seemed strange to do that for degraded, but not for the more serious unavailable.

And finally, I've dropped the old mode switch, and instead distributed the mode check to each relevant guard.  The "we're completely satisfied" case is now where you end up if none of the "we aren't happy" guards trip.  This avoids the need to have an "if we got this far, it must have been because we have undone versions" assumption for the `ClusterOperatorUpdating` block.