### PR TITLE
Add management workload annotations

### DIFF
--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     name: openshift-cluster-version
     openshift.io/run-level: "1"

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -15,6 +15,8 @@ spec:
   template:
     metadata:
       name: cluster-version-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-version-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>