### PR TITLE
Correctly initialize service host and port when environment is missing

### DIFF
--- a/lib/resourcebuilder/podspec.go
+++ b/lib/resourcebuilder/podspec.go
@@ -70,7 +70,7 @@ func updatePodSpecWithInternalLoadBalancerKubeService(podSpec *corev1.PodSpec, c
 			}
 			found = true
 
-			podSpec.InitContainers[i].Env = setKubeServiceValue(podSpec.Containers[i].Env, internalLoadBalancerHost, internalLoadBalancerPort)
+			podSpec.InitContainers[i].Env = setKubeServiceValue(podSpec.InitContainers[i].Env, internalLoadBalancerHost, internalLoadBalancerPort)
 		}
 
 		if !found {

--- a/lib/resourcebuilder/podspec_test.go
+++ b/lib/resourcebuilder/podspec_test.go
@@ -125,6 +125,11 @@ func TestUpdatePodSpecWithInternalLoadBalancerKubeService(t *testing.T) {
 		{
 			name: "no lbhost val",
 			input: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init-foo",
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name: "foo",
@@ -135,6 +140,11 @@ func TestUpdatePodSpecWithInternalLoadBalancerKubeService(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name: "foo",
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name: "init-foo",
 					},
 				},
 			},
@@ -148,10 +158,6 @@ func TestUpdatePodSpecWithInternalLoadBalancerKubeService(t *testing.T) {
 				InitContainers: []corev1.Container{
 					{
 						Name: "init-foo",
-						Env: []corev1.EnvVar{
-							{Name: "KUBERNETES_SERVICE_PORT", Value: "oldport-val"},
-							{Name: "KUBERNETES_SERVICE_HOST", Value: "oldhost-val"},
-						},
 					},
 					{
 						Name: "init-bar",
@@ -201,10 +207,7 @@ func TestUpdatePodSpecWithInternalLoadBalancerKubeService(t *testing.T) {
 				InitContainers: []corev1.Container{
 					{
 						Name: "init-foo",
-						Env: []corev1.EnvVar{
-							{Name: "KUBERNETES_SERVICE_PORT", Value: "oldport-val"},
-							{Name: "KUBERNETES_SERVICE_HOST", Value: "oldhost-val"},
-						}},
+					},
 					{
 						Name: "init-bar",
 					},


### PR DESCRIPTION
The init containers where not be correctly initialized with the service host and port. Also fixed tests.