### PR TITLE
Bug 1982046: lib/resourcedelete: Always check delete progress

### DIFF
--- a/lib/resourcedelete/apiext.go
+++ b/lib/resourcedelete/apiext.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteCustomResourceDefinitionv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteCustomResourceDefinitionv1(ctx context.Context, client apiextclientv1.CustomResourceDefinitionsGetter,
 	required *apiextv1.CustomResourceDefinition, updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.CustomResourceDefinitions().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "customresourcedefinition",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.CustomResourceDefinitions().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.CustomResourceDefinitions().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/apireg.go
+++ b/lib/resourcedelete/apireg.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteAPIServicev1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteAPIServicev1(ctx context.Context, client apiregclientv1.APIServicesGetter, required *apiregv1.APIService,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.APIServices().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "apiservice",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.APIServices().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.APIServices().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/batch.go
+++ b/lib/resourcedelete/batch.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteJobv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteJobv1(ctx context.Context, client batchclientv1.JobsGetter, required *batchv1.Job,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.Jobs(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "job",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.Jobs(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/core.go
+++ b/lib/resourcedelete/core.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteNamespacev1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteNamespacev1(ctx context.Context, client coreclientv1.NamespacesGetter, required *corev1.Namespace,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.Namespaces().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "namespace",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.Namespaces().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.Namespaces().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -41,25 +39,23 @@ func DeleteNamespacev1(ctx context.Context, client coreclientv1.NamespacesGetter
 }
 
 // DeleteServicev1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteServicev1(ctx context.Context, client coreclientv1.ServicesGetter, required *corev1.Service,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.Services(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "service",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.Services(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.Services(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -72,25 +68,23 @@ func DeleteServicev1(ctx context.Context, client coreclientv1.ServicesGetter, re
 }
 
 // DeleteServiceAccountv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteServiceAccountv1(ctx context.Context, client coreclientv1.ServiceAccountsGetter, required *corev1.ServiceAccount,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.ServiceAccounts(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "serviceaccount",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.ServiceAccounts(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.ServiceAccounts(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -103,25 +97,23 @@ func DeleteServiceAccountv1(ctx context.Context, client coreclientv1.ServiceAcco
 }
 
 // DeleteConfigMapv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteConfigMapv1(ctx context.Context, client coreclientv1.ConfigMapsGetter, required *corev1.ConfigMap,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.ConfigMaps(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "configmap",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.ConfigMaps(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.ConfigMaps(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/imagestream.go
+++ b/lib/resourcedelete/imagestream.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteImageStreamv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteImageStreamv1(ctx context.Context, client imageclientv1.ImageStreamsGetter, required *imagev1.ImageStream,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.ImageStreams(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "imagestream",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.ImageStreams(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.ImageStreams(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/rbac.go
+++ b/lib/resourcedelete/rbac.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteClusterRoleBindingv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteClusterRoleBindingv1(ctx context.Context, client rbacclientv1.ClusterRoleBindingsGetter, required *rbacv1.ClusterRoleBinding,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.ClusterRoleBindings().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "clusterrolebinding",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.ClusterRoleBindings().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.ClusterRoleBindings().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -41,25 +39,23 @@ func DeleteClusterRoleBindingv1(ctx context.Context, client rbacclientv1.Cluster
 }
 
 // DeleteClusterRolev1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteClusterRolev1(ctx context.Context, client rbacclientv1.ClusterRolesGetter, required *rbacv1.ClusterRole,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.ClusterRoles().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "clusterrole",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.ClusterRoles().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.ClusterRoles().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -72,25 +68,23 @@ func DeleteClusterRolev1(ctx context.Context, client rbacclientv1.ClusterRolesGe
 }
 
 // DeleteRoleBindingv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteRoleBindingv1(ctx context.Context, client rbacclientv1.RoleBindingsGetter, required *rbacv1.RoleBinding,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.RoleBindings(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "rolebinding",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.RoleBindings(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.RoleBindings(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}
@@ -103,25 +97,23 @@ func DeleteRoleBindingv1(ctx context.Context, client rbacclientv1.RoleBindingsGe
 }
 
 // DeleteRolev1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteRolev1(ctx context.Context, client rbacclientv1.RolesGetter, required *rbacv1.Role,
 	updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.Roles(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "role",
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	existing, err := client.Roles(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.Roles(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}

--- a/lib/resourcedelete/security.go
+++ b/lib/resourcedelete/security.go
@@ -10,25 +10,23 @@ import (
 )
 
 // DeleteSecurityContextConstraintsv1 checks the given resource for a valid delete annotation. If found
-// and in UpdatingMode it will issue a delete request or provide status of a previousily issued delete request.
-// If not in UpdatingMode it simply returns an indication that the delete annotation was found. An error is
-// returned if an invalid annotation is found or an error occurs during delete processing.
+// it checks the status of a previousily issued delete request. If delete has not been
+// requested and in UpdatingMode it will issue a delete request.
 func DeleteSecurityContextConstraintsv1(ctx context.Context, client securityclientv1.SecurityContextConstraintsGetter,
 	required *securityv1.SecurityContextConstraints, updateMode bool) (bool, error) {
 
 	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
 		return delAnnoFound, err
-	} else if !updateMode {
-		return true, nil
 	}
+	existing, err := client.SecurityContextConstraints().Get(ctx, required.Name, metav1.GetOptions{})
 	resource := Resource{
 		Kind:      "securitycontextconstraints",
 		Namespace: "",
 		Name:      required.Name,
 	}
-	existing, err := client.SecurityContextConstraints().Get(ctx, required.Name, metav1.GetOptions{})
 	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		if !deleteRequested {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
 			if err := client.SecurityContextConstraints().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
 				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
 			}


### PR DESCRIPTION
Previously delete methods would simply return when not in UpdateMode. This meant that if a delete was started in UpdateMode but had not completed while in UpdateMode the delete would never be marked as completed and minor upgrades would remain blocked. With this change deletes are continuously checked which also means a deleted resource that is recreated is logged as such by CVO even when not in UpdateMode. Deletes are still only requested when in UpdateMode.