### PR TITLE
Added ownerReference to all objects created and managed by CVO

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -123,7 +123,7 @@ func TestCVO_StartupAndSync(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 3 {
+	if len(actions) != 4 {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	// read from lister
@@ -141,6 +141,10 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			Channel:   "fast",
 		},
 	})
+
+	// read after create
+	expectGet(t, actions[3], "clusterversions", "", "version")
+
 	verifyAllStatus(t, worker.StatusCh())
 
 	// Step 2: Ensure the CVO reports a status error if it has nothing to sync
@@ -445,7 +449,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 3 {
+	if len(actions) != 4 {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	// read from lister
@@ -463,6 +467,9 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Channel:   "fast",
 		},
 	})
+	// read after create
+	expectGet(t, actions[3], "clusterversions", "", "version")
+
 	verifyAllStatus(t, worker.StatusCh())
 
 	// Step 2: Ensure the CVO reports a status error if it has nothing to sync
@@ -757,7 +764,7 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions := client.Actions()
-	if len(actions) != 3 {
+	if len(actions) != 4 {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	// read from lister
@@ -775,6 +782,8 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			Channel:   "fast",
 		},
 	})
+	// read after create
+	expectGet(t, actions[3], "clusterversions", "", "version")
 	verifyAllStatus(t, worker.StatusCh())
 
 	// Step 2: Ensure the CVO reports a status error if it has nothing to sync

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -134,7 +134,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			testMapper.AddToMap(resourcebuilder.Mapper)
 
 			worker := &SyncWorker{eventRecorder: record.NewFakeRecorder(100)}
-			worker.builder = NewResourceBuilder(nil, nil, nil)
+			worker.builder = NewResourceBuilder(nil, nil, nil, nil)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -286,7 +286,7 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	options.PayloadOverride = filepath.Join(dir, "ignored")
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -448,7 +448,7 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	options.ResyncInterval = 3 * time.Second
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Duration: time.Second, Factor: 1.2}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Duration: time.Second, Factor: 1.2}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -563,7 +563,7 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	options.NodeName = "test-node"
 	controllers := options.NewControllerContext(cb)
 
-	worker := cvo.NewSyncWorker(&mapPayloadRetriever{}, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
+	worker := cvo.NewSyncWorker(&mapPayloadRetriever{}, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
@@ -754,7 +754,7 @@ metadata:
 		t.Fatal(err)
 	}
 
-	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
+	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)


### PR DESCRIPTION
The operator object no has a metadata modifier which injects an owner reference if there is no existing owner references. Also updates the ownerReference if it has been changed due to recreation