### PR TITLE
Bug 1980411: [release-4.8] pkg/cvo/egress: Load HTTPS proxy from Proxy status

### DIFF
--- a/pkg/cvo/egress.go
+++ b/pkg/cvo/egress.go
@@ -21,9 +21,9 @@ func (optr *Operator) getHTTPSProxyURL() (*url.URL, error) {
 		return nil, err
 	}
 
-	if &proxy.Spec != nil {
-		if proxy.Spec.HTTPSProxy != "" {
-			proxyURL, err := url.Parse(proxy.Spec.HTTPSProxy)
+	if &proxy.Status != nil {
+		if proxy.Status.HTTPSProxy != "" {
+			proxyURL, err := url.Parse(proxy.Status.HTTPSProxy)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Backport to release-4.8 of [PR 621](https://github.com/openshift/cluster-version-operator/pull/621)

Since 4.2's ea5e3bc (Add http transport for cincinnati to enable
proxy, 2019-07-16, #219), the CVO has been loading proxy config from
the spec property.  We should be loading from status instead, so we
benefit from the network operator's validation.  Risk is small,
because unlike some other in-cluster components, the CVO is unlikely
to break things if it is temporarily consuming a broken proxy
configuration.

This is similar to c9fab43 (pkg/cvo: Fetch proxy CA certs from
openshift-config-managed/trusted-ca-bundle, 2020-01-31, #311), where
we moved our trusted CA source from the user-configured ConfigMap to
the network-operator-validated ConfigMap.