### PR TITLE
Fixing the log message in rbac.go for clusterrole

### DIFF
--- a/lib/resourceapply/rbac.go
+++ b/lib/resourceapply/rbac.go
@@ -61,7 +61,7 @@ func ApplyClusterRolev1(ctx context.Context, client rbacclientv1.ClusterRolesGet
 	if !*modified {
 		return existing, false, nil
 	}
-	klog.V(2).Infof("Updating ClusterRole %s/%s due to diff: %v", required.Name, diff.ObjectDiff(existing, required))
+	klog.V(2).Infof("Updating ClusterRole %s due to diff: %v", required.Name, diff.ObjectDiff(existing, required))
 
 	actual, err := client.ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{})
 	return actual, true, err


### PR DESCRIPTION
Updating format (%s/%s) to %s as there is only 1 string need to be formatted.