### PR TITLE
Bug 1938947: Ensure automountServiceAccountToken is synced on service account updates

### DIFF
--- a/lib/resourceapply/core.go
+++ b/lib/resourceapply/core.go
@@ -87,7 +87,7 @@ func ApplyServiceAccountv1(ctx context.Context, client coreclientv1.ServiceAccou
 	}
 
 	modified := pointer.BoolPtr(false)
-	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	resourcemerge.EnsureServiceAccount(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
 	}

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -15,6 +15,13 @@ func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1
 	mergeMap(modified, &existing.Data, required.Data)
 }
 
+// EnsureServiceAccount ensures that the existing mathces the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureServiceAccount(modified *bool, existing *corev1.ServiceAccount, required corev1.ServiceAccount) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	setBoolPtr(modified, &existing.AutomountServiceAccountToken, required.AutomountServiceAccountToken)
+}
+
 // ensurePodTemplateSpec ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
 func ensurePodTemplateSpec(modified *bool, existing *corev1.PodTemplateSpec, required corev1.PodTemplateSpec) {


### PR DESCRIPTION
Currently, if you were to change the value of the service account `automountServiceAccountToken` field between versions of openshift, CVO will not update it, it only updates metadata.

With this fix, it will now also set the `automountServiceAccountToken` to the value specified in the service account yaml in the manifests.