### PR TITLE
Rename workload annotations

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       name: cluster-version-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cluster-version-operator
     spec:


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged