### PR TITLE
pkg/cvo/metrics: Exclude unrecognized statuses from cluster_operator_conditions

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -341,7 +341,8 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		for _, condition := range cv.Status.Conditions {
-			if condition.Status == configv1.ConditionUnknown {
+			if condition.Status != configv1.ConditionFalse && condition.Status != configv1.ConditionTrue {
+				klog.V(4).Infof("skipping metrics for ClusterVersion condition %s=%s (neither True nor False)", condition.Type, condition.Status)
 				continue
 			}
 			g := m.clusterOperatorConditions.WithLabelValues("version", string(condition.Type), string(condition.Reason))
@@ -381,7 +382,8 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- g
 		for _, condition := range op.Status.Conditions {
-			if condition.Status == configv1.ConditionUnknown {
+			if condition.Status != configv1.ConditionFalse && condition.Status != configv1.ConditionTrue {
+				klog.V(4).Infof("skipping metrics for %s ClusterOperator condition %s=%s (neither True nor False)", op.Name, condition.Type, condition.Status)
 				continue
 			}
 			g := m.clusterOperatorConditions.WithLabelValues(op.Name, string(condition.Type), string(condition.Reason))


### PR DESCRIPTION
We have been excluding `Unknown` since the metric landed in 8b9118992d (#45).  But operators could do crazy things like setting `status: Muahaha`, and we don't want to collapse them all into the `False`/`0` case.  We could enumerate the known statuses (e.g. using 2 for `Unknown`), but that would probably not play well with existing queries, and `Unknown` is hopefully not too popular.