### PR TITLE
install/0000_00_cluster-version-operator_03_deployment: Set dnsPolicy: ClusterFirstWithHostNet

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -39,6 +39,7 @@ spec:
             fieldPath: spec.nodeName
       - name: CLUSTER_PROFILE
         value: {{ .ClusterProfile }}
+  dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
   terminationGracePeriodSeconds: 130
   volumes:

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -59,6 +59,7 @@ spec:
                 fieldPath: spec.nodeName
           - name: CLUSTER_PROFILE
             value: {{ .ClusterProfile }}
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
From [upstream docs][1]:

> For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".

[The type definitions include][2]:

* `ClusterFirstWithHostNet`, using cluster DNS, and falling back to kubelet defaults.
* `Default`, using kubelet defaults alone.
* `ClusterFirst`, which acts like `Default` with `hostNetwork:true` (bizarrely not including cluster DNS at all, despite including `Cluster` in the name), but like `ClusterFirstWithHostNet` otherwise.

There's also some discussion in [rhbz#1880902][3].

[1]: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
[2]: https://github.com/kubernetes/kubernetes/blob/f0b7ad3ee06c5168fef5fa4f01fe445ece595f89/pkg/apis/core/types.go#L2396-L2408
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1880902