### PR TITLE
Bug 1957991: install/0000_90_cluster-version-operator_02_servicemonitor: Soften ClusterOperatorDegraded

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -87,9 +87,9 @@ spec:
           or on (name)
           group by (name) (cluster_operator_up{job="cluster-version-operator"})
         ) == 1
-      for: 10m
+      for: 30m
       labels:
-        severity: critical
+        severity: warning
     - alert: ClusterOperatorFlapping
       annotations:
         message: Cluster operator {{ "{{ $labels.name }}" }} up status is changing often. This might cause upgrades to be unstable.


### PR DESCRIPTION
During install, the CVO has pushed manifests into the cluster as fast as possible without blocking on "has the in-cluster resource leveled?" since way back in b0b4902fce (#136).  That can lead to `ClusterOperatorDown` and `ClusterOperatorDegraded` firing during install, as we see [here][1], where:

* [ClusterOperatorDegraded started pending at 5:00:15Z][2] (`group by (alertstate) (ALERTS{alertname="ClusterOperatorDegraded"})`.
* [Install completed at 5:09:58Z][3].
* [ClusterOperatorDegraded started firing at 5:10:04Z][2].
* [ClusterOperatorDegraded stopped firing at 5:10:23Z][2].
* [The e2e suite][1] complained about:

        alert ClusterOperatorDegraded fired for 15 seconds with labels: {... name="authentication"...} (open bug: https://bugzilla.redhat.com/show_bug.cgi?id=1939580)

`ClusterOperatorDown` is similar, but I'll leave addressing it to a separate commit.  For `ClusterOperatorDegraded`, the degraded condition [should not be particularly urgent][4], so we should be find bumping it to `warning` and using `for: 30m` or something more relaxed than the current `10m`.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.8/1389436726862155776
[2]: https://promecieus.dptools.openshift.org/?search=https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.8/1389436726862155776
[3]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.8/1389436726862155776/artifacts/e2e-aws-upi/clusterversion.json
[4]: https://github.com/openshift/api/pull/916