### PR TITLE
Bug 2011951: pkg/cvo/upgradeable: Include messages for multiple-reason Upgradeable=False

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -3110,7 +3110,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 					Type:    configv1.OperatorUpgradeable,
 					Status:  configv1.ConditionFalse,
 					Reason:  "MultipleReasons",
-					Message: "Cluster should not be upgraded between minor versions for multiple reasons: ClusterOperatorsNotUpgradeable,ClusterVersionOverridesSet",
+					Message: "Cluster should not be upgraded between minor versions for multiple reasons: ClusterVersionOverridesSet,ClusterOperatorsNotUpgradeable\n* Disabling ownership via cluster version overrides prevents upgrades. Please remove overrides before continuing.\n* Multiple cluster operators should not be upgraded between minor versions:\n* Cluster operator default-operator-1 should not be upgraded between minor versions: RandomReason: some random reason why upgrades are not safe.\n* Cluster operator default-operator-2 should not be upgraded between minor versions: RandomReason2: some random reason 2 why upgrades are not safe.",
 				}, {
 					Type:    "UpgradeableClusterOperators",
 					Status:  configv1.ConditionFalse,

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -53,9 +53,11 @@ func (optr *Operator) setUpgradeableConditions() {
 	now := metav1.Now()
 	var conds []configv1.ClusterOperatorStatusCondition
 	var reasons []string
+	var msgs []string
 	for _, check := range optr.upgradeableChecks {
 		if cond := check.Check(); cond != nil {
 			reasons = append(reasons, cond.Reason)
+			msgs = append(msgs, cond.Message)
 			cond.LastTransitionTime = now
 			conds = append(conds, *cond)
 		}
@@ -73,7 +75,7 @@ func (optr *Operator) setUpgradeableConditions() {
 			Type:               configv1.OperatorUpgradeable,
 			Status:             configv1.ConditionFalse,
 			Reason:             "MultipleReasons",
-			Message:            fmt.Sprintf("Cluster should not be upgraded between minor versions for multiple reasons: %s", strings.Join(reasons, ",")),
+			Message:            fmt.Sprintf("Cluster should not be upgraded between minor versions for multiple reasons: %s\n* %s", strings.Join(reasons, ","), strings.Join(msgs, "\n* ")),
 			LastTransitionTime: now,
 		})
 	}
@@ -382,6 +384,7 @@ func (check *clusterAdminAcksCompletedUpgradeable) Check() *configv1.ClusterOper
 
 func (optr *Operator) defaultUpgradeableChecks() []upgradeableCheck {
 	return []upgradeableCheck{
+		&clusterVersionOverridesUpgradeable{name: optr.name, cvLister: optr.cvLister},
 		&clusterAdminAcksCompletedUpgradeable{
 			adminGatesLister: optr.cmConfigManagedLister,
 			adminAcksLister:  optr.cmConfigLister,
@@ -389,7 +392,6 @@ func (optr *Operator) defaultUpgradeableChecks() []upgradeableCheck {
 			cvoName:          optr.name,
 		},
 		&clusterOperatorsUpgradeable{coLister: optr.coLister},
-		&clusterVersionOverridesUpgradeable{name: optr.name, cvLister: optr.cvLister},
 		&clusterManifestDeleteInProgressUpgradeable{},
 	}
 }


### PR DESCRIPTION
Backporting #670 to 4.9.