### PR TITLE
Unset listen option while running CVO locally [doc/dev]

### DIFF
--- a/docs/dev/run-cvo-locally.md
+++ b/docs/dev/run-cvo-locally.md
@@ -42,7 +42,7 @@ $ export PAYLOAD_OVERRIDE=/tmp/release/
 Run the CVO executable specifying `start`, the appropriate release image and, optionally, logging verbosity:
 
 ```console
-$ ./_output/linux/amd64/cluster-version-operator -v5 start --release-image 4.4.0-rc.4
+$ ./_output/linux/amd64/cluster-version-operator -v5 start --release-image 4.4.0-rc.4 --listen=""
 ```
 
 ## Limitations


### PR DESCRIPTION
Reference: https://github.com/openshift/cluster-version-operator/issues/666

As I am a newbie and trying to learn the CVO's flow, let me know, in case unsetting the `listen` doesn't make sense. Will be glad to hear some inputs. 