### PR TITLE
Bug 1881484: Set defaults in deployment

### DIFF
--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -63,6 +63,8 @@ func TestEnsureDeployment(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			defaultDeployment(&test.existing, test.existing)
+			defaultDeployment(&test.expected, test.expected)
 			modified := pointer.BoolPtr(false)
 			EnsureDeployment(modified, &test.existing, test.required)
 			if *modified != test.expectedModified {
@@ -74,6 +76,12 @@ func TestEnsureDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Ensures the structure contains any defaults not explicitly set by the test
+func defaultDeployment(in *appsv1.Deployment, from appsv1.Deployment) {
+	modified := pointer.BoolPtr(false)
+	EnsureDeployment(modified, in, from)
 }
 
 func int32Pointer(i int32) *int32 {

--- a/lib/resourcemerge/batch_test.go
+++ b/lib/resourcemerge/batch_test.go
@@ -77,6 +77,8 @@ func TestEnsureJob(t *testing.T) {
 					}
 				}
 			}()
+			defaultJob(&test.existing, test.existing)
+			defaultJob(&test.expected, test.expected)
 			modified := pointer.BoolPtr(false)
 			EnsureJob(modified, &test.existing, test.required)
 			if *modified != test.expectedModified {
@@ -88,4 +90,10 @@ func TestEnsureJob(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Ensures the structure contains any defaults not explicitly set by the test
+func defaultJob(in *batchv1.Job, from batchv1.Job) {
+	modified := pointer.BoolPtr(false)
+	EnsureJob(modified, in, from)
 }


### PR DESCRIPTION
Mostly followed kube defaulting logic however with some exceptions:
-  Currently only CVO deployment uses "KUBERNETES_SERVICE_HOST" env variable to inject internal LB host.This may result in an IP address being returned by API so always assuming returned value is okay.
-  Toleration keys can be duplicated and are so in CVO (see [Bug 1941901](https://bugzilla.redhat.com/show_bug.cgi?id=1941901)) so needed to change logic to not simply exit when first matched key found possibly incorrectly overwrite the wrong key's value.
Also added VolumeSource defaulting in its entirety even though some are not currently used to avoid future hot looping issues.