### PR TITLE
Bug 1940652: Bump logging to --v=5

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -15,7 +15,7 @@ spec:
       - "--release-image={{.ReleaseImage}}"
       - "--enable-auto-update=false"
       - "--enable-default-cluster-version=false"
-      - "--v=4"
+      - "--v=5"
       - "--kubeconfig=/etc/kubernetes/kubeconfig"
     securityContext:
       privileged: true

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -26,7 +26,7 @@ spec:
           - "--release-image={{.ReleaseImage}}"
           - "--enable-auto-update=false"
           - "--enable-default-cluster-version=true"
-          - "--v=4"
+          - "--v=5"
         resources:
           requests:
             cpu: 20m


### PR DESCRIPTION
To pick up all the .V(5) logging in pkg/cvo/sync_worker.go.  I'm
especially interested in syncStatus logging that logs Generation
to help debug issue [1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1915559