### PR TITLE
Bug 1991010: pkg/cvo/metrics: Ignore Degraded for cluster_operator_up

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -82,7 +82,11 @@ spec:
       annotations:
         message: Cluster operator {{ "{{ $labels.name }}" }} has been degraded for 30 minutes. Operator is degraded because {{ "{{ $labels.reason }}" }} and cluster upgrades will be unstable.
       expr: |
-        cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"} == 1
+        (
+          cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"}
+          or on (name)
+          group by (name) (cluster_operator_up{job="cluster-version-operator"})
+        ) == 1
       for: 30m
       labels:
         severity: warning

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -375,9 +375,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 			klog.V(4).Infof("ClusterOperator %s is not setting the 'operator' version", op.Name)
 		}
 		g := m.clusterOperatorUp.WithLabelValues(op.Name, version)
-		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorDegraded)
-		available := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable)
-		if available && !failing {
+		if resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable) {
 			g.Set(1)
 		} else {
 			g.Set(0)

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -364,13 +364,17 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 	// output cluster operator version and condition info
 	operators, _ := m.optr.coLister.List(labels.Everything())
 	for _, op := range operators {
-		// TODO: when we define how version works, report the appropriate version
-		var firstVersion string
+		var version string
 		for _, v := range op.Status.Versions {
-			firstVersion = v.Version
-			break
+			if v.Name == "operator" {
+				version = v.Version
+				break
+			}
 		}
-		g := m.clusterOperatorUp.WithLabelValues(op.Name, firstVersion)
+		if version == "" {
+			klog.V(4).Infof("ClusterOperator %s is not setting the 'operator' version", op.Name)
+		}
+		g := m.clusterOperatorUp.WithLabelValues(op.Name, version)
 		failing := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorDegraded)
 		available := resourcemerge.IsOperatorStatusConditionTrue(op.Status.Conditions, configv1.OperatorAvailable)
 		if available && !failing {

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -180,8 +180,8 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 							},
 							Status: configv1.ClusterOperatorStatus{
 								Versions: []configv1.OperandVersion{
-									{Version: "10.1.5-1"},
-									{Version: "10.1.5-2"},
+									{Name: "operator", Version: "10.1.5-1"},
+									{Name: "operand", Version: "10.1.5-2"},
 								},
 								Conditions: []configv1.ClusterOperatorStatusCondition{
 									{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},


### PR DESCRIPTION
Bringing #550 back to 4.7.  By hand, since there are neighbor-line conflicts with #587, which landed first in 4.7, but is backported from changes that landed later in master/4.8.