### PR TITLE
Bug 1878925: pkg/cvo/updatepayload: Drop history from target pullspec lookup

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -306,8 +306,7 @@ func copyPayloadCmd(tdir string) string {
 }
 
 // findUpdateFromConfig identifies a desired update from user input or returns false. It will
-// resolve payload if the user specifies a version and a matching available update or previous
-// update is in the history.
+// resolve payload if the user specifies a version and a matching available update.
 func findUpdateFromConfig(config *configv1.ClusterVersion) (configv1.Update, bool) {
 	update := config.Spec.DesiredUpdate
 	if update == nil {
@@ -325,15 +324,6 @@ func findUpdateFromConfigVersion(config *configv1.ClusterVersion, version string
 			return configv1.Update{
 				Version: version,
 				Image:   update.Image,
-				Force:   force,
-			}, true
-		}
-	}
-	for _, history := range config.Status.History {
-		if history.Version == version && len(history.Image) > 0 {
-			return configv1.Update{
-				Version: version,
-				Image:   history.Image,
 				Force:   force,
 			}, true
 		}


### PR DESCRIPTION
The logic I'm removing is a convenience from 558ae021bd (#63).  But the current consensus is that:

* Rollbacks are risky enough that we don't want to make them that convenient.
* Rollbacks have never been supported, so removing the convenient pullspec lookup is a backwards-compatible-enough change.

This also brings the ClusterVersion operator's approach into line with how `oc adm upgrade --to ...` has always worked; openshift/oc#566.