### PR TITLE
Bug 1951339: lib/resourcemerge/core: Clear env and envFrom if unset in manifest

### DIFF
--- a/lib/resourcebuilder/apps.go
+++ b/lib/resourcebuilder/apps.go
@@ -123,6 +123,15 @@ func (b *builder) checkDeploymentHealth(ctx context.Context, deployment *appsv1.
 		}
 	}
 
+	if progressingCondition != nil && progressingCondition.Status == corev1.ConditionFalse && progressingCondition.Reason == "ProgressDeadlineExceeded" {
+		return &payload.UpdateError{
+			Nested:  fmt.Errorf("deployment %s is %s=%s: %s: %s", iden, progressingCondition.Type, progressingCondition.Status, progressingCondition.Reason, progressingCondition.Message),
+			Reason:  "WorkloadNotProgressing",
+			Message: fmt.Sprintf("deployment %s is %s=%s: %s: %s", iden, progressingCondition.Type, progressingCondition.Status, progressingCondition.Reason, progressingCondition.Message),
+			Name:    iden,
+		}
+	}
+
 	if availableCondition == nil && progressingCondition == nil && replicaFailureCondition == nil {
 		klog.Warningf("deployment %s is not setting any expected conditions, and is therefore in an unknown state", iden)
 	}

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -141,9 +141,6 @@ func ensureContainer(modified *bool, existing *corev1.Container, required corev1
 }
 
 func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.EnvVar) {
-	if required == nil {
-		return
-	}
 	if !equality.Semantic.DeepEqual(required, *existing) {
 		*existing = required
 		*modified = true
@@ -151,9 +148,6 @@ func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.E
 }
 
 func ensureEnvFromSource(modified *bool, existing *[]corev1.EnvFromSource, required []corev1.EnvFromSource) {
-	if required == nil {
-		return
-	}
 	if !equality.Semantic.DeepEqual(required, *existing) {
 		*existing = required
 		*modified = true


### PR DESCRIPTION
And also fail on Deployments that set [`ProgressDeadlineExceeded`][1].  More background in the commit messages, but these two changes should address both points from [rhbz#1951339][2].

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#failed-deployment
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1951339