### PR TITLE
Enable errcheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,7 +68,7 @@ linters:
   disable-all: true
   enable:
     # - deadcode
-    # - errcheck
+    - errcheck
     # - gofmt
     # - gosimple
     # - govet

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ var (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
-	flag.CommandLine.Set("alsologtostderr", "true")
+	_ = flag.CommandLine.Set("alsologtostderr", "true")
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 }
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func runRenderCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	if renderOpts.outputDir == "" {

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -144,7 +144,13 @@ func Test_SyncWorker_apply(t *testing.T) {
 				remainingErrors: test.cancelAfter,
 			}
 
-			worker.apply(ctx, up, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			err := worker.apply(ctx, up, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+			if test.wantErr && err == nil {
+				t.Fatal("expected error but apply was successful")
+			}
 			test.check(t, r.actions)
 		})
 	}

--- a/pkg/payload/precondition/clusterversion/upgradable_test.go
+++ b/pkg/payload/precondition/clusterversion/upgradable_test.go
@@ -125,7 +125,7 @@ func TestUpgradeableRun(t *testing.T) {
 					Message: fmt.Sprintf("set to %v", *tc.upgradeable),
 				})
 			}
-			cvLister := fakeClusterVersionLister(clusterVersion)
+			cvLister := fakeClusterVersionLister(t, clusterVersion)
 			instance := NewUpgradeable(cvLister)
 
 			err := instance.Run(context.TODO(), precondition.ReleaseContext{DesiredVersion: tc.desiredVersion}, clusterVersion)
@@ -144,12 +144,15 @@ func TestUpgradeableRun(t *testing.T) {
 	}
 }
 
-func fakeClusterVersionLister(clusterVersion *configv1.ClusterVersion) configv1listers.ClusterVersionLister {
+func fakeClusterVersionLister(t *testing.T, clusterVersion *configv1.ClusterVersion) configv1listers.ClusterVersionLister {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	if clusterVersion == nil {
 		return configv1listers.NewClusterVersionLister(indexer)
 	}
 
-	indexer.Add(clusterVersion)
+	err := indexer.Add(clusterVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return configv1listers.NewClusterVersionLister(indexer)
 }

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -41,8 +41,8 @@ import (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
-	flag.CommandLine.Lookup("v").Value.Set("5")
-	flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
+	_ = flag.CommandLine.Lookup("v").Value.Set("5")
+	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
 }
 
 var (
@@ -685,7 +685,7 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 
 	id, _ := uuid.NewRandom()
 
-	client.ConfigV1().ClusterVersions().Create(
+	_, err = client.ConfigV1().ClusterVersions().Create(
 		ctx,
 		&configv1.ClusterVersion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -699,6 +699,10 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 		},
 		metav1.CreateOptions{},
 	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	dir, err := ioutil.TempDir("", "cvo-test")
 	if err != nil {


### PR DESCRIPTION
Depends on #598 

The [errcheck](https://github.com/kisielk/errcheck) linter ensures that all functions which return errors have their return value checked