### PR TITLE
Bug 1962882: pkg/cvo/updatepayload: Set priorityClassName for the version Job

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -207,6 +207,7 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 					NodeSelector: map[string]string{
 						nodeSelectorKey: "",
 					},
+					PriorityClassName: "openshift-user-critical",
 					Tolerations: []corev1.Toleration{{
 						Key: nodeSelectorKey,
 					}},


### PR DESCRIPTION
Avoid [failing][1]:

    [sig-arch] Managed cluster should ensure platform components have system-* priority class associated [Suite:openshift/conformance/parallel]

by setting the property.  From [our conventions][2], `openshift-user-critical` means it is fine for this workload to be preempted by user-workload and OOMKilled.  If we have such dire resource constraints that the version pod gets evicted, it's probably not a good time to be kicking off an update with all of its associated control-plane churn.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-aws-upgrade-rollback/1395138552144072704
[2]: https://github.com/openshift/enhancements/blob/fe578535d5e6a126a10bb26830b7755266d0f92e/CONVENTIONS.md#priority-classes