### PR TITLE
Bug 1941901: lib/resourcemerge/core: Fix toleration matching logic

### DIFF
--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -1020,3 +1020,181 @@ func TestEnsureServiceType(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureTolerations(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []corev1.Toleration
+		input    []corev1.Toleration
+
+		expectedModified bool
+		expected         []corev1.Toleration
+	}{
+		{
+			name:             "required not set, empty existing",
+			expectedModified: false,
+		},
+		{
+			name: "required not set, existing has content",
+			existing: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			expectedModified: false,
+			expected: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		{
+			name: "required matches existing",
+			existing: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			input: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			expectedModified: false,
+			expected: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		{
+			name: "required matches existing except for order",
+			existing: []corev1.Toleration{{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			input: []corev1.Toleration{{
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			expectedModified: false,
+			expected: []corev1.Toleration{{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+		{
+			name: "required does not match existing",
+			existing: []corev1.Toleration{{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/network-unavailable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}, {
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}, {
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}},
+			input: []corev1.Toleration{{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/network-unavailable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/not-ready",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}, {
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}},
+			expectedModified: true,
+			expected: []corev1.Toleration{{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/unschedulable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:      "node.kubernetes.io/network-unavailable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}, {
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}, {
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: pointer.Int64Ptr(120),
+			}, {
+				Key:      "node.kubernetes.io/not-ready",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modified := pointer.BoolPtr(false)
+			ensureTolerations(modified, &test.existing, test.input)
+			if *modified != test.expectedModified {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
+			}
+			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
+				t.Errorf("unexpected: %s", diff.ObjectReflectDiff(test.expected, test.existing))
+			}
+		})
+	}
+}


### PR DESCRIPTION
As described in [rhbz#1941901][1], the old logic matching on key could lead to later required entries clobbering earlier ones if the keys matched.  Personally, I'd rather just force an exact match here, but that's blocked on gathering sufficient data from the wild to know we wouldn't be clobbering some important admin-added toleration ([rhbz#1942271][2]).  This commit pivots us to at least requiring all manifest tolerations being present in-cluster, althought it does not remove additional admin-added tolerations.  The most important benefit is that previously-key-match-clobbered manifest tolerations will be restored.  A secondary benefit is that it will reduce one source of potential hotloop behavior ([rhbz#1881484][3], #559).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1941901#c0
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1942271
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1881484