### PR TITLE
Fixed fake client for CVO scenarios test

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1113,7 +1113,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	verifySingleUpdate(t, actions)
+	verifyCVSingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
@@ -1366,7 +1366,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	verifySingleUpdate(t, actions)
+	verifyCVSingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
@@ -1667,7 +1667,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	verifySingleUpdate(t, actions)
+	verifyCVSingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
@@ -1929,7 +1929,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	verifySingleUpdate(t, actions)
+	verifyCVSingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
@@ -2861,9 +2861,13 @@ func TestCVO_VerifyUpdatingPayloadState(t *testing.T) {
 	}
 }
 
-func verifySingleUpdate(t *testing.T, actions []clientgotesting.Action) {
+// verifyCVSingleUpdate ensures that the only object to be updated is a ClusterVersion type and it is updated only once
+func verifyCVSingleUpdate(t *testing.T, actions []clientgotesting.Action) {
 	var count int
 	for _, a := range actions {
+		if a.GetResource().Resource != "clusterversions" {
+			t.Fatalf("an resource of type %s was accessed/updated", a.GetResource().Resource)
+		}
 		if a.GetVerb() != "get" {
 			count++
 		}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,19 +38,22 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 	})
 	cvs := make(map[string]runtime.Object)
 	client.AddReactor("*", "clusterversions", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		switch a := action.(type) {
-		case clientgotesting.GetAction:
+		switch strings.ToLower(action.GetVerb()) {
+		case "get":
+			a := action.(clientgotesting.GetAction)
 			obj, ok := cvs[a.GetName()]
 			if !ok {
 				return true, nil, errors.NewNotFound(schema.GroupResource{Resource: "clusterversions"}, a.GetName())
 			}
 			return true, obj.DeepCopyObject(), nil
-		case clientgotesting.CreateAction:
+		case "create":
+			a := action.(clientgotesting.CreateAction)
 			obj := a.GetObject().DeepCopyObject().(*configv1.ClusterVersion)
 			obj.Generation = 1
 			cvs[obj.Name] = obj
 			return true, obj, nil
-		case clientgotesting.UpdateAction:
+		case "update":
+			a := action.(clientgotesting.UpdateAction)
 			obj := a.GetObject().DeepCopyObject().(*configv1.ClusterVersion)
 			existing := cvs[obj.Name].DeepCopyObject().(*configv1.ClusterVersion)
 			rv, _ := strconv.Atoi(existing.ResourceVersion)
@@ -59,7 +63,11 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 			} else {
 				existing.Spec = obj.Spec
 				existing.ObjectMeta = obj.ObjectMeta
-				obj.Generation++
+				if existing.Generation > obj.Generation {
+					existing.Generation = existing.Generation + 1
+				} else {
+					existing.Generation = obj.Generation + 1
+				}
 			}
 			existing.ResourceVersion = nextRV
 			cvs[existing.Name] = existing
@@ -195,8 +203,9 @@ func TestCVO_StartupAndSync(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "1",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -300,8 +309,9 @@ func TestCVO_StartupAndSync(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "2",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -415,7 +425,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 	// make the image report unverified
 	payloadErr := &payload.UpdateError{
 		Reason:  "ImageVerificationFailed",
-		Message: fmt.Sprintf("The update cannot be verified: some random error"),
+		Message: "The update cannot be verified: some random error",
 		Nested:  fmt.Errorf("some random error"),
 	}
 	if !isImageVerificationError(payloadErr) {
@@ -515,8 +525,9 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "1",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -620,8 +631,9 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "2",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -825,8 +837,9 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "1",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -930,8 +943,9 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 	actual = cvs["version"].(*configv1.ClusterVersion)
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "version",
-			Generation: 1,
+			Name:            "version",
+			Generation:      1,
+			ResourceVersion: "2",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: actual.Spec.ClusterID,
@@ -1048,6 +1062,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
 			ResourceVersion: "1",
+			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
@@ -1078,7 +1093,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 	// make the image report unverified
 	payloadErr := &payload.UpdateError{
 		Reason:  "ImageVerificationFailed",
-		Message: fmt.Sprintf("The update cannot be verified: some random error"),
+		Message: "The update cannot be verified: some random error",
 		Nested:  fmt.Errorf("some random error"),
 	}
 	if !isImageVerificationError(payloadErr) {
@@ -1098,19 +1113,19 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 2 {
-		t.Fatalf("%s", spew.Sdump(actions))
-	}
+	verifySingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Step:   "RetrievePayload",
-			Actual: configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "RetrievePayload",
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 		SyncWorkerStatus{
-			Step:    "RetrievePayload",
-			Failure: payloadErr,
-			Actual:  configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "RetrievePayload",
+			Failure:    payloadErr,
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 	)
 
@@ -1128,7 +1143,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "2",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1138,8 +1153,9 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
-			Desired:     desired,
-			VersionHash: "DL-FFQ2Uem8=",
+			ObservedGeneration: 1,
+			Desired:            desired,
+			VersionHash:        "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1255,7 +1271,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "3",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1299,6 +1315,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
 			ResourceVersion: "1",
+			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
@@ -1329,7 +1346,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 	// make the image report unverified
 	payloadErr := &payload.UpdateError{
 		Reason:  "ImageVerificationFailed",
-		Message: fmt.Sprintf("The update cannot be verified: some random error"),
+		Message: "The update cannot be verified: some random error",
 		Nested:  fmt.Errorf("some random error"),
 	}
 	if !isImageVerificationError(payloadErr) {
@@ -1349,19 +1366,19 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 2 {
-		t.Fatalf("%s", spew.Sdump(actions))
-	}
+	verifySingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Step:   "RetrievePayload",
-			Actual: configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "RetrievePayload",
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 		SyncWorkerStatus{
-			Step:    "RetrievePayload",
-			Failure: payloadErr,
-			Actual:  configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "RetrievePayload",
+			Failure:    payloadErr,
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 	)
 
@@ -1379,7 +1396,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "2",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1389,8 +1406,9 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
-			Desired:     desired,
-			VersionHash: "DL-FFQ2Uem8=",
+			ObservedGeneration: 1,
+			Desired:            desired,
+			VersionHash:        "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1503,10 +1521,11 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	expectGet(t, actions[0], "clusterversions", "", "version")
+
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "3",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1607,6 +1626,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
 			ResourceVersion: "1",
+			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID:     clusterUID,
@@ -1647,23 +1667,24 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 2 {
-		t.Fatalf("%s", spew.Sdump(actions))
-	}
+	verifySingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Step:   "RetrievePayload",
-			Actual: configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "RetrievePayload",
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 		SyncWorkerStatus{
-			Step:   "PreconditionChecks",
-			Actual: configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "PreconditionChecks",
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 		SyncWorkerStatus{
-			Step:    "PreconditionChecks",
-			Failure: &payload.UpdateError{Reason: "UpgradePreconditionCheckFailed", Message: "Precondition \"TestPrecondition SuccessAfter: 3\" failed because of \"CheckFailure\": failing, attempt: 1 will succeed after 3 attempt", Name: "PreconditionCheck"},
-			Actual:  configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Step:       "PreconditionChecks",
+			Failure:    &payload.UpdateError{Reason: "UpgradePreconditionCheckFailed", Message: "Precondition \"TestPrecondition SuccessAfter: 3\" failed because of \"CheckFailure\": failing, attempt: 1 will succeed after 3 attempt", Name: "PreconditionCheck"},
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 	)
 
@@ -1681,7 +1702,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "2",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1691,8 +1712,9 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
-			Desired:     desired,
-			VersionHash: "DL-FFQ2Uem8=",
+			ObservedGeneration: 1,
+			Desired:            desired,
+			VersionHash:        "DL-FFQ2Uem8=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
@@ -1812,7 +1834,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "3",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -1887,7 +1909,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 	// make the image report unverified
 	payloadErr := &payload.UpdateError{
 		Reason:  "ImageVerificationFailed",
-		Message: fmt.Sprintf("The update cannot be verified: some random error"),
+		Message: "The update cannot be verified: some random error",
 		Nested:  fmt.Errorf("some random error"),
 	}
 	if !isImageVerificationError(payloadErr) {
@@ -1907,9 +1929,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 2 {
-		t.Fatalf("%s", spew.Sdump(actions))
-	}
+	verifySingleUpdate(t, actions)
 
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
@@ -1939,7 +1959,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "2",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -2063,7 +2083,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "1",
+			ResourceVersion: "3",
 			Generation:      2,
 		},
 		Spec: configv1.ClusterVersionSpec{
@@ -2577,6 +2597,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
 			ResourceVersion: "1",
+			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
@@ -2619,9 +2640,10 @@ func TestCVO_ParallelError(t *testing.T) {
 	//
 	verifyAllStatus(t, worker.StatusCh(),
 		SyncWorkerStatus{
-			Initial: true,
-			Step:    "RetrievePayload",
-			Actual:  configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
+			Initial:    true,
+			Step:       "RetrievePayload",
+			Actual:     configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
+			Generation: 1,
 		},
 		SyncWorkerStatus{
 			Initial:     true,
@@ -2629,6 +2651,7 @@ func TestCVO_ParallelError(t *testing.T) {
 			Step:        "ApplyResources",
 			VersionHash: "Gyh2W6qcDO4=",
 			Actual:      configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
+			Generation:  1,
 		},
 	)
 
@@ -2649,6 +2672,7 @@ func TestCVO_ParallelError(t *testing.T) {
 					VersionHash:  "Gyh2W6qcDO4=",
 					Actual:       configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
 					LastProgress: status.LastProgress,
+					Generation:   1,
 				}) {
 					t.Fatalf("unexpected status: %v", status)
 				}
@@ -2672,6 +2696,7 @@ func TestCVO_ParallelError(t *testing.T) {
 			VersionHash:  "Gyh2W6qcDO4=",
 			Actual:       configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
 			LastProgress: status.LastProgress,
+			Generation:   1,
 		}) {
 			t.Fatalf("unexpected final: %v", status)
 		}
@@ -2693,7 +2718,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
 			Generation:      1,
-			ResourceVersion: "1",
+			ResourceVersion: "2",
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: clusterUID,
@@ -2701,8 +2726,9 @@ func TestCVO_ParallelError(t *testing.T) {
 		},
 		Status: configv1.ClusterVersionStatus{
 			// Prefers the image version over the operator's version (although in general they will remain in sync)
-			Desired:     configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
-			VersionHash: "Gyh2W6qcDO4=",
+			ObservedGeneration: 1,
+			Desired:            configv1.Release{Version: "1.0.0-abc", Image: "image/image:1"},
+			VersionHash:        "Gyh2W6qcDO4=",
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 			},
@@ -2835,6 +2861,18 @@ func TestCVO_VerifyUpdatingPayloadState(t *testing.T) {
 	}
 }
 
+func verifySingleUpdate(t *testing.T, actions []clientgotesting.Action) {
+	var count int
+	for _, a := range actions {
+		if a.GetVerb() != "get" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("Expected only one update. Actual update count %d", count)
+	}
+}
+
 func verifyAllStatus(t *testing.T, ch <-chan SyncWorkerStatus, items ...SyncWorkerStatus) {
 	t.Helper()
 	if len(items) == 0 {
@@ -2861,19 +2899,6 @@ func verifyAllStatus(t *testing.T, ch <-chan SyncWorkerStatus, items ...SyncWork
 		if !reflect.DeepEqual(expect, actual) {
 			t.Fatalf("unexpected status item %d\nExpected: %#v\nActual: %#v", i, expect, actual)
 		}
-	}
-}
-
-func waitFor(t *testing.T, fn func() bool) {
-	t.Helper()
-	err := wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
-		return fn(), nil
-	})
-	if err == wait.ErrWaitTimeout {
-		t.Fatalf("Worker condition was not reached within timeout")
-	}
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
The fake client for the CVO scenarios test uses a switch-case statement to compare the received `Action` pointer type to interfaces for update-action, create-action and get-action. However in go when two interfaces have the same definition(same functions) a concrete type can match against both of them. And because `clientgotesting.CreateAction` and `clientgotesting.UpdateAction` are basically the same interface the action always matched against the first interface. In this case the `CreateAction`. So the `ClusterVersion` object was always recreated and the `ResourceVersion` and `Generation` fields in the result object were reset all the time.

I have fixed the above issue by using the actual structs `CreateActionImpl`, `UpdateActionImpl` and `GetActionImpl` in the switch-case. This means that the test now updates the `ResourceVersion` correctly. The `Generation` field was also not being incremented correctly. The test client now takes the highest value from the received payload and the existing object.
  
I've also added a `verifySingleUpdate` function to ensure that the `ClusterVersion` is updated only once, even if multiple `get` calls are made to it.

