### PR TITLE
Enable staticcheck

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,7 +73,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # - staticcheck
+    - staticcheck
     - structcheck
     - typecheck
     - unused

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -31,5 +31,5 @@ func runImageCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		klog.Fatalf("error: %v", err)
 	}
-	fmt.Printf(image)
+	fmt.Print(image)
 }

--- a/pkg/cvo/egress.go
+++ b/pkg/cvo/egress.go
@@ -21,14 +21,12 @@ func (optr *Operator) getHTTPSProxyURL() (*url.URL, error) {
 		return nil, err
 	}
 
-	if &proxy.Spec != nil {
-		if proxy.Spec.HTTPSProxy != "" {
-			proxyURL, err := url.Parse(proxy.Spec.HTTPSProxy)
-			if err != nil {
-				return nil, err
-			}
-			return proxyURL, nil
+	if proxy.Spec.HTTPSProxy != "" {
+		proxyURL, err := url.Parse(proxy.Spec.HTTPSProxy)
+		if err != nil {
+			return nil, err
 		}
+		return proxyURL, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Depends on #598 and #602

[staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) is a code analysis tool which detects common mistakes in go.