### PR TITLE
Dockerfile*: Bump to Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \


### PR DESCRIPTION
Catching up with openshift/ocp-build-data@e3b61ff1dde2b.  Generated with:

```console
$ sed -i 's/golang-1.15/golang-1.16/g' $(git grep -l golang-1.15)
```

Replaces #535.

[1]: https://github.com/openshift/ocp-build-data/commit/e3b61ff1dde2bfc2bc7f2b5efdd155d1d3299cd7