### PR TITLE
[release-4.8] Bug 2015025: lib/resourcemerge/imagestream.go: Copy all data for new tag reference

### DIFF
--- a/lib/resourcemerge/imagestream.go
+++ b/lib/resourcemerge/imagestream.go
@@ -21,13 +21,8 @@ func EnsureImagestreamv1(modified *bool, existing *imagev1.ImageStream, required
 		}
 		if existingCurr == nil {
 			*modified = true
-			existing.Spec.Tags = append(existing.Spec.Tags,
-				imagev1.TagReference{Name: required.Name,
-					From:            required.From,
-					Annotations:     required.Annotations,
-					Generation:      required.Generation,
-					ImportPolicy:    required.ImportPolicy,
-					ReferencePolicy: required.ReferencePolicy})
+			existing.Spec.Tags = append(existing.Spec.Tags, imagev1.TagReference{})
+			required.DeepCopyInto(&existing.Spec.Tags[len(existing.Spec.Tags)-1])
 		} else {
 			ensureTagReferencev1(modified, existingCurr, required)
 		}

--- a/lib/resourcemerge/imagestream.go
+++ b/lib/resourcemerge/imagestream.go
@@ -21,10 +21,16 @@ func EnsureImagestreamv1(modified *bool, existing *imagev1.ImageStream, required
 		}
 		if existingCurr == nil {
 			*modified = true
-			existing.Spec.Tags = append(existing.Spec.Tags, imagev1.TagReference{})
-			existingCurr = &existing.Spec.Tags[len(existing.Spec.Tags)-1]
+			existing.Spec.Tags = append(existing.Spec.Tags,
+				imagev1.TagReference{Name: required.Name,
+					From:            required.From,
+					Annotations:     required.Annotations,
+					Generation:      required.Generation,
+					ImportPolicy:    required.ImportPolicy,
+					ReferencePolicy: required.ReferencePolicy})
+		} else {
+			ensureTagReferencev1(modified, existingCurr, required)
 		}
-		ensureTagReferencev1(modified, existingCurr, required)
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of #674 + #677 on release-4.8 branch