### PR TITLE
Bug 2005581: install/0000_00_cluster-version-operator_03_deployment: Explicit kube-api-access

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         k8s-app: cluster-version-operator
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
         image: {{.ReleaseImage}}
@@ -47,6 +48,9 @@ spec:
             readOnly: true
           - mountPath: /etc/tls/serving-cert
             name: serving-cert
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
             readOnly: true
         env:
           - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
@@ -92,3 +96,21 @@ spec:
         - name: serving-cert
           secret:
             secretName: cluster-version-operator-serving-cert
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace


### PR DESCRIPTION
[This content][2] is [injected by an admission webhook][1].  When we started removing not-in-manifest volumes in 83faa6e716 (#654), the cluster-version operator started removing the webhook-injected volume, leading to the cluster-version operator crash-looping on updates from 4.8 to 4.9 with messages [like][3]:

    F0920 13:23:23.565439       1 start.go:24] error: error creating clients: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable

With this commit, we follow the precedent of the Kubernetes API server's own manifest: openshift/cluster-kube-apiserver-operator#1142.

[1]: https://github.com/kubernetes/kubernetes/blob/2f68346fbb6246961ce0a3176418630950aea500/plugin/pkg/admission/serviceaccount/admission.go#L53-L54
[2]: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2005581