### PR TITLE
.ci-operator: Bump to Go 1.16

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.15
+  tag: golang-1.16


### PR DESCRIPTION
This is [ART's default for OpenShift 4.10][1], and we need [1.16's new `io/fs` package][2] to [avoid][3]:

    INFO[2021-09-24T19:45:46Z] vendor/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go:21:2: cannot find package "." in:
    	/go/src/github.com/openshift/cluster-version-operator/vendor/io/fs

for the 1.22 Kube bumps needed for targeted edge blocking (#663).

[1]: https://github.com/openshift/ocp-build-data/blob/f14ea97fcb9893c325f12bed9d9afb9cd2f10857/streams.yml#L31
[2]: https://golang.org/doc/go1.16#fs
[3]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/663/pull-ci-openshift-cluster-version-operator-master-unit/1441488679963987968#1:build-log.txt%3A13