### PR TITLE
Bug 1978376: pkg/cvo/upgradeable: Enable admin-ack logic

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -3756,12 +3756,6 @@ func TestOperator_upgradeableSync(t *testing.T) {
 				optr.cmConfigLister = cmInformerLister.Lister().ConfigMaps("test")
 
 				optr.upgradeableChecks = optr.defaultUpgradeableChecks()
-
-				// This Upgradeable check must be added here since it is not active in 4.9 but present to allow
-				// back port to 4.8 where it will first become active.
-				optr.upgradeableChecks = append(optr.upgradeableChecks,
-					&clusterAdminAcksCompletedUpgradeable{optr.cmConfigManagedLister, optr.cmConfigLister, optr.cvLister, optr.name})
-
 				optr.eventRecorder = record.NewFakeRecorder(100)
 
 				if tt.gateCm != nil {


### PR DESCRIPTION
519b466793 (#633) had these commented out, because 4.9 has no built-in acks.  But with the code commented out, it's [hard to verify][1] that the logic works in 4.9 before backporting to 4.8.  Enabling these checks should be a no-op outside of verification, because admins are unlikely to inject additional keys in the `openshift-config-managed` namespace's `admin-gates` ConfigMap.  And it allows us to verify the logic in 4.9 and cook there with live code before approving the 4.8 backports.  It's also one less thing we might forget before enabling new admin acks in future versions, like 4.10 or later.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1978376#c19