### PR TITLE
Bug 1834551: pkg/cvo/metrics: Ignore Degraded for cluster_operator_up

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -82,7 +82,11 @@ spec:
       annotations:
         message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 10 minutes. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
       expr: |
-        cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"} == 1
+        (
+          cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"}
+          or on (name)
+          group by (name) (cluster_operator_up{job="cluster-version-operator"})
+        ) == 1
       for: 10m
       labels:
         severity: critical

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -358,9 +358,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 			klog.V(4).Infof("ClusterOperator %s is not setting the 'operator' version", op.Name)
 		}
 		g := m.clusterOperatorUp.WithLabelValues(op.Name, version)
-		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorDegraded)
-		available := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable)
-		if available && !failing {
+		if resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable) {
 			g.Set(1)
 		} else {
 			g.Set(0)


### PR DESCRIPTION
`ClusterOperatorDown` is based on `cluster_operator_up`, but we also have `ClusterOperatorDegraded` based on `cluster_operator_conditions{condition="Degraded"}`.  Firing `ClusterOperatorDown` for operators which are `Available=True` and `Degraded=True` [confuses users][1].  `ClusterOperatorDegraded` will also be firing.  With this commit, I'm adjusting `cluster_operator_up` to only care about `Available`, to decouple the two alerts and bring them in line with their existing "has not been available" and "has been degraded" descriptions.

However, `IsOperatorStatusConditionTrue` requires the condition to be present, and `cluster_operator_conditions` only creates entries when the conditions are present.  To guard against the Degraded-unset condition in `ClusterOperatorDegraded`, I'm covering with an [`or`][2] and [`group by`][3] guard.  So we should have the following cases:

* `Available` unset or `!= True`: `ClusterOperatorDown` will fire.
* `Available=True`, `Degraded` unset or `!= False`: `ClusterOperatorDegraded` will fire.  Firing on unset is new in this commit.  Not firing `ClusterOperatorDown` here is new in this commit.
* `Available=True`, `Degraded=False`: Neither alert fires.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1834551#c0
[2]: https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
[3]: https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators