### PR TITLE
Adding seed to make rand.Float64() return random values

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -19,6 +21,9 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			// To help debugging, immediately log version
 			klog.Info(version.String)
+
+			//Setting seed for all the calls to rand methods in the code
+			rand.Seed(time.Now().UnixNano())
 
 			if err := opts.Run(context.Background()); err != nil {
 				klog.Fatalf("error: %v", err)


### PR DESCRIPTION
Without different seed values in rand.Seed(), rand.Float64() does not return random values

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>