### PR TITLE
Enable govet

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,7 +71,7 @@ linters:
     # - errcheck
     # - gofmt
     - gosimple
-    # - govet
+    - govet
     - ineffassign
     # - staticcheck
     # - structcheck

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -257,7 +257,7 @@ func TestOperator_sync(t *testing.T) {
 		name        string
 		key         string
 		syncStatus  *SyncWorkerStatus
-		optr        Operator
+		optr        *Operator
 		init        func(optr *Operator)
 		want        bool
 		wantErr     func(*testing.T, error)
@@ -266,7 +266,7 @@ func TestOperator_sync(t *testing.T) {
 	}{
 		{
 			name: "create version and status",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -305,7 +305,7 @@ func TestOperator_sync(t *testing.T) {
 					Message: "unable to apply object",
 				},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -369,7 +369,7 @@ func TestOperator_sync(t *testing.T) {
 		},
 		{
 			name: "progressing and previously failed, reconciling",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -444,7 +444,7 @@ func TestOperator_sync(t *testing.T) {
 		},
 		{
 			name: "progressing and previously failed, reconciling and multiple completions",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -520,7 +520,7 @@ func TestOperator_sync(t *testing.T) {
 		},
 		{
 			name: "progressing and encounters error during image sync",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -596,7 +596,7 @@ func TestOperator_sync(t *testing.T) {
 				Failure: os.ErrNotExist,
 				Actual:  configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -653,7 +653,7 @@ func TestOperator_sync(t *testing.T) {
 				Failure: os.ErrNotExist,
 				Actual:  configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -699,7 +699,7 @@ func TestOperator_sync(t *testing.T) {
 						Desired: configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 						History: []configv1.UpdateHistory{
 							// we populate state, but not startedTime
-							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{time.Unix(0, 0)}},
+							{State: configv1.PartialUpdate, Version: "4.0.1", Image: "image/image:v4.0.1", StartedTime: metav1.Time{Time: time.Unix(0, 0)}},
 						},
 						VersionHash: "",
 						Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -718,7 +718,7 @@ func TestOperator_sync(t *testing.T) {
 			syncStatus: &SyncWorkerStatus{
 				Actual: configv1.Release{Image: "image/image:v4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -778,7 +778,7 @@ func TestOperator_sync(t *testing.T) {
 			syncStatus: &SyncWorkerStatus{
 				Actual: configv1.Release{Image: "image/image:v4.0.2", Version: "4.0.2"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.2",
 					Image:   "image/image:v4.0.2",
@@ -870,7 +870,7 @@ func TestOperator_sync(t *testing.T) {
 				// one).
 				Actual: configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -976,7 +976,7 @@ func TestOperator_sync(t *testing.T) {
 				Done:   334,
 				Total:  1000,
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -1086,7 +1086,7 @@ func TestOperator_sync(t *testing.T) {
 				Actual: configv1.Release{Image: "image/image:v4.0.1"},
 				Step:   "RetrievePayload",
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -1187,7 +1187,7 @@ func TestOperator_sync(t *testing.T) {
 				VersionHash: "xyz",
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1264,7 +1264,7 @@ func TestOperator_sync(t *testing.T) {
 				VersionHash: "xyz",
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "0.0.1-abc",
 					Image:   "image/image:v4.0.1",
@@ -1324,7 +1324,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1429,7 +1429,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1507,7 +1507,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1584,7 +1584,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1658,7 +1658,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1743,7 +1743,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1823,7 +1823,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1887,7 +1887,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -1962,7 +1962,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2040,7 +2040,7 @@ func TestOperator_sync(t *testing.T) {
 				VersionHash: "y_Kc5IQiIyU=",
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "0.0.1-abc",
 					Image:   "image/image:v4.0.1",
@@ -2102,7 +2102,7 @@ func TestOperator_sync(t *testing.T) {
 				VersionHash: "y_Kc5IQiIyU=",
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "0.0.1-abc",
 					Image:   "image/image:v4.0.1",
@@ -2169,7 +2169,7 @@ func TestOperator_sync(t *testing.T) {
 								Image:          "image/image:v4.0.1",
 								Version:        "0.0.1-abc",
 								CompletionTime: &defaultCompletionTime,
-								StartedTime:    metav1.Time{time.Unix(0, 0)},
+								StartedTime:    metav1.Time{Time: time.Unix(0, 0)},
 							},
 						},
 						Desired:            configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
@@ -2193,7 +2193,7 @@ func TestOperator_sync(t *testing.T) {
 				Completed:   1,
 				Actual:      configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2254,7 +2254,7 @@ func TestOperator_sync(t *testing.T) {
 			syncStatus: &SyncWorkerStatus{
 				Actual: configv1.Release{Image: "image/image:v4.0.1", Version: "0.0.1-abc"},
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2329,7 +2329,7 @@ func TestOperator_sync(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			optr := &tt.optr
+			optr := tt.optr
 			if tt.init != nil {
 				tt.init(optr)
 			}
@@ -2376,13 +2376,13 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		name        string
 		key         string
 		handler     http.HandlerFunc
-		optr        Operator
+		optr        *Operator
 		wantErr     func(*testing.T, error)
 		wantUpdates *availableUpdates
 	}{
 		{
 			name: "when version is missing, do nothing (other loops should create it)",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2397,7 +2397,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2436,7 +2436,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -2477,7 +2477,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
@@ -2517,7 +2517,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "4.0.1",
@@ -2577,7 +2577,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				}
 				`)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "4.0.1",
@@ -2641,7 +2641,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				}
 				`)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "4.0.1",
@@ -2691,7 +2691,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer:      "http://localhost:8080/graph",
 				minimumUpdateCheckInterval: 1 * time.Minute,
 				availableUpdates: &availableUpdates{
@@ -2794,13 +2794,13 @@ func TestOperator_upgradeableSync(t *testing.T) {
 	tests := []struct {
 		name    string
 		key     string
-		optr    Operator
+		optr    *Operator
 		wantErr func(*testing.T, error)
 		want    *upgradeable
 	}{
 		{
 			name: "when version is missing, do nothing (other loops should create it)",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2812,7 +2812,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when overrides is set for version",
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2849,7 +2849,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when the single clusteroperator is not upgradeable",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -2898,7 +2898,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when single clusteroperator is not upgradeable and another has no conditions",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -2955,7 +2955,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when single clusteroperator is not upgradeable and another is upgradeable",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -3015,7 +3015,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when two clusteroperators are not upgradeable",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -3077,7 +3077,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "report error condition when clusteroperators and version are not upgradeable",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -3152,7 +3152,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "no error conditions",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -3182,7 +3182,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "no error conditions",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",
@@ -3214,7 +3214,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		},
 		{
 			name: "no error conditions",
-			optr: Operator{
+			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
 					Version: "v4.0.0",

--- a/pkg/cvo/internal/operatorstatus_test.go
+++ b/pkg/cvo/internal/operatorstatus_test.go
@@ -43,7 +43,7 @@ func Test_checkOperatorHealth(t *testing.T) {
 			},
 		},
 		expErr: &payload.UpdateError{
-			Nested:       apierrors.NewNotFound(schema.GroupResource{"", "clusteroperator"}, "test-co"),
+			Nested:       apierrors.NewNotFound(schema.GroupResource{Resource: "clusteroperator"}, "test-co"),
 			UpdateEffect: payload.UpdateEffectNone,
 			Reason:       "ClusterOperatorNotAvailable",
 			Message:      "Cluster operator test-co has not yet reported success",

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -148,7 +148,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 	}
 	tests := []struct {
 		name        string
-		optr        Operator
+		optr        *Operator
 		init        func(optr *Operator)
 		wantErr     func(*testing.T, error)
 		wantActions func(*testing.T, *Operator)
@@ -159,7 +159,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 	}{
 		{
 			ierr: fmt.Errorf("bad"),
-			optr: Operator{
+			optr: &Operator{
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -238,7 +238,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			optr := &tt.optr
+			optr := tt.optr
 			if tt.init != nil {
 				tt.init(optr)
 			}

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -67,10 +67,10 @@ func Test_SyncWorker_apply(t *testing.T) {
 				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
-			if got, exp := actions[1], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[1], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, "default", "testb")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
@@ -94,7 +94,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}`,
 		},
 		reactors: map[action]error{
-			newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
+			newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa"): &meta.NoResourceMatchError{},
 		},
 		cancelAfter: 2,
 		wantErr:     true,
@@ -104,7 +104,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 				t.Fatalf("unexpected %d actions", len(actions))
 			}
 
-			if got, exp := actions[0], (newAction(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
+			if got, exp := actions[0], (newAction(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, "default", "testa")); !reflect.DeepEqual(got, exp) {
 				t.Fatalf("%s", diff.ObjectReflectDiff(exp, got))
 			}
 		},
@@ -129,8 +129,8 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 			r := &recorder{}
 			testMapper := resourcebuilder.NewResourceMapper()
-			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestA"}, newTestBuilder(r, test.reactors))
-			testMapper.RegisterGVK(schema.GroupVersionKind{"test.cvo.io", "v1", "TestB"}, newTestBuilder(r, test.reactors))
+			testMapper.RegisterGVK(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestA"}, newTestBuilder(r, test.reactors))
+			testMapper.RegisterGVK(schema.GroupVersionKind{Group: "test.cvo.io", Version: "v1", Kind: "TestB"}, newTestBuilder(r, test.reactors))
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
 			worker := &SyncWorker{eventRecorder: record.NewFakeRecorder(100)}


### PR DESCRIPTION
Depends on #598 

According to the [documentation](https://golang.org/cmd/vet/):
> Vet examines Go source code and reports suspicious constructs

Results from the linter:
```
pkg/cvo/cvo_test.go:702:100                    govet  composites: `k8s.io/apimachinery/pkg/apis/meta/v1.Time` composite literal uses unkeyed fields
pkg/cvo/cvo_test.go:2172:25                    govet  composites: `k8s.io/apimachinery/pkg/apis/meta/v1.Time` composite literal uses unkeyed fields
pkg/cvo/sync_test.go:70:42                     govet  composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind` composite literal uses unkeyed fields
pkg/cvo/sync_test.go:73:42                     govet  composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind` composite literal uses unkeyed fields
pkg/cvo/sync_test.go:97:14                     govet  composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind` composite literal uses unkeyed fields
pkg/cvo/internal/operatorstatus_test.go:46:40  govet  composites: `k8s.io/apimachinery/pkg/runtime/schema.GroupResource` composite literal uses unkeyed fields
pkg/cvo/cvo_test.go:2330:9                     govet  copylocks: range var tt copies lock: struct{name string; key string; syncStatus *github.com/openshift/cluster-version-operator/pkg/cvo.SyncWorkerStatus; optr github.com/openshift/cluster-version-operator/pkg/cvo.Operator; init func(optr *github.com/openshift/cluster-version-operator/pkg/cvo.Operator); want bool; wantErr func(*testing.T, error); wantActions func(*testing.T, *github.com/openshift/cluster-version-operator/pkg/cvo.Operator); wantSync []github.com/openshift/api/config/v1.Update} contains github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
pkg/cvo/cvo_test.go:2735:9                     govet  copylocks: range var tt copies lock: struct{name string; key string; handler net/http.HandlerFunc; optr github.com/openshift/cluster-version-operator/pkg/cvo.Operator; wantErr func(*testing.T, error); wantUpdates *github.com/openshift/cluster-version-operator/pkg/cvo.availableUpdates} contains github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
pkg/cvo/cvo_test.go:2737:12                    govet  copylocks: assignment copies lock value to optr: github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
pkg/cvo/cvo_test.go:3259:9                     govet  copylocks: range var tt copies lock: struct{name string; key string; optr github.com/openshift/cluster-version-operator/pkg/cvo.Operator; wantErr func(*testing.T, error); want *github.com/openshift/cluster-version-operator/pkg/cvo.upgradeable} contains github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
pkg/cvo/cvo_test.go:3261:12                    govet  copylocks: assignment copies lock value to optr: github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
pkg/cvo/status_test.go:239:9                   govet  copylocks: range var tt copies lock: struct{name string; optr github.com/openshift/cluster-version-operator/pkg/cvo.Operator; init func(optr *github.com/openshift/cluster-version-operator/pkg/cvo.Operator); wantErr func(*testing.T, error); wantActions func(*testing.T, *github.com/openshift/cluster-version-operator/pkg/cvo.Operator); wantSync []github.com/openshift/api/config/v1.Release; original *github.com/openshift/api/config/v1.ClusterVersion; ierr error} contains github.com/openshift/cluster-version-operator/pkg/cvo.Operator contains sync.Mutex
```

The code uses unkeyed composite literals and in the [words](https://groups.google.com/g/golang-nuts/c/Ub1GMMrfgFc/m/4SIWMRRgEQAJ) of Rob Pike:

> The argument for the complaint is that keyed composite literals are more future-proof. If you later change the layout of s, the code will fail to compile if the keys no longer work, but an unkeyed literal may compile incorrectly. In your example, if you swapped a and b in s, the first assignment of z would set 1 to b and 2 to a.

There are also some instances where structs containing locks are passed by value. This is incorrect because when passing locks by value the lock is copied and effectively there are multiple locks.