### PR TITLE
Enable structcheck

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,7 +74,7 @@ linters:
     # - govet
     - ineffassign
     # - staticcheck
-    # - structcheck
+    - structcheck
     - typecheck
     # - unused
     - varcheck

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -39,8 +39,7 @@ type Controller struct {
 	client        clientset.Interface
 	eventRecorder record.EventRecorder
 
-	syncHandler       func(ctx context.Context, key string) error
-	statusSyncHandler func(key string) error
+	syncHandler func(ctx context.Context, key string) error
 
 	cvLister    configlistersv1.ClusterVersionLister
 	coLister    configlistersv1.ClusterOperatorLister

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -103,8 +103,6 @@ type Operator struct {
 	payloadDir string
 	// defaultUpstreamServer is intended for testing.
 	defaultUpstreamServer string
-	// syncBackoff allows the tests to use a quicker backoff
-	syncBackoff wait.Backoff
 
 	cvLister              configlistersv1.ClusterVersionLister
 	coLister              configlistersv1.ClusterOperatorLister


### PR DESCRIPTION
Depends on #598

The [structcheck](https://gitlab.com/opennota/check) linter finds unused fields in structs.