### PR TITLE
Bug 1970421: Do not check if Job has Failed count set

### DIFF
--- a/lib/resourcebuilder/batch.go
+++ b/lib/resourcebuilder/batch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	batchclientv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
@@ -46,15 +47,40 @@ func checkJobHealth(ctx context.Context, client batchclientv1.JobsGetter, job *b
 	}
 
 	// Since we have filled in "activeDeadlineSeconds",
-	// the Job will 'Active == 0' if and only if it exceeds the deadline.
+	// the Job will 'Active == 0' if and only if it exceeds the deadline or if the update image could not be pulled.
 	// Failed jobs will be recreated in the next run.
-	if j.Status.Active == 0 && j.Status.Failed > 0 {
-		reason := "DeadlineExceeded"
-		message := "Job was active longer than specified deadline"
-		if len(j.Status.Conditions) > 0 {
-			reason, message = j.Status.Conditions[0].Reason, j.Status.Conditions[0].Message
+	if j.Status.Active == 0 {
+		klog.V(4).Infof("No active pods for job %s in namespace %s", job.Name, job.Namespace)
+		failed, reason, message := hasJobFailed(job)
+		// If there is more than one failed job pod then get the cause for failure
+		if j.Status.Failed > 0 {
+			failureReason := "DeadlineExceeded"
+			failureMessage := "Job was active longer than specified deadline"
+			if failed {
+				failureReason, failureMessage = reason, message
+			}
+			return false, fmt.Errorf("deadline exceeded, reason: %q, message: %q", failureReason, failureMessage)
 		}
-		return false, fmt.Errorf("deadline exceeded, reason: %q, message: %q", reason, message)
+
+		// When the update image cannot be pulled then the pod is not marked as Failed, but the status condition is set
+		// after the job deadline is exceeded.
+		if failed {
+			if reason == "DeadlineExceeded" {
+				return false, fmt.Errorf("deadline exceeded, reason: %q, message: %q", reason, message)
+			} else {
+				klog.V(4).Infof("Ignoring job %s in namespace %s with condition Failed=True because %s: %s", job.Name, job.Namespace, reason, message)
+			}
+		}
 	}
+
 	return false, nil
+}
+
+func hasJobFailed(job *batchv1.Job) (bool, string, string) {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
+			return true, condition.Reason, condition.Message
+		}
+	}
+	return false, "", ""
 }


### PR DESCRIPTION
When a job pod fails because kubelet is unable to pull the image, the pod is never considered *active* and subsequently after timing out it is never considered as `Failed` and the `Failed` count in the job status is never incremented.