### PR TITLE
Enable misspell linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,6 +73,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - structcheck
     - typecheck

--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -22,7 +22,7 @@ var (
 type ResourceMapper struct {
 	l *sync.Mutex
 
-	gvkToNew map[schema.GroupVersionKind]NewInteraceFunc
+	gvkToNew map[schema.GroupVersionKind]NewInterfaceFunc
 }
 
 // AddToMap adds all keys from caller to input.
@@ -35,22 +35,22 @@ func (rm *ResourceMapper) AddToMap(irm *ResourceMapper) {
 	}
 }
 
-// Exist returns true when gvk is known.
+// Exists returns true when gvk is known.
 func (rm *ResourceMapper) Exists(gvk schema.GroupVersionKind) bool {
 	_, ok := rm.gvkToNew[gvk]
 	return ok
 }
 
-// RegisterGVK adds GVK to NewInteraceFunc mapping.
+// RegisterGVK adds GVK to NewInterfaceFunc mapping.
 // It does not lock before adding the mapping.
-func (rm *ResourceMapper) RegisterGVK(gvk schema.GroupVersionKind, f NewInteraceFunc) {
+func (rm *ResourceMapper) RegisterGVK(gvk schema.GroupVersionKind, f NewInterfaceFunc) {
 	rm.gvkToNew[gvk] = f
 }
 
 // NewResourceMapper returns a new map.
 // This is required a we cannot push to uninitialized map.
 func NewResourceMapper() *ResourceMapper {
-	m := map[schema.GroupVersionKind]NewInteraceFunc{}
+	m := map[schema.GroupVersionKind]NewInterfaceFunc{}
 	return &ResourceMapper{
 		l:        &sync.Mutex{},
 		gvkToNew: m,
@@ -59,10 +59,10 @@ func NewResourceMapper() *ResourceMapper {
 
 type MetaV1ObjectModifierFunc func(metav1.Object)
 
-// NewInteraceFunc returns an Interface.
+// NewInterfaceFunc returns an Interface.
 // It requires rest Config that can be used to create a client
 // and the Manifest.
-type NewInteraceFunc func(rest *rest.Config, m manifest.Manifest) Interface
+type NewInterfaceFunc func(rest *rest.Config, m manifest.Manifest) Interface
 
 // Mode is how this builder is being used.
 type Mode int

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -117,7 +117,7 @@ type genericBuilder struct {
 	modifier resourcebuilder.MetaV1ObjectModifierFunc
 }
 
-// NewGenericBuilder returns an implentation of resourcebuilder.Interface that
+// NewGenericBuilder returns an implementation of resourcebuilder.Interface that
 // uses dynamic clients for applying.
 func NewGenericBuilder(client dynamic.ResourceInterface, m manifest.Manifest) (resourcebuilder.Interface, error) {
 	return &genericBuilder{

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -95,7 +95,7 @@ version for 'cluster', or empty for 'initial'.
 		}, []string{"type", "version", "invoker"}),
 		clusterVersionOperatorUpdateRetrievalTimestampSeconds: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_version_operator_update_retrieval_timestamp_seconds",
-			Help: "Reports when updates were last succesfully retrieved.",
+			Help: "Reports when updates were last successfully retrieved.",
 		}, []string{"name"}),
 	}
 }

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -371,7 +371,7 @@ func (t *testBuilder) Do(_ context.Context) error {
 	return t.reactors[a]
 }
 
-func newTestBuilder(r *recorder, rts map[action]error) resourcebuilder.NewInteraceFunc {
+func newTestBuilder(r *recorder, rts map[action]error) resourcebuilder.NewInterfaceFunc {
 	return func(_ *rest.Config, m manifest.Manifest) resourcebuilder.Interface {
 		return &testBuilder{recorder: r, reactors: rts, m: &m}
 	}

--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -245,7 +245,7 @@ func (r *payloadRetriever) pruneJobs(ctx context.Context, retain int) error {
 	var deleteJobs []batchv1.Job
 	for _, job := range jobs.Items {
 		switch {
-		// Ignore jobs not begining with operatorName
+		// Ignore jobs not beginning with operatorName
 		case !strings.HasPrefix(job.Name, r.operatorName+"-"):
 			break
 		// Ignore jobs that have not yet started


### PR DESCRIPTION
Enabled the misspell linter to catch spelling errors in comments. Also fixed other spelling errors in code.