### PR TITLE
bootstrap/bootstrap-pod: Pivot from --enable-default-cluster-version to --wait-for-cluster-version

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -14,7 +14,7 @@ spec:
       - "start"
       - "--release-image={{.ReleaseImage}}"
       - "--enable-auto-update=false"
-      - "--enable-default-cluster-version=false"
+      - "--wait-for-cluster-version"
       - "--listen="
       - "--v=5"
       - "--kubeconfig=/etc/kubernetes/kubeconfig"

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -31,7 +31,7 @@ func init() {
 	cmd.PersistentFlags().StringVar(&opts.Kubeconfig, "kubeconfig", opts.Kubeconfig, "Kubeconfig file to access a remote cluster (testing only)")
 	cmd.PersistentFlags().StringVar(&opts.NodeName, "node-name", opts.NodeName, "kubernetes node name CVO is scheduled on.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpdate, "enable-auto-update", opts.EnableAutoUpdate, "Enables the autoupdate controller.")
-	cmd.PersistentFlags().BoolVar(&opts.EnableDefaultClusterVersion, "enable-default-cluster-version", opts.EnableDefaultClusterVersion, "Allows the operator to create a ClusterVersion object if one does not already exist.")
+	cmd.PersistentFlags().BoolVar(&opts.WaitForClusterVersion, "wait-for-cluster-version", opts.WaitForClusterVersion, "Blocks manifest reconciliation until the ClusterVersion resource exists.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The Openshift release image url.")
 	cmd.PersistentFlags().StringVar(&opts.ServingCertFile, "serving-cert-file", opts.ServingCertFile, "The X.509 certificate file for serving metrics over HTTPS.  You must set both --serving-cert-file and --serving-key-file unless you set --listen empty.")
 	cmd.PersistentFlags().StringVar(&opts.ServingKeyFile, "serving-key-file", opts.ServingKeyFile, "The X.509 key file for serving metrics over HTTPS.  You must set both --serving-cert-file and --serving-key-file unless you set --listen empty.")

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -29,7 +29,6 @@ spec:
           - "start"
           - "--release-image={{.ReleaseImage}}"
           - "--enable-auto-update=false"
-          - "--enable-default-cluster-version=true"
           - "--listen=0.0.0.0:9099"
           - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
           - "--serving-key-file=/etc/tls/serving-cert/tls.key"

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -73,15 +73,14 @@ func setupCVOTest(payloadDir string) (*Operator, map[string]runtime.Object, *fak
 	})
 
 	o := &Operator{
-		namespace:                   "test",
-		name:                        "version",
-		enableDefaultClusterVersion: true,
-		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
-		client:                      client,
-		cvLister:                    &clientCVLister{client: client},
-		exclude:                     "exclude-test",
-		eventRecorder:               record.NewFakeRecorder(100),
-		clusterProfile:              payload.DefaultClusterProfile,
+		namespace:      "test",
+		name:           "version",
+		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cvo-loop-test"),
+		client:         client,
+		cvLister:       &clientCVLister{client: client},
+		exclude:        "exclude-test",
+		eventRecorder:  record.NewFakeRecorder(100),
+		clusterProfile: payload.DefaultClusterProfile,
 	}
 
 	dynamicScheme := runtime.NewScheme()

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -195,10 +195,9 @@ func TestOperator_sync(t *testing.T) {
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
 				},
-				enableDefaultClusterVersion: true,
-				namespace:                   "test",
-				name:                        "default",
-				client:                      fake.NewSimpleClientset(),
+				namespace: "test",
+				name:      "default",
+				client:    fake.NewSimpleClientset(),
 			},
 			wantActions: func(t *testing.T, optr *Operator) {
 				f := optr.client.(*fake.Clientset)
@@ -4379,14 +4378,12 @@ func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 		cvName         string
 		expectedResult *configv1.ClusterVersion
 		cvs            []configv1.ClusterVersion
-		enableDefault  bool
 		changed        bool
 	}{
 		{
 			name:           "no existing cluster version",
 			cvName:         "version",
 			expectedResult: &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
-			enableDefault:  true,
 			changed:        true,
 		},
 		{
@@ -4396,7 +4393,6 @@ func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
 			},
 			expectedResult: &configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version", UID: types.UID("version")}},
-			enableDefault:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -4407,7 +4403,7 @@ func TestOperator_getOrCreateClusterVersion(t *testing.T) {
 				cvLister: &clientCVLister{client: client},
 				client:   client,
 			}
-			cv, changed, err := optr.getOrCreateClusterVersion(context.Background(), tt.enableDefault)
+			cv, changed, err := optr.getOrCreateClusterVersion(context.Background(), false)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -59,8 +59,8 @@ type Options struct {
 	NodeName   string
 	ListenAddr string
 
-	EnableAutoUpdate            bool
-	EnableDefaultClusterVersion bool
+	EnableAutoUpdate      bool
+	WaitForClusterVersion bool
 
 	// Exclude is used to determine whether to exclude
 	// certain manifests based on an annotation:
@@ -430,7 +430,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder) *Context {
 			o.NodeName,
 			o.Namespace, o.Name,
 			o.ReleaseImage,
-			o.EnableDefaultClusterVersion,
+			o.WaitForClusterVersion,
 			o.PayloadOverride,
 			resyncPeriod(o.ResyncInterval)(),
 			cvInformer.Config().V1().ClusterVersions(),

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -280,7 +280,6 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	options.Namespace = ns
 	options.Name = ns
 	options.ListenAddr = ""
-	options.EnableDefaultClusterVersion = true
 	options.NodeName = "test-node"
 	options.ReleaseImage = payloadImage1
 	options.PayloadOverride = filepath.Join(dir, "ignored")
@@ -441,7 +440,6 @@ func TestIntegrationCVO_initializeAndHandleError(t *testing.T) {
 	options.Namespace = ns
 	options.Name = ns
 	options.ListenAddr = ""
-	options.EnableDefaultClusterVersion = true
 	options.NodeName = "test-node"
 	options.ReleaseImage = payloadImage1
 	options.PayloadOverride = filepath.Join(dir, "ignored")


### PR DESCRIPTION
We've been using `--enable-default-cluster-version` to avoid a cluster-bootstrap vs. cluster-version operator race since d7760cec0f (#238). But openshift/enhancements#922 is considering passing component configuration to the CVO via ClusterVersion that would affect the manifests getting applied.  So this commit pivots to a new option that blocks the whole sync cycle on the existence of a ClusterVersion resource.  That way, we know we have up-to-date data before reconciling any manifests (although it might slow down the bootstrapping process a bit).