### PR TITLE
[release-4.9] Bug 2015024: lib/resourcemerge/imagestream.go: Copy all data for new tag reference

### DIFF
--- a/lib/resourcemerge/imagestream.go
+++ b/lib/resourcemerge/imagestream.go
@@ -21,13 +21,8 @@ func EnsureImagestreamv1(modified *bool, existing *imagev1.ImageStream, required
 		}
 		if existingCurr == nil {
 			*modified = true
-			existing.Spec.Tags = append(existing.Spec.Tags,
-				imagev1.TagReference{Name: required.Name,
-					From:            required.From,
-					Annotations:     required.Annotations,
-					Generation:      required.Generation,
-					ImportPolicy:    required.ImportPolicy,
-					ReferencePolicy: required.ReferencePolicy})
+			existing.Spec.Tags = append(existing.Spec.Tags, imagev1.TagReference{})
+			required.DeepCopyInto(&existing.Spec.Tags[len(existing.Spec.Tags)-1])
 		} else {
 			ensureTagReferencev1(modified, existingCurr, required)
 		}


### PR DESCRIPTION
Cherry-pick of #674 + #677 on release-4.9 branch