### PR TITLE
Bug 2020107: Remove run-level label

### DIFF
--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-cluster-version
-    openshift.io/run-level: "1"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
Given the original commit for this was in 2018, it might be possible to remove the label now entirely. Given #24 is specifically setting it a dependency on the openshift-apiserver, I doubt it, 

Will use this PR for testing and further discussion. 