### PR TITLE
Bug 1957775: pkg/cvo/sync_worker: Shift ClusterOperator pre-creation into the manifest-task node

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -726,10 +726,11 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 		precreateObjects = true
 	}
 
-	// in specific modes, attempt to precreate a set of known types (currently ClusterOperator) without
-	// retries
-	if precreateObjects {
-		payload.RunGraph(ctx, graph, 8, func(ctx context.Context, tasks []*payload.Task) error {
+	// update each object
+	errs := payload.RunGraph(ctx, graph, maxWorkers, func(ctx context.Context, tasks []*payload.Task) error {
+		// in specific modes, attempt to precreate a set of known types (currently ClusterOperator) without
+		// retries
+		if precreateObjects {
 			for _, task := range tasks {
 				if err := ctx.Err(); err != nil {
 					return cr.ContextError(err)
@@ -742,22 +743,14 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 					klog.V(4).Infof("Skipping precreation of %s as unmanaged", task)
 					continue
 				}
-				if task.Manifest.Obj.GetName() == "baremetal" {
-					klog.V(4).Infof("Skipping precreation of %s, https://bugzilla.redhat.com/show_bug.cgi?id=1929917", task)
-					continue
-				}
 				if err := w.builder.Apply(ctx, task.Manifest, payload.PrecreatingPayload); err != nil {
 					klog.V(2).Infof("Unable to precreate resource %s: %v", task, err)
 					continue
 				}
 				klog.V(4).Infof("Precreated resource %s", task)
 			}
-			return nil
-		})
-	}
+		}
 
-	// update each object
-	errs := payload.RunGraph(ctx, graph, maxWorkers, func(ctx context.Context, tasks []*payload.Task) error {
 		for _, task := range tasks {
 			if err := ctx.Err(); err != nil {
 				return cr.ContextError(err)


### PR DESCRIPTION
ClusterOperator pre-creation landed in 2a469e37c1 (#318) to move us from:

1. CVO creates a namespace for an operator.
2. CVO creates ... for the operator.
3. CVO creates the operator Deployment.
4. Operator deployment never comes up, for whatever reason.
5. Admin must-gathers.
6. Must gather uses ClusterOperators for discovering important stuff, and because the ClusterOperator doesn't exist yet, we get no data about why the deployment didn't come up.

to:

1. CVO pre-creates ClusterOperator for an operator.
2. CVO creates the namespace for an operator.
3. CVO creates ... for the operator.
4. CVO creates the operator Deployment.
5. Operator deployment never comes up, for whatever reason.
6. Admin must-gathers.
7. Must gather uses ClusterOperators for discovering important stuff, and finds the one the CVO had pre-created with hard-coded `relatedObjects`, gathers stuff from the referenced operator namespace, and allows us to trouble-shoot the issue.

But when ClusterOperator pre-creation happens at the beginning of an update sync cycle, it can take a while before the CVO gets from the ClusterOperator creation in (1) to the operator managing that ClusterOperator in (4), which can lead to ClusterOperatorDown alerts ([rhbz#1929917][1], [rhbz#1957775][2]).

fdef37dc0e (#531) landed a narrow hack to avoid issues on 4.6 -> 4.7 updates, which added the baremetal operator ([rhbz#1929917][1]).  But we're adding a cloud-controller-manager operator in 4.7 -> 4.8, and breaking the same way ([rhbz#1957775][2]).  This commit pivots to a more generic fix, by delaying the pre-creation until the CVO reaches the manifest-task node containing the ClusterOperator manifest.  That will usually be the same node that has the other critical operator manifests like the namespace, RBAC, and operator deployment.

Dropping fdef37dc0e's baremetal hack will re-expose us to issues on install, where we race through all the manifests as fast as possible.  It's possible that we will now pre-create the ClusterOperator early (because it's only blocked by the CRD) and still be a ways in front of the operator pod coming up (because that needs a schedulable control-plane node).  But we can address that by surpressing ClusterOperatorDown and ClusterOperatorDegraded for some portion of install in follow-up work.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1929917
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1957775