### PR TITLE
Bug 1978376: Add admin ack Upgradeable condition gate

### DIFF
--- a/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-acks
+  namespace: openshift-config
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"

--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-gates
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -200,6 +200,8 @@ func New(
 	}
 
 	cvInformer.Informer().AddEventHandler(optr.eventHandler())
+	cmConfigInformer.Informer().AddEventHandler(optr.adminAcksEventHandler())
+	cmConfigManagedInformer.Informer().AddEventHandler(optr.adminGatesEventHandler())
 
 	optr.coLister = coInformer.Lister()
 	optr.cacheSynced = append(optr.cacheSynced, coInformer.Informer().HasSynced)
@@ -613,7 +615,7 @@ func (optr *Operator) upgradeableSync(ctx context.Context, key string) error {
 		return nil
 	}
 
-	return optr.syncUpgradeable(config)
+	return optr.syncUpgradeable()
 }
 
 // isOlderThanLastUpdate returns true if the cluster version is older than

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -26,8 +26,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -2708,15 +2713,36 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 	}
 }
 
+// waits for admin ack configmap changes
+func waitForCm(t *testing.T, cmChan chan *corev1.ConfigMap) {
+	select {
+	case cm := <-cmChan:
+		t.Logf("Got configmap from channel: %s/%s", cm.Namespace, cm.Name)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Error("Informer did not get the configmap")
+	}
+}
+
 func TestOperator_upgradeableSync(t *testing.T) {
 	id := uuid.Must(uuid.NewRandom()).String()
 
+	var defaultGateCm = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+			Namespace: "test"},
+	}
+	var defaultAckCm = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-acks",
+			Namespace: "test"},
+	}
 	tests := []struct {
-		name    string
-		key     string
-		optr    *Operator
-		wantErr func(*testing.T, error)
-		want    *upgradeable
+		name           string
+		key            string
+		optr           *Operator
+		cm             corev1.ConfigMap
+		gateCm         *corev1.ConfigMap
+		ackCm          *corev1.ConfigMap
+		wantErr        func(*testing.T, error)
+		expectedResult *upgradeable
 	}{
 		{
 			name: "when version is missing, do nothing (other loops should create it)",
@@ -2728,6 +2754,10 @@ func TestOperator_upgradeableSync(t *testing.T) {
 				namespace: "test",
 				name:      "default",
 				client:    fake.NewSimpleClientset(),
+			},
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
 			},
 		},
 		{
@@ -2758,7 +2788,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -2807,7 +2841,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -2864,7 +2902,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -2924,7 +2966,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -2986,7 +3032,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -3051,7 +3101,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{
 				Conditions: []configv1.ClusterOperatorStatusCondition{{
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
@@ -3098,7 +3152,11 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{},
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{},
 		},
 		{
 			name: "no error conditions",
@@ -3130,15 +3188,19 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{},
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{},
 		},
 		{
-			name: "no error conditions",
+			name: "no error conditions and admin ack gate does not apply to version",
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
 				release: configv1.Release{
-					Version: "v4.0.0",
-					Image:   "image/image:v4.0.1",
+					Version: "v4.9.0",
+					Image:   "image/image:v4.9.1",
 				},
 				namespace: "test",
 				name:      "default",
@@ -3156,7 +3218,8 @@ func TestOperator_upgradeableSync(t *testing.T) {
 						},
 						Status: configv1.ClusterVersionStatus{
 							History: []configv1.UpdateHistory{
-								{Image: "image/image:v4.0.1"},
+								{Version: "4.9.0"},
+								{Image: "image/image:v4.9.1"},
 							},
 						},
 					},
@@ -3173,42 +3236,697 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					},
 				),
 			},
-			want: &upgradeable{},
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+			},
+			expectedResult: &upgradeable{},
+		},
+		{
+			name: "admin-gates configmap gate does not have value",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": ""},
+			},
+			ackCm: &defaultAckCm,
+			expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "AdminAckConfigMapGateValueError",
+					Message: "admin-gates configmap gate ack-4.8-kube-122-api-removals-in-4.9 must contain a non-empty value."}},
+			},
+		},
+		{
+			name: "admin ack required",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description."},
+			},
+			ackCm: &defaultAckCm,
+			expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "AdminAckRequired",
+					Message: "Description."}},
+			},
+		},
+		{
+			name: "admin ack required and admin ack gate does not apply to version",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description.",
+					"ack-4.9-kube-122-api-removals-in-4.9": "Description 2."},
+			},
+			ackCm: &defaultAckCm, expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "AdminAckRequired",
+					Message: "Description."}},
+			},
+		},
+		{
+			name: "admin ack required and configmap gate does not have value",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description.",
+					"ack-4.8-foo": ""},
+			},
+			ackCm: &defaultAckCm, expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "MultipleReasons",
+					Message: "Description. admin-gates configmap gate ack-4.8-foo must contain a non-empty value."}},
+			},
+		},
+		{
+			name: "multiple admin acks required",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description 2.",
+					"ack-4.8-foo": "Description 1.",
+					"ack-4.8-bar": "Description 3."},
+			},
+			ackCm: &defaultAckCm, expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "AdminAckRequired",
+					Message: "Description 1. Description 2. Description 3."}},
+			},
+		},
+		{
+			name: "admin ack found",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description."},
+			},
+			ackCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-acks",
+					Namespace: "test"}, Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "true"},
+			},
+			expectedResult: &upgradeable{},
+		},
+		{
+			name: "admin ack 2 of 3 found",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description.",
+					"ack-4.8-foo": "Description foo.",
+					"ack-4.8-bar": "Description bar."},
+			},
+			ackCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-acks",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "true",
+					"ack-4.8-bar": "true"}},
+			expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "AdminAckRequired",
+					Message: "Description foo."}},
+			},
+		},
+		{
+			name: "multiple admin acks found",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description.",
+					"ack-4.8-foo": "Description foo.",
+					"ack-4.8-bar": "Description bar."},
+			},
+			ackCm: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "admin-acks",
+				Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "true",
+					"ack-4.8-bar": "true",
+					"ack-4.8-foo": "true"}},
+			expectedResult: &upgradeable{},
+		},
+		// delete tests are last so we don't have to re-create the config map for other tests
+		{
+			name: "admin-acks configmap not found",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-gates",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description."},
+			},
+			// Name triggers deletion of config map
+			ackCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "delete",
+					Namespace: "test"}, Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "true"},
+			},
+			expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "UnableToAccessAdminAcksConfigMap",
+					Message: "admin-acks configmap not found."}},
+			},
+		},
+		// delete tests are last so we don't have to re-create the config map for other tests
+		{
+			name: "admin-gates configmap not found",
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				release: configv1.Release{
+					Version: "v4.8.0",
+					Image:   "image/image:v4.8.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+							Overrides: []configv1.ComponentOverride{{
+								Unmanaged: false,
+							}},
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Version: "4.8.0"},
+							},
+						},
+					},
+				),
+			},
+			// Name triggers deletion of config map
+			gateCm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "delete",
+					Namespace: "test"},
+				Data: map[string]string{"ack-4.8-kube-122-api-removals-in-4.9": "Description."},
+			},
+			ackCm: nil,
+			expectedResult: &upgradeable{
+				Conditions: []configv1.ClusterOperatorStatusCondition{{
+					Type:    configv1.OperatorUpgradeable,
+					Status:  configv1.ConditionFalse,
+					Reason:  "UnableToAccessAdminGatesConfigMap",
+					Message: "admin-gates configmap not found."}},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcherStarted := make(chan struct{})
+	f := kfake.NewSimpleClientset()
+
+	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
+	f.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := f.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	cms := make(chan *corev1.ConfigMap, 1)
+	configManagedInformer := informers.NewSharedInformerFactory(f, 0)
+	cmInformerLister := configManagedInformer.Core().V1().ConfigMaps()
+	cmInformer := configManagedInformer.Core().V1().ConfigMaps().Informer()
+	cmInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			cm := obj.(*corev1.ConfigMap)
+			t.Logf("cm added: %s/%s", cm.Namespace, cm.Name)
+			cms <- cm
+		},
+		DeleteFunc: func(obj interface{}) {
+			cm := obj.(*corev1.ConfigMap)
+			t.Logf("cm deleted: %s/%s", cm.Namespace, cm.Name)
+			cms <- cm
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			cm := newObj.(*corev1.ConfigMap)
+			t.Logf("cm updated: %s/%s", cm.Namespace, cm.Name)
+			cms <- cm
+		},
+	})
+	configManagedInformer.Start(ctx.Done())
+
+	_, err := f.CoreV1().ConfigMaps("test").Create(ctx, &defaultGateCm, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("error injecting admin-gates configmap: %v", err)
+	}
+	waitForCm(t, cms)
+	_, err = f.CoreV1().ConfigMaps("test").Create(ctx, &defaultAckCm, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("error injecting admin-acks configmap: %v", err)
+	}
+	waitForCm(t, cms)
+
+	for _, tt := range tests {
+		{
+			t.Run(tt.name, func(t *testing.T) {
+				optr := tt.optr
+				optr.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+				optr.proxyLister = &clientProxyLister{client: optr.client}
+				optr.coLister = &clientCOLister{client: optr.client}
+				optr.cvLister = &clientCVLister{client: optr.client}
+				optr.cmConfigManagedLister = cmInformerLister.Lister().ConfigMaps("test")
+				optr.cmConfigLister = cmInformerLister.Lister().ConfigMaps("test")
+
+				optr.upgradeableChecks = optr.defaultUpgradeableChecks()
+
+				// This Upgradeable check must be added here since it is not active in 4.9 but present to allow
+				// back port to 4.8 where it will first become active.
+				optr.upgradeableChecks = append(optr.upgradeableChecks,
+					&clusterAdminAcksCompletedUpgradeable{optr.cmConfigManagedLister, optr.cmConfigLister, optr.cvLister, optr.name})
+
+				optr.eventRecorder = record.NewFakeRecorder(100)
+
+				if tt.gateCm != nil {
+					if tt.gateCm.Name == "delete" {
+						err := f.CoreV1().ConfigMaps("test").Delete(ctx, "admin-gates", metav1.DeleteOptions{})
+						if err != nil {
+							t.Errorf("error deleting configmap admin-gates: %v", err)
+						}
+					} else {
+						_, err = f.CoreV1().ConfigMaps("test").Update(ctx, tt.gateCm, metav1.UpdateOptions{})
+						if err != nil {
+							t.Errorf("error updating configmap admin-gates: %v", err)
+						}
+					}
+					waitForCm(t, cms)
+				}
+				if tt.ackCm != nil {
+					if tt.ackCm.Name == "delete" {
+						err := f.CoreV1().ConfigMaps("test").Delete(ctx, "admin-acks", metav1.DeleteOptions{})
+						if err != nil {
+							t.Errorf("error deleting configmap admin-acks: %v", err)
+						}
+					} else {
+						_, err = f.CoreV1().ConfigMaps("test").Update(ctx, tt.ackCm, metav1.UpdateOptions{})
+						if err != nil {
+							t.Errorf("error updating configmap admin-acks: %v", err)
+						}
+					}
+					waitForCm(t, cms)
+				}
+
+				err = optr.upgradeableSync(ctx, optr.queueKey())
+				if err != nil && tt.wantErr == nil {
+					t.Fatalf("Operator.sync() unexpected error: %v", err)
+				}
+				if err != nil {
+					return
+				}
+
+				if optr.upgradeable != nil {
+					optr.upgradeable.At = time.Time{}
+					for i := range optr.upgradeable.Conditions {
+						optr.upgradeable.Conditions[i].LastTransitionTime = metav1.Time{}
+					}
+				}
+
+				if !reflect.DeepEqual(optr.upgradeable, tt.expectedResult) {
+					t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(tt.expectedResult, optr.upgradeable))
+				}
+				if (optr.queue.Len() > 0) != (optr.upgradeable != nil) {
+					t.Fatalf("unexpected queue")
+				}
+			})
+		}
+	}
+}
+
+func Test_gateApplicableToCurrentVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		gateName       string
+		cv             string
+		wantErr        bool
+		expectedResult bool
+	}{
+		{
+			name:           "gate name invalid format no dot",
+			gateName:       "ack-4>8-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format 2 dots",
+			gateName:       "ack-4..8-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format does not start with ack",
+			gateName:       "ck-4.8-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format major version must be 4 or 5",
+			gateName:       "ack-3.8-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format minor version must be a number",
+			gateName:       "ack-4.x-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format no following dash",
+			gateName:       "ack-4.8.1-foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format 2 following dashes",
+			gateName:       "ack-4.x--foo",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name invalid format no description following dash",
+			gateName:       "ack-4.x-",
+			cv:             "4.8.1",
+			wantErr:        true,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name match",
+			gateName:       "ack-4.8-foo",
+			cv:             "4.8.1",
+			wantErr:        false,
+			expectedResult: true,
+		},
+		{
+			name:           "gate name match big minor version",
+			gateName:       "ack-4.123456-foo",
+			cv:             "4.123456",
+			wantErr:        false,
+			expectedResult: true,
+		},
+		{
+			name:           "gate name no match",
+			gateName:       "ack-4.8-foo",
+			cv:             "4.9.1",
+			wantErr:        false,
+			expectedResult: false,
+		},
+		{
+			name:           "gate name no match multi digit minor",
+			gateName:       "ack-4.8-foo",
+			cv:             "4.80.1",
+			wantErr:        false,
+			expectedResult: false,
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			optr := tt.optr
-			optr.queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-			optr.proxyLister = &clientProxyLister{client: optr.client}
-			optr.coLister = &clientCOLister{client: optr.client}
-			optr.cvLister = &clientCVLister{client: optr.client}
-			optr.upgradeableChecks = optr.defaultUpgradeableChecks()
-			optr.eventRecorder = record.NewFakeRecorder(100)
-
-			ctx := context.Background()
-			err := optr.upgradeableSync(ctx, optr.queueKey())
-			if err != nil && tt.wantErr == nil {
-				t.Fatalf("Operator.sync() unexpected error: %v", err)
-			}
-			if err != nil {
-				return
-			}
-
-			if optr.upgradeable != nil {
-				optr.upgradeable.At = time.Time{}
-				for i := range optr.upgradeable.Conditions {
-					optr.upgradeable.Conditions[i].LastTransitionTime = metav1.Time{}
+		{
+			t.Run(tt.name, func(t *testing.T) {
+				isApplicable, err := gateApplicableToCurrentVersion(tt.gateName, tt.cv)
+				if err != nil && !tt.wantErr {
+					t.Fatalf("gateApplicableToCurrentVersion() unexpected error: %v", err)
 				}
-			}
-
-			if !reflect.DeepEqual(optr.upgradeable, tt.want) {
-				t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(tt.want, optr.upgradeable))
-			}
-			if (optr.queue.Len() > 0) != (optr.upgradeable != nil) {
-				t.Fatalf("unexpected queue")
-			}
-		})
+				if err != nil {
+					return
+				}
+				if isApplicable && !tt.expectedResult {
+					t.Fatalf("gateApplicableToCurrentVersion() %s should not apply", tt.gateName)
+				}
+			})
+		}
 	}
 }
 
@@ -3663,19 +4381,19 @@ func makeTestClient(cvs ...configv1.ClusterVersion) *fake.Clientset {
 }
 func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 	tests := []struct {
-		name          string
-		cvName        string
-		want          *configv1.ClusterVersion
-		cvs           []configv1.ClusterVersion
-		enableDefault bool
-		changed       bool
+		name           string
+		cvName         string
+		expectedResult *configv1.ClusterVersion
+		cvs            []configv1.ClusterVersion
+		enableDefault  bool
+		changed        bool
 	}{
 		{
-			name:          "no existing cluster version",
-			cvName:        "version",
-			want:          &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
-			enableDefault: true,
-			changed:       true,
+			name:           "no existing cluster version",
+			cvName:         "version",
+			expectedResult: &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
+			enableDefault:  true,
+			changed:        true,
 		},
 		{
 			name:   "existing cluster version",
@@ -3683,8 +4401,8 @@ func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 			cvs: []configv1.ClusterVersion{
 				{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
 			},
-			want:          &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
-			enableDefault: true,
+			expectedResult: &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
+			enableDefault:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -3701,8 +4419,8 @@ func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 			}
 			// ignore ClusterVersion spec
 			cv.Spec = configv1.ClusterVersionSpec{}
-			if !reflect.DeepEqual(cv, tt.want) {
-				t.Errorf("expected does not match %v", cmp.Diff(cv, tt.want))
+			if !reflect.DeepEqual(cv, tt.expectedResult) {
+				t.Errorf("expected does not match %v", cmp.Diff(cv, tt.expectedResult))
 			}
 			if changed != tt.changed {
 				t.Errorf("Expected change: %t, got: %t", tt.changed, changed)

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -2,6 +2,7 @@ package cvo
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -9,27 +10,46 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-version-operator/lib/resourcedelete"
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
+	"github.com/openshift/cluster-version-operator/pkg/internal"
+	"github.com/openshift/cluster-version-operator/pkg/payload/precondition/clusterversion"
 )
+
+const (
+	adminAckGateFmt             string = "^ack-[4-5][.]([0-9]{1,})-[^-]"
+	upgradeableAdminAckRequired        = configv1.ClusterStatusConditionType("UpgradeableAdminAckRequired")
+)
+
+var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 
 // syncUpgradeable. The status is only checked if it has been more than
 // the minimumUpdateCheckInterval since the last check.
-func (optr *Operator) syncUpgradeable(config *configv1.ClusterVersion) error {
+func (optr *Operator) syncUpgradeable() error {
 	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
 	u := optr.getUpgradeable()
 	if u != nil && u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
 		klog.V(4).Infof("Upgradeable conditions were recently checked, will try later.")
 		return nil
 	}
+	optr.setUpgradeableConditions()
 
+	// requeue
+	optr.queue.Add(optr.queueKey())
+	return nil
+}
+
+func (optr *Operator) setUpgradeableConditions() {
 	now := metav1.Now()
 	var conds []configv1.ClusterOperatorStatusCondition
 	var reasons []string
@@ -61,9 +81,6 @@ func (optr *Operator) syncUpgradeable(config *configv1.ClusterVersion) error {
 	optr.setUpgradeable(&upgradeable{
 		Conditions: conds,
 	})
-	// requeue
-	optr.queue.Add(optr.queueKey())
-	return nil
 }
 
 type upgradeable struct {
@@ -234,10 +251,191 @@ func (check *clusterManifestDeleteInProgressUpgradeable) Check() *configv1.Clust
 	return nil
 }
 
+func gateApplicableToCurrentVersion(gateName string, currentVersion string) (bool, error) {
+	var applicable bool
+	if ackVersion := adminAckGateRegexp.FindString(gateName); ackVersion == "" {
+		return false, fmt.Errorf("%s configmap gate name %s has invalid format; must comply with %q.",
+			internal.AdminGatesConfigMap, gateName, adminAckGateFmt)
+	} else {
+		parts := strings.Split(ackVersion, "-")
+		ackMinor := clusterversion.GetEffectiveMinor(parts[1])
+		cvMinor := clusterversion.GetEffectiveMinor(currentVersion)
+		if ackMinor == cvMinor {
+			applicable = true
+		}
+	}
+	return applicable, nil
+}
+
+func checkAdminGate(gateName string, gateValue string, currentVersion string,
+	ackConfigmap *corev1.ConfigMap) (string, string) {
+
+	if applies, err := gateApplicableToCurrentVersion(gateName, currentVersion); err == nil {
+		if !applies {
+			return "", ""
+		}
+	} else {
+		klog.Error(err)
+		return "AdminAckConfigMapGateNameError", err.Error()
+	}
+	if gateValue == "" {
+		message := fmt.Sprintf("%s configmap gate %s must contain a non-empty value.", internal.AdminGatesConfigMap, gateName)
+		klog.Error(message)
+		return "AdminAckConfigMapGateValueError", message
+	}
+	if val, ok := ackConfigmap.Data[gateName]; !ok || val != "true" {
+		return "AdminAckRequired", gateValue
+	}
+	return "", ""
+}
+
+type clusterAdminAcksCompletedUpgradeable struct {
+	adminGatesLister listerscorev1.ConfigMapNamespaceLister
+	adminAcksLister  listerscorev1.ConfigMapNamespaceLister
+	cvLister         configlistersv1.ClusterVersionLister
+	cvoName          string
+}
+
+func (check *clusterAdminAcksCompletedUpgradeable) Check() *configv1.ClusterOperatorStatusCondition {
+	cv, err := check.cvLister.Get(check.cvoName)
+	if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+		message := fmt.Sprintf("Unable to get ClusterVersion, err=%v.", err)
+		klog.Error(message)
+		return &configv1.ClusterOperatorStatusCondition{
+			Type:    upgradeableAdminAckRequired,
+			Status:  configv1.ConditionFalse,
+			Reason:  "UnableToGetClusterVersion",
+			Message: message,
+		}
+	}
+	currentVersion := clusterversion.GetCurrentVersion(cv.Status.History)
+
+	// This can occur in early start up when the configmap is first added and version history
+	// has not yet been populated.
+	if currentVersion == "" {
+		return nil
+	}
+
+	var gateCm *corev1.ConfigMap
+	if gateCm, err = check.adminGatesLister.Get(internal.AdminGatesConfigMap); err != nil {
+		var message string
+		if apierrors.IsNotFound(err) {
+			message = fmt.Sprintf("%s configmap not found.", internal.AdminGatesConfigMap)
+		} else if err != nil {
+			message = fmt.Sprintf("Unable to access configmap %s, err=%v.", internal.AdminGatesConfigMap, err)
+		}
+		klog.Error(message)
+		return &configv1.ClusterOperatorStatusCondition{
+			Type:    upgradeableAdminAckRequired,
+			Status:  configv1.ConditionFalse,
+			Reason:  "UnableToAccessAdminGatesConfigMap",
+			Message: message,
+		}
+	}
+	var ackCm *corev1.ConfigMap
+	if ackCm, err = check.adminAcksLister.Get(internal.AdminAcksConfigMap); err != nil {
+		var message string
+		if apierrors.IsNotFound(err) {
+			message = fmt.Sprintf("%s configmap not found.", internal.AdminAcksConfigMap)
+		} else if err != nil {
+			message = fmt.Sprintf("Unable to access configmap %s, err=%v.", internal.AdminAcksConfigMap, err)
+		}
+		klog.Error(message)
+		return &configv1.ClusterOperatorStatusCondition{
+			Type:    upgradeableAdminAckRequired,
+			Status:  configv1.ConditionFalse,
+			Reason:  "UnableToAccessAdminAcksConfigMap",
+			Message: message,
+		}
+	}
+	reasons := make(map[string][]string)
+	for k, v := range gateCm.Data {
+		if reason, message := checkAdminGate(k, v, currentVersion, ackCm); reason != "" {
+			reasons[reason] = append(reasons[reason], message)
+		}
+	}
+	var reason string
+	var messages []string
+	for k, v := range reasons {
+		reason = k
+		sort.Strings(v)
+		messages = append(messages, strings.Join(v, " "))
+	}
+	if len(reasons) == 1 {
+		return &configv1.ClusterOperatorStatusCondition{
+			Type:    upgradeableAdminAckRequired,
+			Status:  configv1.ConditionFalse,
+			Reason:  reason,
+			Message: messages[0],
+		}
+	} else if len(reasons) > 1 {
+		sort.Strings(messages)
+		return &configv1.ClusterOperatorStatusCondition{
+			Type:    upgradeableAdminAckRequired,
+			Status:  configv1.ConditionFalse,
+			Reason:  "MultipleReasons",
+			Message: strings.Join(messages, " "),
+		}
+	}
+	return nil
+}
+
+// Since there are no admin ack gates in this initial release the Upgradeable check
+// clusterAdminAcksCompletedUpgradeable is not included.
 func (optr *Operator) defaultUpgradeableChecks() []upgradeableCheck {
 	return []upgradeableCheck{
 		&clusterOperatorsUpgradeable{coLister: optr.coLister},
 		&clusterVersionOverridesUpgradeable{name: optr.name, cvLister: optr.cvLister},
 		&clusterManifestDeleteInProgressUpgradeable{},
+	}
+}
+
+func (optr *Operator) addFunc(obj interface{}) {
+	cm := obj.(*corev1.ConfigMap)
+	if cm.Name == internal.AdminGatesConfigMap || cm.Name == internal.AdminAcksConfigMap {
+		klog.V(4).Infof("ConfigMap %s/%s added.", cm.Namespace, cm.Name)
+		// When clusterAdminAcksCompletedUpgradeable upgardeable check added we will call
+		// optr.setUpgradeableConditions() here
+	}
+}
+
+func (optr *Operator) updateFunc(oldObj, newObj interface{}) {
+	cm := newObj.(*corev1.ConfigMap)
+	if cm.Name == internal.AdminGatesConfigMap || cm.Name == internal.AdminAcksConfigMap {
+		oldCm := oldObj.(*corev1.ConfigMap)
+		if !equality.Semantic.DeepEqual(cm, oldCm) {
+			klog.V(4).Infof("ConfigMap %s/%s updated.", cm.Namespace, cm.Name)
+			// When clusterAdminAcksCompletedUpgradeable upgardeable check added we will call
+			// optr.setUpgradeableConditions() here
+		}
+	}
+}
+
+func (optr *Operator) deleteFunc(obj interface{}) {
+	cm := obj.(*corev1.ConfigMap)
+	if cm.Name == internal.AdminGatesConfigMap || cm.Name == internal.AdminAcksConfigMap {
+		klog.V(4).Infof("ConfigMap %s/%s deleted.", cm.Namespace, cm.Name)
+		// When clusterAdminAcksCompletedUpgradeable upgardeable check added we will call
+		// optr.setUpgradeableConditions() here
+	}
+}
+
+// adminAcksEventHandler handles changes to the admin-acks configmap by re-assessing all
+// Upgradeable conditions.
+func (optr *Operator) adminAcksEventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    optr.addFunc,
+		UpdateFunc: optr.updateFunc,
+		DeleteFunc: optr.deleteFunc,
+	}
+}
+
+// adminGatesEventHandler handles changes to the admin-gates configmap by re-assessing all
+// Upgradeable conditions.
+func (optr *Operator) adminGatesEventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    optr.addFunc,
+		UpdateFunc: optr.updateFunc,
+		DeleteFunc: optr.deleteFunc,
 	}
 }

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -3,6 +3,8 @@ package internal
 const (
 	ConfigNamespace        = "openshift-config"
 	ConfigManagedNamespace = "openshift-config-managed"
+	AdminGatesConfigMap    = "admin-gates"
+	AdminAcksConfigMap     = "admin-acks"
 	InstallerConfigMap     = "openshift-install"
 	ManifestsConfigMap     = "openshift-install-manifests"
 )

--- a/pkg/payload/precondition/clusterversion/upgradable_test.go
+++ b/pkg/payload/precondition/clusterversion/upgradable_test.go
@@ -45,7 +45,7 @@ func TestGetEffectiveMinor(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getEffectiveMinor(tc.input)
+			actual := GetEffectiveMinor(tc.input)
 			if tc.expected != actual {
 				t.Error(actual)
 			}

--- a/pkg/payload/precondition/clusterversion/upgradeable.go
+++ b/pkg/payload/precondition/clusterversion/upgradeable.go
@@ -78,9 +78,9 @@ func (pf *Upgradeable) Run(ctx context.Context, releaseContext precondition.Rele
 		return nil
 	}
 
-	currentVersion := getCurrentVersion(cv.Status.History)
-	currentMinor := getEffectiveMinor(currentVersion)
-	desiredMinor := getEffectiveMinor(releaseContext.DesiredVersion)
+	currentVersion := GetCurrentVersion(cv.Status.History)
+	currentMinor := GetEffectiveMinor(currentVersion)
+	desiredMinor := GetEffectiveMinor(releaseContext.DesiredVersion)
 	klog.V(5).Infof("currentMinor %s releaseContext.DesiredVersion %s desiredMinor %s", currentMinor, releaseContext.DesiredVersion, desiredMinor)
 
 	// if there is no difference in the minor version (4.y.z where 4.y is the same for current and desired), then we can still upgrade
@@ -111,23 +111,27 @@ func (pf *Upgradeable) Run(ctx context.Context, releaseContext precondition.Rele
 // Name returns Name for the precondition.
 func (pf *Upgradeable) Name() string { return "ClusterVersionUpgradeable" }
 
-// getCurrentVersion determines and returns the cluster's current version by iterating through the
+// GetCurrentVersion determines and returns the cluster's current version by iterating through the
 // provided update history until it finds the first version with update State of Completed. If a
 // Completed version is not found the version of the oldest history entry, which is the originally
-// installed version, is returned.
-func getCurrentVersion(history []configv1.UpdateHistory) string {
+// installed version, is returned. If history is empty the empty string is returned.
+func GetCurrentVersion(history []configv1.UpdateHistory) string {
 	for _, h := range history {
 		if h.State == configv1.CompletedUpdate {
 			klog.V(5).Infof("Cluster current version=%s", h.Version)
 			return h.Version
 		}
 	}
-	return history[len(history)-1].Version
+	// Empty history should only occur if method is called early in startup before history is populated.
+	if len(history) != 0 {
+		return history[len(history)-1].Version
+	}
+	return ""
 }
 
-// getEffectiveMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
+// GetEffectiveMinor attempts to do a simple parse of the version provided.  If it does not parse, the value is considered
 // empty string, which works for the comparison done here for equivalence.
-func getEffectiveMinor(version string) string {
+func GetEffectiveMinor(version string) string {
 	splits := strings.Split(version, ".")
 	if len(splits) < 2 {
 		return ""


### PR DESCRIPTION
This PR adds a generic upgrade blocking mechanism for blocking minor level upgrades. It is the general implementation of the [Add admin ack upgrade gate enhancement](https://github.com/openshift/enhancements/pull/828). Therefore since 4.9 does not contain any active admin ack gates the check `clusterAdminAcksCompletedUpgradeable` is not added to `defaultUpgradeableChecks`. It is added as part of unit test and tested.

This PR will be backported to 4.8.z and the 4.8 specific implementation details will be added, i.e. the `ack-4.8-kube-122-api-removals-in-4.9` gate will be added by adding check `clusterAdminAcksCompletedUpgradeable` to `defaultUpgradeableChecks`.

Once active the  `clusterAdminAcksCompletedUpgradeable` Upgradeable check implementation differs from other Upgradeable checks by also being synchronously triggered when either configmap admin-gates or admin-acks is added, updated, or deleted. This will be achieved by adding an event handler to the `cmConfigInformer` and `cmConfigManagedInformer` Informers. The event handlers will simply invoke `setUpgradeableConditions` to ensure all conditions are properly evaluated. Since the check will be added as a default Upgradeable check when active it will also be evaluated during the existing periodic polling of Upgradeable conditions.
 
I also removed the unused parameter `config` from `cvo.syncUpgradeable`.