### PR TITLE
pkg/payload/task: Handle MultipleErrors in SummaryForReason

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -264,6 +264,11 @@ func SummaryForReason(reason, name string) string {
 			return fmt.Sprintf("the workload %s cannot roll out", name)
 		}
 		return "a workload cannot roll out"
+	case "MultipleErrors":
+		if len(name) > 0 {
+			return fmt.Sprintf("the workload %s cannot roll out", name)
+		}
+		return "multiple errors reconciling the payload"
 	}
 
 	if strings.HasPrefix(reason, "UpdatePayload") {


### PR DESCRIPTION
The `MultipleErrors` reason landed in c2ac20fa17 (#158), but for some reason was left out of `SummaryForReason`.  I'm adding it in this commit to get something more useful than:

```console
$ oc adm upgrade
info: An upgrade is in progress. Unable to apply 4.8.0-0.ci-2021-05-26-172803: an unknown error has occurred: MultipleErrors
```

when the `Failing=True` message is:

```
Multiple errors are preventing progress:
* Cluster operator machine-api is updating versions
* Cluster operator openshift-apiserver is updating versions
```

I'm not entirely clear on why these didn't fallback to the `unknown error` strings at the bottom of `SummaryForReason`, but they don't seem to have done so.