### PR TITLE
[WIP] Added golangci-lint for linting and fixed detected linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,80 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+    - vendor
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  modules-download-mode: vendor
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: tab
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+  fast: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - gofmt
     - gosimple
     - govet
     - ineffassign

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GOLANGCI_LINT_BIN=./bin/golangci-lint
+GOLANGCI_LINT_VERSION=v1.40.1
+
 all: build
 .PHONY: all
 
@@ -21,3 +24,12 @@ verify-codegen-crds:
 verify-codegen: verify-codegen-crds
 verify: verify-codegen
 .PHONY: update-codegen-crds update-codegen verify-codegen-crds verify-codegen verify
+
+
+.PHONY: lint
+## Checks the code with golangci-lint
+lint: $(GOLANGCI_LINT_BIN)
+	./bin/golangci-lint ${V_FLAG} run --deadline=30m
+
+$(GOLANGCI_LINT_BIN):
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin ${GOLANGCI_LINT_VERSION}

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -31,5 +31,5 @@ func runImageCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		klog.Fatalf("error: %v", err)
 	}
-	fmt.Printf(image)
+	fmt.Print(image)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ var (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
-	flag.CommandLine.Set("alsologtostderr", "true")
+	_ = flag.CommandLine.Set("alsologtostderr", "true")
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 }
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func runRenderCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	if renderOpts.outputDir == "" {

--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -508,16 +508,6 @@ func ensureCapabilities(modified *bool, existing *corev1.Capabilities, required 
 	}
 }
 
-func setStringSliceIfSet(modified *bool, existing *[]string, required []string) {
-	if required == nil {
-		return
-	}
-	if !equality.Semantic.DeepEqual(required, *existing) {
-		*existing = required
-		*modified = true
-	}
-}
-
 func setStringSlice(modified *bool, existing *[]string, required []string) {
 	if !reflect.DeepEqual(required, *existing) {
 		*existing = required

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -33,24 +33,24 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "remove regular containers from existing",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"},
-					corev1.Container{Name: "to-be-removed"}}},
+					{Name: "test"},
+					{Name: "to-be-removed"}}},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 		},
 		{
 			name: "remove regular and init containers from existing",
 			existing: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init"}},
+					{Name: "test-init"}},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 			input: corev1.PodSpec{},
 
 			expectedModified: true,
@@ -60,7 +60,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "remove init containers from existing",
 			existing: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init"}}},
+					{Name: "test-init"}}},
 			input: corev1.PodSpec{},
 
 			expectedModified: true,
@@ -70,29 +70,29 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "append regular and init containers",
 			existing: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init-a"}},
+					{Name: "test-init-a"}},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-a"}}},
+					{Name: "test-a"}}},
 			input: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init-a"},
-					corev1.Container{Name: "test-init-b"},
+					{Name: "test-init-a"},
+					{Name: "test-init-b"},
 				},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-a"},
-					corev1.Container{Name: "test-b"},
+					{Name: "test-a"},
+					{Name: "test-b"},
 				},
 			},
 
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init-a"},
-					corev1.Container{Name: "test-init-b"},
+					{Name: "test-init-a"},
+					{Name: "test-init-b"},
 				},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-a"},
-					corev1.Container{Name: "test-b"},
+					{Name: "test-a"},
+					{Name: "test-b"},
 				},
 			},
 		},
@@ -100,27 +100,27 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "match regular and init containers",
 			existing: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init"}},
+					{Name: "test-init"}},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 			input: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init"}},
+					{Name: "test-init"}},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 
 			expectedModified: false,
 			expected: corev1.PodSpec{
 				InitContainers: []corev1.Container{
-					corev1.Container{Name: "test-init"}},
+					{Name: "test-init"}},
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 		},
 		{
 			name: "remove limits and requests on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -131,12 +131,12 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"}}},
+					{Name: "test"}}},
 
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"},
+					{Name: "test"},
 				},
 			},
 		},
@@ -144,7 +144,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "modify limits and requests on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -155,7 +155,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4m")},
@@ -168,7 +168,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4m")},
@@ -182,7 +182,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "match limits and requests on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -193,7 +193,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -206,7 +206,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: false,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -220,12 +220,12 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "add limits and requests on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"},
+					{Name: "test"},
 				},
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -238,7 +238,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Resources: corev1.ResourceRequirements{
 							Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2m")},
@@ -252,20 +252,20 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "remove a container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-A"},
-					corev1.Container{Name: "test-B"},
+					{Name: "test-A"},
+					{Name: "test-B"},
 				},
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-B"},
+					{Name: "test-B"},
 				},
 			},
 
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test-B"},
+					{Name: "test-B"},
 				},
 			},
 		},
@@ -273,15 +273,15 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "add ports on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"},
+					{Name: "test"},
 				},
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 8080},
+							{ContainerPort: 8080},
 						},
 					},
 				},
@@ -289,10 +289,10 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 8080},
+							{ContainerPort: 8080},
 						},
 					},
 				},
@@ -302,20 +302,20 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "replace ports on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 8080},
+							{ContainerPort: 8080},
 						},
 					},
 				},
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 9191},
+							{ContainerPort: 9191},
 						},
 					},
 				},
@@ -323,10 +323,10 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 9191},
+							{ContainerPort: 9191},
 						},
 					},
 				},
@@ -336,23 +336,23 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "remove container ports",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name: "test",
 						Ports: []corev1.ContainerPort{
-							corev1.ContainerPort{ContainerPort: 8080},
+							{ContainerPort: 8080},
 						},
 					},
 				},
 			},
 			input: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{Name: "test"},
+					{Name: "test"},
 				},
 			},
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name:  "test",
 						Ports: []corev1.ContainerPort{},
 					},

--- a/lib/validation/validation.go
+++ b/lib/validation/validation.go
@@ -69,20 +69,6 @@ func countPayloadsForVersion(config *configv1.ClusterVersion, version string) in
 	return 0
 }
 
-func hasAmbiguousPayloadForVersion(config *configv1.ClusterVersion, version string) bool {
-	for _, update := range config.Status.AvailableUpdates {
-		if update.Version == version {
-			return len(update.Image) > 0
-		}
-	}
-	for _, history := range config.Status.History {
-		if history.Version == version {
-			return len(history.Image) > 0
-		}
-	}
-	return false
-}
-
 func ClearInvalidFields(config *configv1.ClusterVersion, errs field.ErrorList) *configv1.ClusterVersion {
 	if len(errs) == 0 {
 		return config

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -40,7 +40,6 @@ type Controller struct {
 	eventRecorder record.EventRecorder
 
 	syncHandler       func(ctx context.Context, key string) error
-	statusSyncHandler func(key string) error
 
 	cvLister    configlistersv1.ClusterVersionLister
 	coLister    configlistersv1.ClusterOperatorLister

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -39,7 +39,7 @@ type Controller struct {
 	client        clientset.Interface
 	eventRecorder record.EventRecorder
 
-	syncHandler       func(ctx context.Context, key string) error
+	syncHandler func(ctx context.Context, key string) error
 
 	cvLister    configlistersv1.ClusterVersionLister
 	coLister    configlistersv1.ClusterOperatorLister

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -103,8 +103,6 @@ type Operator struct {
 	payloadDir string
 	// defaultUpstreamServer is intended for testing.
 	defaultUpstreamServer string
-	// syncBackoff allows the tests to use a quicker backoff
-	syncBackoff wait.Backoff
 
 	cvLister              configlistersv1.ClusterVersionLister
 	coLister              configlistersv1.ClusterOperatorLister

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1744,8 +1744,8 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	}
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Step:       "PreconditionChecks",
-			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:   "PreconditionChecks",
+			Actual: configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
 		},
 		SyncWorkerStatus{
 			Total:       3,

--- a/pkg/cvo/egress.go
+++ b/pkg/cvo/egress.go
@@ -21,14 +21,12 @@ func (optr *Operator) getHTTPSProxyURL() (*url.URL, error) {
 		return nil, err
 	}
 
-	if &proxy.Spec != nil {
-		if proxy.Spec.HTTPSProxy != "" {
-			proxyURL, err := url.Parse(proxy.Spec.HTTPSProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURL, nil
+	if proxy.Spec.HTTPSProxy != "" {
+		proxyURL, err := url.Parse(proxy.Spec.HTTPSProxy)
+		if err != nil {
+			return nil, err
 		}
+		return proxyURL, nil
 	}
 	return nil, nil
 }

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/openshift/cluster-version-operator/lib/resourceapply"
@@ -10,10 +9,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 
@@ -119,16 +116,4 @@ func (b *genericBuilder) Do(ctx context.Context) error {
 
 	_, _, err := applyUnstructured(ctx, b.client, ud)
 	return err
-}
-
-func createPatch(original, modified runtime.Object) ([]byte, error) {
-	originalData, err := json.Marshal(original)
-	if err != nil {
-		return nil, err
-	}
-	modifiedData, err := json.Marshal(modified)
-	if err != nil {
-		return nil, err
-	}
-	return strategicpatch.CreateTwoWayMergePatch(originalData, modifiedData, original)
 }

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"unicode"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -231,11 +230,4 @@ func checkOperatorHealth(ctx context.Context, client ClusterOperatorsGetter, exp
 	}
 
 	return nil
-}
-
-func lowerFirst(str string) string {
-	for i, v := range str {
-		return string(unicode.ToLower(v)) + str[i+1:]
-	}
-	return ""
 }

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -43,7 +43,7 @@ func Test_checkOperatorHealth(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       apierrors.NewNotFound(schema.GroupResource{"", "clusteroperator"}, "test-co"),
+			Nested:       apierrors.NewNotFound(schema.GroupResource{Resource: "clusteroperator"}, "test-co"),
 			UpdateEffect: payload.UpdateEffectNone,
 			Reason:       "ClusterOperatorNotAvailable",
 			Message:      "Cluster operator test-co has not yet reported success",

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func Test_mergeEqualVersions(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name    string
 		current *configv1.UpdateHistory
@@ -144,11 +142,9 @@ func Test_pruneStatusHistory(t *testing.T) {
 
 func TestOperator_syncFailingStatus(t *testing.T) {
 	ctx := context.Background()
-	type args struct {
-	}
 	tests := []struct {
 		name        string
-		optr        Operator
+		optr        *Operator
 		init        func(optr *Operator)
 		wantErr     func(*testing.T, error)
 		wantActions func(*testing.T, *Operator)
@@ -159,7 +155,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 	}{
 		{
 			ierr: fmt.Errorf("bad"),
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -238,7 +234,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			optr := &tt.optr
+			optr := tt.optr
 			if tt.init != nil {
 				tt.init(optr)
 			}

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -67,10 +67,10 @@ func Test_SyncWorker_apply(t *testing.T) {
 				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
-			if got, exp := actions[1], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[1], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
@@ -94,7 +94,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
 		cancelAfter: 2,
 		wantErr:     true,
@@ -104,7 +104,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
@@ -129,8 +129,8 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 			r := &recorder{}
 			testMapper := resourcebuilder.NewResourceMapper()
-			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, newTestBuilder(r, test.reactors))
-			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, newTestBuilder(r, test.reactors))
+			testMapper.RegisterGVK(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, newTestBuilder(r, test.reactors))
+			testMapper.RegisterGVK(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, newTestBuilder(r, test.reactors))
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
 			worker := &SyncWorker{eventRecorder: record.NewFakeRecorder(100)}
@@ -144,7 +144,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 				remainingErrors: test.cancelAfter,
 			}
 
-			worker.apply(ctx, up, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			_ = worker.apply(ctx, up, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
 			test.check(t, r.actions)
 		})
 	}
@@ -408,16 +408,6 @@ func (r *fakeSyncRecorder) Start(ctx context.Context, maxWorkers int, cvoOptrNam
 func (r *fakeSyncRecorder) Update(generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State) *SyncWorkerStatus {
 	r.Updates = append(r.Updates, desired)
 	return r.Returns
-}
-
-type fakeResourceBuilder struct {
-	M   []*manifest.Manifest
-	Err error
-}
-
-func (b *fakeResourceBuilder) Apply(m *manifest.Manifest) error {
-	b.M = append(b.M, m)
-	return b.Err
 }
 
 type fakeDirectoryRetriever struct {

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -23,7 +22,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
 	"github.com/openshift/cluster-version-operator/pkg/payload"
 	"github.com/openshift/cluster-version-operator/pkg/payload/precondition"
 	"github.com/openshift/library-go/pkg/manifest"
@@ -1000,10 +998,6 @@ func newClusterOperatorsNotAvailable(errs []error) error {
 		return nil
 	}
 
-	nested := make([]error, 0, len(errs))
-	for _, err := range errs {
-		nested = append(nested, err)
-	}
 	sort.Strings(names)
 	name := strings.Join(names, ", ")
 	return &payload.UpdateError{
@@ -1071,16 +1065,6 @@ func getOverrideForManifest(overrides []configv1.ComponentOverride, manifest *ma
 		}
 	}
 	return configv1.ComponentOverride{}, false
-}
-
-// ownerKind contains the schema.GroupVersionKind for type that owns objects managed by CVO.
-var ownerKind = configv1.SchemeGroupVersion.WithKind("ClusterVersion")
-
-func ownerRefModifier(config *configv1.ClusterVersion) resourcebuilder.MetaV1ObjectModifierFunc {
-	oref := metav1.NewControllerRef(config, ownerKind)
-	return func(obj metav1.Object) {
-		obj.SetOwnerReferences([]metav1.OwnerReference{*oref})
-	}
 }
 
 // runThrottledStatusNotifier invokes fn every time ch is updated, but no more often than once

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -85,25 +85,21 @@ func Test_statusWrapper_ReportProgress(t *testing.T) {
 			w.Report(tt.next)
 			close(w.w.report)
 			if tt.want {
-				select {
-				case evt, ok := <-w.w.report:
-					if !ok {
-						t.Fatalf("no event")
-					}
-					if tt.wantProgress != (!evt.LastProgress.IsZero()) {
-						t.Errorf("unexpected progress timestamp: %#v", evt)
-					}
-					evt.LastProgress = time.Time{}
-					if !reflect.DeepEqual(evt, tt.next) {
-						t.Fatalf("unexpected: %#v", evt)
-					}
+				evt, ok := <-w.w.report
+				if !ok {
+					t.Fatalf("no event")
+				}
+				if tt.wantProgress != (!evt.LastProgress.IsZero()) {
+					t.Errorf("unexpected progress timestamp: %#v", evt)
+				}
+				evt.LastProgress = time.Time{}
+				if !reflect.DeepEqual(evt, tt.next) {
+					t.Fatalf("unexpected: %#v", evt)
 				}
 			} else {
-				select {
-				case evt, ok := <-w.w.report:
-					if ok {
-						t.Fatalf("unexpected event: %#v", evt)
-					}
+				evt, ok := <-w.w.report
+				if ok {
+					t.Fatalf("unexpected event: %#v", evt)
 				}
 			}
 		})
@@ -138,11 +134,9 @@ func Test_statusWrapper_ReportGeneration(t *testing.T) {
 			w.Report(tt.next)
 			close(w.w.report)
 
-			select {
-			case evt := <-w.w.report:
-				if tt.want != evt.Generation {
-					t.Fatalf("mismatch: expected generation: %d, got generation: %d", tt.want, evt.Generation)
-				}
+			evt := <-w.w.report
+			if tt.want != evt.Generation {
+				t.Fatalf("mismatch: expected generation: %d, got generation: %d", tt.want, evt.Generation)
 			}
 		})
 	}

--- a/pkg/payload/precondition/clusterversion/upgradable_test.go
+++ b/pkg/payload/precondition/clusterversion/upgradable_test.go
@@ -125,7 +125,7 @@ func TestUpgradeableRun(t *testing.T) {
 					Message: fmt.Sprintf("set to %v", *tc.upgradeable),
 				})
 			}
-			cvLister := fakeClusterVersionLister(clusterVersion)
+			cvLister := fakeClusterVersionLister(t, clusterVersion)
 			instance := NewUpgradeable(cvLister)
 
 			err := instance.Run(context.TODO(), precondition.ReleaseContext{DesiredVersion: tc.desiredVersion}, clusterVersion)
@@ -144,12 +144,15 @@ func TestUpgradeableRun(t *testing.T) {
 	}
 }
 
-func fakeClusterVersionLister(clusterVersion *configv1.ClusterVersion) configv1listers.ClusterVersionLister {
+func fakeClusterVersionLister(t *testing.T, clusterVersion *configv1.ClusterVersion) configv1listers.ClusterVersionLister {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	if clusterVersion == nil {
 		return configv1listers.NewClusterVersionLister(indexer)
 	}
 
-	indexer.Add(clusterVersion)
+	err := indexer.Add(clusterVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return configv1listers.NewClusterVersionLister(indexer)
 }

--- a/pkg/payload/precondition/precondition_test.go
+++ b/pkg/payload/precondition/precondition_test.go
@@ -20,7 +20,7 @@ func TestSummarize(t *testing.T) {
 		input: []error{&Error{
 			Nested:  nil,
 			Reason:  "NotAllowedFeatureGateSet",
-			Message: fmt.Sprintf("Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform."),
+			Message: "Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform.",
 			Name:    "FeatureGate",
 		}},
 		exp: `Precondition "FeatureGate" failed because of "NotAllowedFeatureGateSet": Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform.`,
@@ -33,12 +33,12 @@ func TestSummarize(t *testing.T) {
 		input: []error{&Error{
 			Nested:  nil,
 			Reason:  "NotAllowedFeatureGateSet",
-			Message: fmt.Sprintf("Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform."),
+			Message: "Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform.",
 			Name:    "FeatureGate",
 		}, &Error{
 			Nested:  nil,
 			Reason:  "NotAllowedFeatureGateSet",
-			Message: fmt.Sprintf("Feature Gate random-2 is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform."),
+			Message: "Feature Gate random-2 is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform.",
 			Name:    "FeatureGate",
 		}},
 		exp: `Multiple precondition checks failed:
@@ -50,7 +50,7 @@ func TestSummarize(t *testing.T) {
 			&Error{
 				Nested:  nil,
 				Reason:  "NotAllowedFeatureGateSet",
-				Message: fmt.Sprintf("Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform."),
+				Message: "Feature Gate random is set for the cluster. This Feature Gate turns on features that are not part of the normal supported platform.",
 				Name:    "FeatureGate",
 			}},
 		exp: `Multiple precondition checks failed:

--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -386,15 +386,6 @@ func (g *TaskGraph) Tree() string {
 	return strings.Join(out, "\n")
 }
 
-func covers(all []int, some []int) bool {
-	for _, i := range some {
-		if all[i] == 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func (g *TaskGraph) bulkAdd(nodes []*TaskNode, inNodes []int) []int {
 	from := len(g.Nodes)
 	g.Nodes = append(g.Nodes, nodes...)

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -41,8 +41,8 @@ import (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
-	flag.CommandLine.Lookup("v").Value.Set("5")
-	flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
+	_ = flag.CommandLine.Lookup("v").Value.Set("5")
+	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
 }
 
 var (
@@ -685,7 +685,7 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 
 	id, _ := uuid.NewRandom()
 
-	client.ConfigV1().ClusterVersions().Create(
+	_, err = client.ConfigV1().ClusterVersions().Create(
 		ctx,
 		&configv1.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -699,6 +699,9 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 		},
 		metav1.CreateOptions{},
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	dir, err := ioutil.TempDir("", "cvo-test")
 	if err != nil {


### PR DESCRIPTION
Added [golangci-lint](https://golangci-lint.run/) as a make target which can be run as a check.
Also fixed issues which were reported by golangci-lint.

Discovered an issue with `cvo_scenarios_test.go` where the `ClusterVersion` resource was never actually updated in the fake client but always recreated. Fixed this which led to some knock on changes in the tests.

