### PR TITLE
pkg/cvo: Drop the explicit 'upstream' from our replacement ClusterVersion

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -661,11 +661,6 @@ func (optr *Operator) getOrCreateClusterVersion(ctx context.Context, enableDefau
 		return nil, false, nil
 	}
 
-	var upstream configv1.URL
-	if len(optr.defaultUpstreamServer) > 0 {
-		u := configv1.URL(optr.defaultUpstreamServer)
-		upstream = u
-	}
 	id, _ := uuid.NewRandom()
 
 	// XXX: generate ClusterVersion from options calculated above.
@@ -674,7 +669,6 @@ func (optr *Operator) getOrCreateClusterVersion(ctx context.Context, enableDefau
 			Name: optr.name,
 		},
 		Spec: configv1.ClusterVersionSpec{
-			Upstream:  upstream,
 			Channel:   "fast",
 			ClusterID: configv1.ClusterID(id.String()),
 		},


### PR DESCRIPTION
Hopefully we never actually have to stuff a CVO-generated ClusterVersion into the cluster; it's just for recovery after admins accidentally delete their existing ClusterVersion.  But if we ever do hit this code, we want to push it without `spec.upstream`, to allow later ClusterVersion-consuming code to say "ah, user doesn't care which upstream I use, so I'll use the best default I'm aware of". This effectively pushes default choice from the CVO that creates the ClusterVersion out to the CVO that consumes the ClusterVersion, and that later CVO is almost certainly more current on which default is best.

Similar to openshift/installer@c9095b3451 (openshift/installer#4112).