### PR TITLE
Bug 1927168: pkg/cvo/internal/operatorstatus: Replace wait-for with single-shot "is it alive now?"

### DIFF
--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 	"unicode"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -123,130 +121,115 @@ func (b *clusterOperatorBuilder) Do(ctx context.Context) error {
 		return nil
 	}
 
-	return waitForOperatorStatusToBeDone(ctx, 1*time.Second, b.client, os, b.mode)
+	return checkOperatorHealth(ctx, b.client, os, b.mode)
 }
 
-func waitForOperatorStatusToBeDone(ctx context.Context, interval time.Duration, client ClusterOperatorsGetter, expected *configv1.ClusterOperator, mode resourcebuilder.Mode) error {
-	var lastErr error
-	err := wait.PollImmediateUntil(interval, func() (bool, error) {
-		actual, err := client.Get(ctx, expected.Name)
-		if err != nil {
-			lastErr = &payload.UpdateError{
-				Nested:       err,
-				UpdateEffect: payload.UpdateEffectNone,
-				Reason:       "ClusterOperatorNotAvailable",
-				Message:      fmt.Sprintf("Cluster operator %s has not yet reported success", expected.Name),
-				Name:         expected.Name,
-			}
-			return false, nil
+func checkOperatorHealth(ctx context.Context, client ClusterOperatorsGetter, expected *configv1.ClusterOperator, mode resourcebuilder.Mode) error {
+	if len(expected.Status.Versions) == 0 {
+		return &payload.UpdateError{
+			UpdateEffect: payload.UpdateEffectFail,
+			Reason:       "ClusterOperatorNotAvailable",
+			Message:      fmt.Sprintf("Cluster operator %s does not declare expected versions", expected.Name),
+			Name:         expected.Name,
 		}
-
-		if len(expected.Status.Versions) == 0 {
-			lastErr = &payload.UpdateError{
-				UpdateEffect: payload.UpdateEffectFail,
-				Reason:       "ClusterOperatorNotAvailable",
-				Message:      fmt.Sprintf("Cluster operator %s does not declare expected versions", expected.Name),
-				Name:         expected.Name,
-			}
-			return false, nil
-		}
-
-		// undone is a sorted slice of transition messages for incomplete operands.
-		undone := make([]string, 0, len(expected.Status.Versions))
-		for _, expOp := range expected.Status.Versions {
-			current := ""
-			for _, actOp := range actual.Status.Versions {
-				if actOp.Name == expOp.Name {
-					current = actOp.Version
-					break
-				}
-			}
-			if current != expOp.Version {
-				if current == "" {
-					undone = append(undone, fmt.Sprintf("%s to %s", expOp.Name, expOp.Version))
-				} else {
-					undone = append(undone, fmt.Sprintf("%s from %s to %s", expOp.Name, current, expOp.Version))
-				}
-			}
-		}
-		sort.Strings(undone)
-
-		available := false
-		var availableCondition *configv1.ClusterOperatorStatusCondition
-		progressing := true
-		degraded := true
-		var degradedCondition *configv1.ClusterOperatorStatusCondition
-		for i := range actual.Status.Conditions {
-			condition := &actual.Status.Conditions[i]
-			switch {
-			case condition.Type == configv1.OperatorAvailable:
-				if condition.Status == configv1.ConditionTrue {
-					available = true
-				}
-				availableCondition = condition
-			case condition.Type == configv1.OperatorProgressing && condition.Status == configv1.ConditionFalse:
-				progressing = false
-			case condition.Type == configv1.OperatorDegraded:
-				if condition.Status == configv1.ConditionFalse {
-					degraded = false
-				}
-				degradedCondition = condition
-			}
-		}
-
-		nestedMessage := fmt.Errorf("cluster operator %s: available=%v, progressing=%v, degraded=%v, undone=%s",
-			actual.Name, available, progressing, degraded, strings.Join(undone, ", "))
-
-		if !available {
-			if availableCondition != nil && len(availableCondition.Message) > 0 {
-				nestedMessage = fmt.Errorf("cluster operator %s is %s=%s: %s: %s", actual.Name, availableCondition.Type, availableCondition.Status, availableCondition.Reason, availableCondition.Message)
-			}
-			lastErr = &payload.UpdateError{
-				Nested:       nestedMessage,
-				UpdateEffect: payload.UpdateEffectFail,
-				Reason:       "ClusterOperatorNotAvailable",
-				Message:      fmt.Sprintf("Cluster operator %s is not available", actual.Name),
-				Name:         actual.Name,
-			}
-			return false, nil
-		}
-
-		// during initialization we allow degraded
-		if degraded && mode != resourcebuilder.InitializingMode {
-			if degradedCondition != nil && len(degradedCondition.Message) > 0 {
-				nestedMessage = fmt.Errorf("cluster operator %s is %s=%s: %s, %s", actual.Name, degradedCondition.Type, degradedCondition.Status, degradedCondition.Reason, degradedCondition.Message)
-			}
-			lastErr = &payload.UpdateError{
-				Nested:       nestedMessage,
-				UpdateEffect: payload.UpdateEffectFailAfterInterval,
-				Reason:       "ClusterOperatorDegraded",
-				Message:      fmt.Sprintf("Cluster operator %s is degraded", actual.Name),
-				Name:         actual.Name,
-			}
-			return false, nil
-		}
-
-		// during initialization we allow undone versions
-		if len(undone) > 0 && mode != resourcebuilder.InitializingMode {
-			nestedMessage = fmt.Errorf("cluster operator %s is available and not degraded but has not finished updating to target version", actual.Name)
-			lastErr = &payload.UpdateError{
-				Nested:       nestedMessage,
-				UpdateEffect: payload.UpdateEffectNone,
-				Reason:       "ClusterOperatorUpdating",
-				Message:      fmt.Sprintf("Cluster operator %s is updating versions", actual.Name),
-				Name:         actual.Name,
-			}
-			return false, nil
-		}
-
-		return true, nil
-	}, ctx.Done())
-	if err != nil {
-		if err == wait.ErrWaitTimeout && lastErr != nil {
-			return lastErr
-		}
-		return err
 	}
+
+	actual, err := client.Get(ctx, expected.Name)
+	if err != nil {
+		return &payload.UpdateError{
+			Nested:       err,
+			UpdateEffect: payload.UpdateEffectNone,
+			Reason:       "ClusterOperatorNotAvailable",
+			Message:      fmt.Sprintf("Cluster operator %s has not yet reported success", expected.Name),
+			Name:         expected.Name,
+		}
+	}
+
+	// undone is a sorted slice of transition messages for incomplete operands.
+	undone := make([]string, 0, len(expected.Status.Versions))
+	for _, expOp := range expected.Status.Versions {
+		current := ""
+		for _, actOp := range actual.Status.Versions {
+			if actOp.Name == expOp.Name {
+				current = actOp.Version
+				break
+			}
+		}
+		if current != expOp.Version {
+			if current == "" {
+				undone = append(undone, fmt.Sprintf("%s to %s", expOp.Name, expOp.Version))
+			} else {
+				undone = append(undone, fmt.Sprintf("%s from %s to %s", expOp.Name, current, expOp.Version))
+			}
+		}
+	}
+	sort.Strings(undone)
+
+	available := false
+	var availableCondition *configv1.ClusterOperatorStatusCondition
+	progressing := true
+	degraded := true
+	var degradedCondition *configv1.ClusterOperatorStatusCondition
+	for i := range actual.Status.Conditions {
+		condition := &actual.Status.Conditions[i]
+		switch {
+		case condition.Type == configv1.OperatorAvailable:
+			if condition.Status == configv1.ConditionTrue {
+				available = true
+			}
+			availableCondition = condition
+		case condition.Type == configv1.OperatorProgressing && condition.Status == configv1.ConditionFalse:
+			progressing = false
+		case condition.Type == configv1.OperatorDegraded:
+			if condition.Status == configv1.ConditionFalse {
+				degraded = false
+			}
+			degradedCondition = condition
+		}
+	}
+
+	nestedMessage := fmt.Errorf("cluster operator %s: available=%v, progressing=%v, degraded=%v, undone=%s",
+		actual.Name, available, progressing, degraded, strings.Join(undone, ", "))
+
+	if !available {
+		if availableCondition != nil && len(availableCondition.Message) > 0 {
+			nestedMessage = fmt.Errorf("cluster operator %s is %s=%s: %s: %s", actual.Name, availableCondition.Type, availableCondition.Status, availableCondition.Reason, availableCondition.Message)
+		}
+		return &payload.UpdateError{
+			Nested:       nestedMessage,
+			UpdateEffect: payload.UpdateEffectFail,
+			Reason:       "ClusterOperatorNotAvailable",
+			Message:      fmt.Sprintf("Cluster operator %s is not available", actual.Name),
+			Name:         actual.Name,
+		}
+	}
+
+	// during initialization we allow degraded
+	if degraded && mode != resourcebuilder.InitializingMode {
+		if degradedCondition != nil && len(degradedCondition.Message) > 0 {
+			nestedMessage = fmt.Errorf("cluster operator %s is %s=%s: %s, %s", actual.Name, degradedCondition.Type, degradedCondition.Status, degradedCondition.Reason, degradedCondition.Message)
+		}
+		return &payload.UpdateError{
+			Nested:       nestedMessage,
+			UpdateEffect: payload.UpdateEffectFailAfterInterval,
+			Reason:       "ClusterOperatorDegraded",
+			Message:      fmt.Sprintf("Cluster operator %s is degraded", actual.Name),
+			Name:         actual.Name,
+		}
+	}
+
+	// during initialization we allow undone versions
+	if len(undone) > 0 && mode != resourcebuilder.InitializingMode {
+		nestedMessage = fmt.Errorf("cluster operator %s is available and not degraded but has not finished updating to target version", actual.Name)
+		return &payload.UpdateError{
+			Nested:       nestedMessage,
+			UpdateEffect: payload.UpdateEffectNone,
+			Reason:       "ClusterOperatorUpdating",
+			Message:      fmt.Sprintf("Cluster operator %s is updating versions", actual.Name),
+			Name:         actual.Name,
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +19,8 @@ import (
 	"github.com/openshift/cluster-version-operator/pkg/payload"
 )
 
-func Test_waitForOperatorStatusToBeDone(t *testing.T) {
+func Test_checkOperatorHealth(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		name   string
 		actual *configv1.ClusterOperator
@@ -528,9 +528,7 @@ func Test_waitForOperatorStatusToBeDone(t *testing.T) {
 				return false, nil, fmt.Errorf("unexpected client action: %#v", action)
 			})
 
-			ctxWithTimeout, cancel := context.WithTimeout(context.TODO(), 1*time.Millisecond)
-			defer cancel()
-			err := waitForOperatorStatusToBeDone(ctxWithTimeout, 1*time.Millisecond, clientClusterOperatorsGetter{getter: client.ConfigV1().ClusterOperators()}, test.exp, test.mode)
+			err := checkOperatorHealth(ctx, clientClusterOperatorsGetter{getter: client.ConfigV1().ClusterOperators()}, test.exp, test.mode)
 			if (test.expErr == nil) != (err == nil) {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
Like cc9292a061 (#400), but for ClusterOperator.  In that commit message, I'd explain that we'd continue on past imperfect (e.g. Progressing=True) but still happy-enough Deployments and such and later block on the ClusterOperator.  But there's really no need to poll the ClusterOperator while we're blocked on it; we can instead fail that sync loop, take the short cool-off break, and come in again with a new pass at the sync cycle.

This will help reduce delays like [rhbz#1927168][1] where a good chunk of the ~5.5 minute delay was waiting for the network ClusterOperator to become happy.  If instead we give up on that sync cycle and start in again with a fresh sync cycle, we would have been more likely to recreate the ServiceMonitors CRD more quickly.

The downside is that we will now complain about unavailable, degraded, and unleveled operators more quickly, without giving them time to become happy before complaining in ClusterVersion's status.  This is mitigated by most of the returned errors being UpdateEffectNone, which we will render as "waiting on..." Progressing messages.  The exceptions are mostly unavailable, which is a serious enough condition that I'm fine complaining about it aggressively, and degraded, which has the fail-after-interval guard keeping us from complaining about it too aggressively.

I'm also shifting the "does not declare expected versions" check before the `Get` call.  It's goal is still to ensure that we fail in CI before shipping an operator with such a manifest, and there's no point in firing off an API GET before failing on a guard that only needs local information.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1927168#c2