### PR TITLE
Revert "prevent pod deployment deadlock due to custom SA projected volume injection"

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -20,10 +20,6 @@ spec:
       labels:
         k8s-app: cluster-version-operator
     spec:
-      # prevents circular dependency with OpenShift service-ca CM volume injection by
-      # KAS and creation of the CM by KCM
-      # TODO: remove in 4.9
-      automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
         image: {{.ReleaseImage}}
@@ -51,9 +47,6 @@ spec:
             readOnly: true
           - mountPath: /etc/tls/serving-cert
             name: serving-cert
-            readOnly: true
-          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-            name: kube-api-access
             readOnly: true
         env:
           - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
@@ -102,21 +95,3 @@ spec:
         - name: serving-cert
           secret:
             secretName: cluster-version-operator-serving-cert
-        - name: kube-api-access
-          projected:
-            defaultMode: 420
-            sources:
-            - serviceAccountToken:
-                expirationSeconds: 3600
-                path: token
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace


### PR DESCRIPTION
This reverts commit 9bde7bb89677fe166303c040d220b763c3291234, #585.

It was a temporary workaround in 4.8 to bridge a gap between Kube-API-server and Kube-controller-manager during 4.7 -> 4.8 updates. Once the cluster has reconciled 4.8, we will no longer need the crutch.  And 4.8 has now forked off master, so we can revert now, and that revert will go out in 4.9.