### PR TITLE
Bug 2006145: install/0000_00_cluster-version-operator_03_deployment: Explicit kube-api-access

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         k8s-app: cluster-version-operator
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
         image: {{.ReleaseImage}}
@@ -47,6 +48,9 @@ spec:
             readOnly: true
           - mountPath: /etc/tls/serving-cert
             name: serving-cert
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
             readOnly: true
         env:
           - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
@@ -92,3 +96,21 @@ spec:
         - name: serving-cert
           secret:
             secretName: cluster-version-operator-serving-cert
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace


### PR DESCRIPTION
Backporting #660 to 4.9.