### PR TITLE
Bug 1871303: metrics: serve metrics after leader lock acquired

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -406,6 +406,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 	} else if manifests, err := m.optr.cmConfigLister.Get(internal.ManifestsConfigMap); err == nil {
 		ch <- gaugeFromInstallConfigMap(manifests, m.clusterInstaller, "other")
 	} else if apierrors.IsNotFound(err) {
+		klog.Warningf("ConfigMap %s not found api error: %v", internal.ManifestsConfigMap, err)
 		g := m.clusterInstaller.WithLabelValues("", "", "")
 		g.Set(1.0)
 		ch <- g


### PR DESCRIPTION
We'll get a CI error if installer metric is generated with either `type` or `invoker` set to "". Fix possible race condition whereby informers are not yet sync'ed before metrics are served which results in an API IsNotFound error.