### PR TITLE
pkg/payload/task: Disambiguate the ClusterOperatorNotAvailable Progressing message

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -262,6 +262,7 @@ func (optr *Operator) InitializeFromPayload(restConfig *rest.Config, burstRestCo
 			Duration: time.Second * 10,
 			Factor:   1.3,
 			Steps:    3,
+			Cap:      time.Second * 15,
 		},
 		optr.exclude,
 		optr.eventRecorder,

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -2662,9 +2662,6 @@ func TestCVO_ParallelError(t *testing.T) {
 
 	// Step 3: Cancel after we've accumulated 2/3 errors
 	//
-	time.Sleep(100 * time.Millisecond)
-	cancel()
-	//
 	// verify we observe the remaining changes in the first sync
 	for status := range worker.StatusCh() {
 		if status.Failure == nil {
@@ -2707,6 +2704,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		}
 		break
 	}
+	cancel()
 	verifyAllStatus(t, worker.StatusCh())
 
 	client.ClearActions()

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -127,7 +127,7 @@ func checkOperatorHealth(ctx context.Context, client ClusterOperatorsGetter, exp
 	if len(expected.Status.Versions) == 0 {
 		return &payload.UpdateError{
 			UpdateEffect: payload.UpdateEffectFail,
-			Reason:       "ClusterOperatorNotAvailable",
+			Reason:       "ClusterOperatorNoVersions",
 			Message:      fmt.Sprintf("Cluster operator %s does not declare expected versions", expected.Name),
 			Name:         expected.Name,
 		}

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -135,13 +135,7 @@ func checkOperatorHealth(ctx context.Context, client ClusterOperatorsGetter, exp
 
 	actual, err := client.Get(ctx, expected.Name)
 	if err != nil {
-		return &payload.UpdateError{
-			Nested:       err,
-			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      fmt.Sprintf("Cluster operator %s has not yet reported success", expected.Name),
-			Name:         expected.Name,
-		}
+		return err
 	}
 
 	// undone is a sorted slice of transition messages for incomplete operands.

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -42,13 +42,7 @@ func Test_checkOperatorHealth(t *testing.T) {
 				}},
 			},
 		},
-		expErr: &payload.UpdateError{
-			Nested:       apierrors.NewNotFound(schema.GroupResource{Resource: "clusteroperator"}, "test-co"),
-			UpdateEffect: payload.UpdateEffectNone,
-			Reason:       "ClusterOperatorNotAvailable",
-			Message:      "Cluster operator test-co has not yet reported success",
-			Name:         "test-co",
-		},
+		expErr: apierrors.NewNotFound(schema.GroupResource{Resource: "clusteroperator"}, "test-co"),
 	}, {
 		name: "cluster operator reporting available=true and degraded=false, but no versions",
 		actual: &configv1.ClusterOperator{

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -35,6 +35,7 @@ import (
 
 func Test_SyncWorker_apply(t *testing.T) {
 	tests := []struct {
+		name        string
 		manifests   []string
 		reactors    map[action]error
 		cancelAfter int
@@ -42,6 +43,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 		check   func(*testing.T, []action)
 		wantErr bool
 	}{{
+		name: "successful creation",
 		manifests: []string{
 			`{
 				"apiVersion": "test.cvo.io/v1",
@@ -75,6 +77,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 		},
 	}, {
+		name: "unknown resource failures",
 		manifests: []string{
 			`{
 				"apiVersion": "test.cvo.io/v1",
@@ -112,8 +115,8 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 		},
 	}}
-	for idx, test := range tests {
-		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			var manifests []manifest.Manifest
 			for _, s := range test.manifests {
 				m := manifest.Manifest{}

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -678,8 +678,11 @@ func (w *SyncWorker) apply(ctx context.Context, payloadUpdate *payload.Update, w
 
 	var tasks []*payload.Task
 	backoff := w.backoff
+	if backoff.Steps == 0 {
+		return fmt.Errorf("SyncWorker requires at least one backoff step to apply any manifests")
+	}
 	if backoff.Steps > 1 && work.State == payload.InitializingPayload {
-		backoff = wait.Backoff{Steps: 4, Factor: 2, Duration: time.Second}
+		backoff = wait.Backoff{Steps: 4, Factor: 2, Duration: time.Second, Cap: 15 * time.Second}
 	}
 	for i := range payloadUpdate.Manifests {
 		tasks = append(tasks, &payload.Task{

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -95,51 +95,46 @@ func (st *Task) String() string {
 	return fmt.Sprintf("%s \"%s/%s\" (%d of %d)", strings.ToLower(st.Manifest.GVK.Kind), ns, name, st.Index, st.Total)
 }
 
-// Run attempts to create the provided object until it succeeds or context is cancelled. It returns the
-// last error if context is cancelled.
+// Run attempts to create the provided object until it:
+//
+// * Succeeds, or
+// * Fails with an UpdateError, because these are unlikely to improve quickly on retry, or
+// * The context is canceled, in which case it returns the most recent error.
 func (st *Task) Run(ctx context.Context, version string, builder ResourceBuilder, state State) error {
 	var lastErr error
 	backoff := st.Backoff
-	maxDuration := 15 * time.Second // TODO: fold back into Backoff in 1.13
-	for {
-		// attempt the apply, waiting as long as necessary
-		err := builder.Apply(ctx, st.Manifest, state)
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func() (done bool, err error) {
+		err = builder.Apply(ctx, st.Manifest, state)
 		if err == nil {
-			return nil
+			return true, nil
 		}
-
 		lastErr = err
 		utilruntime.HandleError(errors.Wrapf(err, "error running apply for %s", st))
 		metricPayloadErrors.WithLabelValues(version).Inc()
-
-		// TODO: this code will become easier in Kube 1.13 because Backoff now supports max
-		d := time.Duration(float64(backoff.Duration) * backoff.Factor)
-		if d > maxDuration {
-			d = maxDuration
+		if updateErr, ok := err.(*UpdateError); ok {
+			updateErr.Task = st.Copy()
+			return false, updateErr // failing fast for UpdateError
 		}
-		d = wait.Jitter(d, backoff.Jitter)
-
-		// sleep or wait for cancellation
-		select {
-		case <-time.After(d):
-			continue
-		case <-ctx.Done():
-			if uerr, ok := lastErr.(*UpdateError); ok {
-				uerr.Task = st.Copy()
-				return uerr
-			}
-			reason, cause := reasonForPayloadSyncError(lastErr)
-			if len(cause) > 0 {
-				cause = ": " + cause
-			}
-			return &UpdateError{
-				Nested:  lastErr,
-				Reason:  reason,
-				Message: fmt.Sprintf("Could not update %s%s", st, cause),
-
-				Task: st.Copy(),
-			}
-		}
+		return false, nil
+	})
+	if err == nil {
+		return nil
+	}
+	if lastErr != nil {
+		err = lastErr
+	}
+	if _, ok := err.(*UpdateError); ok {
+		return err
+	}
+	reason, cause := reasonForPayloadSyncError(err)
+	if len(cause) > 0 {
+		cause = ": " + cause
+	}
+	return &UpdateError{
+		Nested:  err,
+		Reason:  reason,
+		Message: fmt.Sprintf("Could not update %s%s", st, cause),
+		Task:    st.Copy(),
 	}
 }
 
@@ -177,7 +172,7 @@ func (e *UpdateError) Cause() error {
 	return e.Nested
 }
 
-// reasonForUpdateError provides a succint explanation of a known error type for use in a human readable
+// reasonForPayloadSyncError provides a succint explanation of a known error type for use in a human readable
 // message during update. Since all objects in the image should be successfully applied, messages
 // should direct the reader (likely a cluster administrator) to a possible cause in their own config.
 func reasonForPayloadSyncError(err error) (string, string) {

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -244,11 +244,16 @@ func SummaryForReason(reason, name string) string {
 		return "a cluster operator is degraded"
 	case "ClusterOperatorNotAvailable":
 		if len(name) > 0 {
-			return fmt.Sprintf("the cluster operator %s has not yet successfully rolled out", name)
+			return fmt.Sprintf("the cluster operator %s is not available", name)
 		}
-		return "a cluster operator has not yet rolled out"
+		return "a cluster operator is not available"
 	case "ClusterOperatorsNotAvailable":
-		return "some cluster operators have not yet rolled out"
+		return "some cluster operators are not available"
+	case "ClusterOperatorNoVersions":
+		if len(name) > 0 {
+			return fmt.Sprintf("the cluster operator %s does not declare expected versions", name)
+		}
+		return "a cluster operator does not declare expected versions"
 	case "WorkloadNotAvailable":
 		if len(name) > 0 {
 			return fmt.Sprintf("the workload %s has not yet successfully rolled out", name)


### PR DESCRIPTION
For example, in a recent test cluster:

```console
$ oc get -o json clusterversion version | jq -r '.status.conditions[] | .lastTransitionTime + " " + .type + "=" + .status + " " + (.reason // "-") + ": " + (.message // "-")'
2021-05-26T20:18:35Z Available=True -: Done applying 4.8.0-0.ci-2021-05-26-172803
2021-05-26T21:58:16Z Failing=True ClusterOperatorNotAvailable: Cluster operator machine-config is not available
2021-05-26T21:42:31Z Progressing=False ClusterOperatorNotAvailable: Error while reconciling 4.8.0-0.ci-2021-05-26-172803: the cluster operator machine-config has not yet successfully rolled out
2021-05-26T19:53:47Z RetrievedUpdates=False NoChannel: The update channel has not been configured.
2021-05-26T21:26:31Z Upgradeable=False DegradedPool: Cluster operator machine-config cannot be upgraded between minor versions: One or more machine config pools are degraded, please see `oc get mcp` for further details and resolve before upgrading
```

But the "has not yet successfully rolled out" we used for `Progressing` is much less direct than "is not available" we used for `Failing`.  6c7cd992c6 (#573) removed the last important abuse of `ClusterOperatorNotAvailable` (for failures to `client.Get` the target ClusterOperator).  In this commit I'm moving the remaining abuser over to a new `ClusterOperatorNoVersions`.  So the only remaining `ClusterOperatorNotAvailable` really means "not `Available=True`", and we can say that more directly.