### PR TITLE
Bug 1997596: install/0000_90_cluster-version-operator_02_servicemonitor: Trim labels for UpdateAvailable

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
         summary: Your upstream update recommendation service recommends you update your cluster.
         description: For more information refer to 'oc adm upgrade'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
       expr: |
-        cluster_version_available_updates > 0
+        sum by (channel,upstream) (cluster_version_available_updates) > 0
       labels:
         severity: info
   - name: cluster-operators


### PR DESCRIPTION
These are the only two labels we set on the metric, but the Prometheus scraper adds some more, like `job`, `namespace`, `pod`, etc., to describe who was scraping what.  Reducing to the labels we care about avoids [annoying re-triggers][1], e.g. the CVO pod changes.  With this change, folks will be able to use a single silence per `channel`/`upstream` tuple.

I could even see stripping all the labels, but folks who care enough to bump their channel or upstream are presumably interested in hearing about available updates, at least for a while, so having them re-silence if they go back to not caring doesn't sound that tedious.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1997596