### PR TITLE
install: Drop single-node-developer profile

### DIFF
--- a/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
@@ -6,5 +6,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -6,4 +6,3 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
There's [an enhancement proposal][1] for this profile, and the Code Ready Containers folks [took a run at using it][2] before [backing off][3].  I don't have any problems with having a specific CRC profile, but if we end up going that way, we'll need a lot more CVO manifests with the annotation than just these two admin-ack ConfigMaps (e.g. we'll probably also want the CVO's Namespace and Deployment, etc., or there won't be anything consuming the admin-ack ConfigMaps ;).  This commit drops these two annotations, which slipped in when the ConfigMaps landed in 519b466793 (#633).

[1]: https://github.com/openshift/enhancements/blob/2911c46bf7d2f22eb1ab81739b4f9c2603fd0c07/enhancements/single-node/developer-cluster-profile.md
[2]: https://github.com/code-ready/snc/pull/338
[3]: https://github.com/code-ready/snc/pull/373#issue-835807822