### PR TITLE
lib/resourcemerge/rbac: Reconcile ClusterRole.AggregationRule

### DIFF
--- a/lib/resourcemerge/rbac.go
+++ b/lib/resourcemerge/rbac.go
@@ -27,6 +27,10 @@ func EnsureClusterRole(modified *bool, existing *rbacv1.ClusterRole, required rb
 		*modified = true
 		existing.Rules = required.Rules
 	}
+	if !equality.Semantic.DeepEqual(existing.AggregationRule, required.AggregationRule) {
+		*modified = true
+		existing.AggregationRule = required.AggregationRule
+	}
 }
 
 // EnsureRoleBinding ensures that the existing matches the required.

--- a/lib/resourcemerge/rbacv1beta1.go
+++ b/lib/resourcemerge/rbacv1beta1.go
@@ -27,6 +27,10 @@ func EnsureClusterRolev1beta1(modified *bool, existing *rbacv1beta1.ClusterRole,
 		*modified = true
 		existing.Rules = required.Rules
 	}
+	if !equality.Semantic.DeepEqual(existing.AggregationRule, required.AggregationRule) {
+		*modified = true
+		existing.AggregationRule = required.AggregationRule
+	}
 }
 
 // EnsureRoleBindingv1beta1 ensures that the existing matches the required.


### PR DESCRIPTION
This wasn't covered when ClusterRole reconciliation landed in 697cbf6370 (#10), but the property existed even back then:

```console
$ git grep -A20 'type ClusterRole struct' 697cbf6370 | grep '[-][[:space:]]Aggrega
tionRule'
697cbf6370:vendor/k8s.io/api/rbac/v1/types.go-  AggregationRule *AggregationRule `json:"aggregationRule,omitempty" protobuf:"bytes,3,opt,name=aggregationRule"`
697cbf6370:vendor/k8s.io/api/rbac/v1alpha1/types.go-    AggregationRule *AggregationRule `json:"aggregationRule,omitempty" protobuf:"bytes,3,opt,name=aggregationRule"`
697cbf6370:vendor/k8s.io/api/rbac/v1beta1/types.go-     AggregationRule *AggregationRule `json:"aggregationRule,omitempty" protobuf:"bytes,3,opt,name=aggregationRule"`
```

and now folks want to use `aggregationRule` for something: openshift/machine-api-operator#795.