### PR TITLE
Bug 1881481: Only compare ServiceType when set in manifest

### DIFF
--- a/lib/resourceapply/core.go
+++ b/lib/resourceapply/core.go
@@ -58,14 +58,13 @@ func ApplyServicev1(ctx context.Context, client coreclientv1.ServicesGetter, req
 	modified := pointer.BoolPtr(false)
 	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 	resourcemerge.EnsureServicePorts(modified, &existing.Spec.Ports, required.Spec.Ports)
+	resourcemerge.EnsureServiceType(modified, &existing.Spec.Type, required.Spec.Type)
 	selectorSame := equality.Semantic.DeepEqual(existing.Spec.Selector, required.Spec.Selector)
-	typeSame := equality.Semantic.DeepEqual(existing.Spec.Type, required.Spec.Type)
 
-	if selectorSame && typeSame && !*modified {
+	if selectorSame && !*modified {
 		return nil, false, nil
 	}
 	existing.Spec.Selector = required.Spec.Selector
-	existing.Spec.Type = required.Spec.Type // if this is different, the update will fail.  Status will indicate it.
 
 	actual, err := client.Services(required.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
 	return actual, true, err

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -253,6 +253,18 @@ func EnsureServicePorts(modified *bool, existing *[]corev1.ServicePort, required
 	}
 }
 
+func EnsureServiceType(modified *bool, existing *corev1.ServiceType, required corev1.ServiceType) {
+	// if we have no required ensure existing is set to default
+	if required == "" {
+		required = corev1.ServiceTypeClusterIP
+	}
+
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}
+
 func ensureServicePort(modified *bool, existing *corev1.ServicePort, required corev1.ServicePort) {
 	ensureServicePortDefaults(&required)
 	if !equality.Semantic.DeepEqual(required, *existing) {


### PR DESCRIPTION
Previously ServiceType was simply checked for equality resulting in CVO hot looping trying to clear ServiceType field that server continuously defaults. Added EnsureServiceType that will only check field equality if the field has been set. If field has not been set  EnsureServiceType ensures the in-cluster object's ServiceType is set to the default "ClusterIP".