### PR TITLE
pkg/cvo/availableupdates: Expose upstream URI in RetrievedUpdates=True

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -236,9 +236,10 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, tran
 	}
 
 	return cvoCurrent, cvoUpdates, configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.RetrievedUpdates,
-		Status: configv1.ConditionTrue,
-
+		Type:               configv1.RetrievedUpdates,
+		Status:             configv1.ConditionTrue,
+		Reason:             "AsExpected",
+		Message:            fmt.Sprintf("Successfully retrieved updates from %s", upstream),
 		LastTransitionTime: metav1.Now(),
 	}
 }

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2540,6 +2540,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:   configv1.RetrievedUpdates,
 					Status: configv1.ConditionTrue,
+					Reason: "AsExpected",
 				},
 			},
 		},
@@ -2603,6 +2604,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:   configv1.RetrievedUpdates,
 					Status: configv1.ConditionTrue,
+					Reason: "AsExpected",
 				},
 			},
 		},
@@ -2670,6 +2672,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				}
 				if optr.availableUpdates != nil && optr.availableUpdates.Upstream == "http://localhost:8080/graph" {
 					optr.availableUpdates.Upstream = s.URL
+				}
+				if tt.wantUpdates != nil && tt.wantUpdates.Condition.Status == configv1.ConditionTrue {
+					tt.wantUpdates.Condition.Message = fmt.Sprintf("Successfully retrieved updates from %s", s.URL)
 				}
 			}
 			old := optr.availableUpdates


### PR DESCRIPTION
So folks can easily see where we're getting the data from, even if `spec.upstream` is unset.  I'm not including the proxy information, because that's all calculated in other layers, and it may contain sensitive information like proxy-connection credentials.  We don't have to worry about sensitive information in the upstream URI, because our default value is in public code, and any sensitive information from `spec.upstream` is already in the ClusterVersion object where we're putting this message.