### PR TITLE
Bug 1929917: pkg/cvo/sync_worker: Skip precreation of baremetal ClusterOperator

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -742,6 +742,10 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 					klog.V(4).Infof("Skipping precreation of %s as unmanaged", task)
 					continue
 				}
+				if task.Manifest.Obj.GetName() == "baremetal" {
+					klog.V(4).Infof("Skipping precreation of %s, https://bugzilla.redhat.com/show_bug.cgi?id=1929917", task)
+					continue
+				}
 				if err := w.builder.Apply(ctx, task.Manifest, payload.PrecreatingPayload); err != nil {
 					klog.V(2).Infof("Unable to precreate resource %s: %v", task, err)
 					continue


### PR DESCRIPTION
This is a hack fix for [rhbz#1929917][1], where we have a delay on 4.6->4.7 updates, and on some 4.7 installs, between the very early ClusterOperator precreation and the operator eventually coming up to set its status conditions.  In the interim, there are no conditions, which causes `cluster_operator_up` to be 0, which causes the `critical` `ClusterOperatorDown` to fire.  We'll want a more general fix going forward, this commit is a temporary hack to avoid firing the critical `ClusterOperatorDown` while we build consensus around the general fix.

The downside to dropping precreates for this operator is that we lose the must-gather references when the operator fails to come up.  That was what precreation was designed to address in 2a469e37c1 (#318).  If we actually get a must-gather without the bare-metal bits and we miss them, we can revisit the approach this hack is taking.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1929917