### PR TITLE
Bug 1985802: Updating the lease, renew, retry duration

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -44,13 +44,9 @@ const (
 
 	minResyncPeriod = 2 * time.Minute
 
-	// TODO set the slower lease values after we're able to reliably shut down gracefully.  This fixes the slow status update for now.
-	//leaseDuration = 90 * time.Second
-	//renewDeadline = 45 * time.Second
-	//retryPeriod   = 30 * time.Second
-	leaseDuration = 30 * time.Second
-	renewDeadline = 15 * time.Second
-	retryPeriod   = 10 * time.Second
+	leaseDuration = 137 * time.Second
+	renewDeadline = 107 * time.Second
+	retryPeriod   = 26 * time.Second
 )
 
 // Options are the valid inputs to starting the CVO.


### PR DESCRIPTION
As per [1]
[1] https://github.com/openshift/library-go/blob/4b9033d00d37b88393f837a88ff541a56fd13621/pkg/config/leaderelection/leaderelection.go#L84

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>