### PR TITLE
Bug 1943973: pkg/cvo/sync_worker: Skip precreation of baremetal ClusterOperator

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -699,6 +699,10 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 				if task.Manifest.GVK != configv1.SchemeGroupVersion.WithKind("ClusterOperator") {
 					continue
 				}
+				if task.Manifest.Obj.GetName() == "baremetal" {
+					klog.V(4).Infof("Skipping precreation of %s, https://bugzilla.redhat.com/show_bug.cgi?id=1929917", task)
+					continue
+				}
 				if err := w.builder.Apply(ctx, task.Manifest, payload.PrecreatingPayload); err != nil {
 					klog.V(2).Infof("Unable to precreate resource %s: %v", task, err)
 					continue


### PR DESCRIPTION
Picking #534 back to release-4.6 manually, because 4.6 doesn't include #488.