### PR TITLE
pkg/cvo/sync_worker: Reject alternate image with same version

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -617,6 +617,19 @@ func (w *SyncWorker) syncOnce(ctx context.Context, work *SyncWork, maxWorkers in
 				Verified:    info.Verified,
 			})
 			return err
+		} else if !equalDigest(payloadUpdate.Release.Image, work.Desired.Image) {
+			err = fmt.Errorf("both release images %s and %s claim the same version %s", work.Desired.Image, payloadUpdate.Release.Image, work.Desired.Version)
+			w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeWarning, "VerifyPayloadVersionFailed", "verifying payload failed version=%q image=%q failure=%v", work.Desired.Version, work.Desired.Image, err)
+			reporter.Report(SyncWorkerStatus{
+				Generation:  work.Generation,
+				Failure:     err,
+				Step:        "VerifyPayloadVersion",
+				Initial:     work.State.Initializing(),
+				Reconciling: work.State.Reconciling(),
+				Actual:      desired,
+				Verified:    info.Verified,
+			})
+			return err
 		}
 
 		// need to make sure the payload is only set when the preconditions have been successful


### PR DESCRIPTION
This should never happen in production, but sometimes in CI we are asked to update from A->B where both A and B have the same version string.  Because ClusterOperator leveling is based on `status.versions` strings, the CVO decides operators have leveled, when in fact they have just received their new image pullspecs, and the whole update gets very jumbled and broken.  An example [is][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/26097/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1387565894850318336/artifacts/e2e-gcp-upgrade/gather-extra/artifacts/clusterversion.json | jq -r '.items[].status.history[] | .startedTime + " " + .completionTime + " " + .state + " " + .version + " " + .image'
2021-04-29T01:29:45Z 2021-04-29T01:31:08Z Completed 4.8.0-0.ci.test-2021-04-29-003543-ci-op-ji979z35 registry.build01.ci.openshift.org/ci-op-ji979z35/release@sha256:22ed5994775319c23bbe242c969c2713b14ce96669b30070265c2e2251c5c8e4
2021-04-29T01:00:52Z 2021-04-29T01:25:30Z Completed 4.8.0-0.ci.test-2021-04-29-003543-ci-op-ji979z35 registry.build01.ci.openshift.org/ci-op-ji979z35/release@sha256:30afe5f877f9f1b0d7f273d4e480ace475221f3cd814fcd888a4d874b500976a
```

Confirming the versions baked into the two images:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/26097/pull-ci-openshift-origin-master-2e-gcp-upgrade/1387565894850318336/artifacts/release/artifacts/release-payload-initial/release-metadata
{
  "kind": "cincinnati-metadata-v0",
  "version": "4.8.0-0.ci.test-2021-04-29-003543-ci-op-ji979z35",
  "previous": []
}
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/26097/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1387565894850318336/artifacts/release/artifacts/release-payload-latest/release-metadata
{
  "kind": "cincinnati-metadata-v0",
  "version": "4.8.0-0.ci.test-2021-04-29-003543-ci-op-ji979z35",
  "previous": []
}
```

With this commit, that sort of thing will lead to `VerifyPayloadVersionFailed`.  We still allow users to change from one by-digest pullspec to another, as long as they preserve the digest, if for some reason they wanted a different canonical registry for the same release image.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26097/pull-ci-openshift-origin-master-e2e-gcp-upgrade/1387565894850318336