### PR TITLE
Removed redudant check for dereference

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -424,11 +424,8 @@ func (w *SyncWorker) calculateNext(work *SyncWork) bool {
 		work.Attempt = 0
 	}
 
-	if w.work != nil {
-		work.Desired = w.work.Desired
-		work.Overrides = w.work.Overrides
-	}
-
+	work.Desired = w.work.Desired
+	work.Overrides = w.work.Overrides
 	work.Generation = w.work.Generation
 
 	return changed


### PR DESCRIPTION
`w.work` has already been dereferenced previously and this not nil check is redundant.