### PR TITLE
Bug 1969501: install/0000_90_cluster-version-operator_02_servicemonitor: Soften ClusterOperatorDegraded

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -80,12 +80,12 @@ spec:
         severity: critical
     - alert: ClusterOperatorDegraded
       annotations:
-        message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 10 minutes. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
+        message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 30 minutes. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
       expr: |
         cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"} == 1
-      for: 10m
+      for: 30m
       labels:
-        severity: critical
+        severity: warning
     - alert: ClusterOperatorFlapping
       annotations:
         message: Cluster operator {{ "{{ $labels.name }}" }} up status is changing often. This might cause upgrades to be unstable.


### PR DESCRIPTION
This pull request brings back fb5257d4be (#554) and 92ed7f110c (#556).  There are some conflicts, because I am not bringing back 90539f9a17 (#550).  But that one [had its own conflicts in `metrics.go`][5], and the conflicts with this commit were orthogonal context issues, so moving this back to 4.7 first won't make it much harder to bring back #550 and such later on, if we decide to do that.

[5]: https://github.com/openshift/cluster-version-operator/pull/550#issuecomment-856815344