### PR TITLE
Enable gosimple

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -70,7 +70,7 @@ linters:
     # - deadcode
     # - errcheck
     # - gofmt
-    # - gosimple
+    - gosimple
     # - govet
     - ineffassign
     # - staticcheck

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -1003,10 +1003,6 @@ func newClusterOperatorsNotAvailable(errs []error) error {
 		return nil
 	}
 
-	nested := make([]error, 0, len(errs))
-	for _, err := range errs {
-		nested = append(nested, err)
-	}
 	sort.Strings(names)
 	name := strings.Join(names, ", ")
 	return &payload.UpdateError{

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -85,25 +85,21 @@ func Test_statusWrapper_ReportProgress(t *testing.T) {
 			w.Report(tt.next)
 			close(w.w.report)
 			if tt.want {
-				select {
-				case evt, ok := <-w.w.report:
-					if !ok {
-						t.Fatalf("no event")
-					}
-					if tt.wantProgress != (!evt.LastProgress.IsZero()) {
-						t.Errorf("unexpected progress timestamp: %#v", evt)
-					}
-					evt.LastProgress = time.Time{}
-					if !reflect.DeepEqual(evt, tt.next) {
-						t.Fatalf("unexpected: %#v", evt)
-					}
+				evt, ok := <-w.w.report
+				if !ok {
+					t.Fatalf("no event")
+				}
+				if tt.wantProgress != (!evt.LastProgress.IsZero()) {
+					t.Errorf("unexpected progress timestamp: %#v", evt)
+				}
+				evt.LastProgress = time.Time{}
+				if !reflect.DeepEqual(evt, tt.next) {
+					t.Fatalf("unexpected: %#v", evt)
 				}
 			} else {
-				select {
-				case evt, ok := <-w.w.report:
-					if ok {
-						t.Fatalf("unexpected event: %#v", evt)
-					}
+				evt, ok := <-w.w.report
+				if ok {
+					t.Fatalf("unexpected event: %#v", evt)
 				}
 			}
 		})
@@ -138,11 +134,9 @@ func Test_statusWrapper_ReportGeneration(t *testing.T) {
 			w.Report(tt.next)
 			close(w.w.report)
 
-			select {
-			case evt := <-w.w.report:
-				if tt.want != evt.Generation {
-					t.Fatalf("mismatch: expected generation: %d, got generation: %d", tt.want, evt.Generation)
-				}
+			evt := <-w.w.report
+			if tt.want != evt.Generation {
+				t.Fatalf("mismatch: expected generation: %d, got generation: %d", tt.want, evt.Generation)
 			}
 		})
 	}


### PR DESCRIPTION
Depends on #598 and #597 

This [linter](https://github.com/dominikh/go-tools/tree/master/simple) looks for common non-idiomatic patterns in code which can be simplified.
 
Result from linter:
```
pkg/cvo/sync_worker_test.go:88:5       gosimple  S1000: should use a simple channel send/receive instead of `select` with a single case
pkg/cvo/sync_worker_test.go:102:5      gosimple  S1000: should use a simple channel send/receive instead of `select` with a single case
pkg/cvo/sync_worker_test.go:141:4      gosimple  S1000: should use a simple channel send/receive instead of `select` with a single case
pkg/cvo/cvo_scenarios_test.go:418:12   gosimple  S1039: unnecessary use of fmt.Sprintf
pkg/cvo/cvo_scenarios_test.go:1081:12  gosimple  S1039: unnecessary use of fmt.Sprintf
pkg/cvo/cvo_scenarios_test.go:1332:12  gosimple  S1039: unnecessary use of fmt.Sprintf
pkg/cvo/sync_worker.go:1004:2          gosimple  S1011: should replace loop with `nested = append(nested, errs...)`
```