### PR TITLE
install: Add description annotations to manifests

### DIFF
--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-cluster-version
   annotations:
+    kubernetes.io/description: The cluster-version operator manages OpenShift updates and reconciles core resources and cluster operators.
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"

--- a/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_adminack_configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: admin-acks
   namespace: openshift-config
   annotations:
+    kubernetes.io/description: Record administrator acknowledgments of update gates defined in the admin-gates ConfigMap in the openshift-config-managed namespace.
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"

--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -4,5 +4,6 @@ metadata:
   name: admin-gates
   namespace: openshift-config-managed
   annotations:
+    kubernetes.io/description: Define update gates for the administrator to acknowledge in the admin-acks ConfigMap in the openshift-config namespace.
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/install/0000_00_cluster-version-operator_02_roles.yaml
+++ b/install/0000_00_cluster-version-operator_02_roles.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cluster-version-operator
   annotations:
+    kubernetes.io/description: Grant the cluster-version operator permission to perform cluster-admin actions while managing the OpenShift core.
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   kind: ClusterRole

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
   annotations:
+    kubernetes.io/description: The cluster-version operator manages OpenShift updates and reconciles core resources and cluster operators.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/install/0000_90_cluster-version-operator_00_prometheusrole.yaml
+++ b/install/0000_90_cluster-version-operator_00_prometheusrole.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-version
   annotations:
+    kubernetes.io/description: Grant access to monitor the cluster-version operator's metrics.
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:

--- a/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
+++ b/install/0000_90_cluster-version-operator_01_prometheusrolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-cluster-version
   annotations:
+    kubernetes.io/description: Grant Prometheus access to monitor the cluster-version operator's metrics.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
   annotations:
+    kubernetes.io/description: Configure Prometheus to monitor cluster-version operator metrics.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
@@ -32,6 +33,7 @@ metadata:
   name: cluster-version-operator
   namespace: openshift-cluster-version
   annotations:
+    kubernetes.io/description: Alerting rules for when cluster-version operator metrics call for administrator attention.
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:

--- a/install/0001_00_cluster-version-operator_03_service.yaml
+++ b/install/0001_00_cluster-version-operator_03_service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: cluster-version-operator
   annotations:
+    kubernetes.io/description: Expose cluster-version operator metrics to other in-cluster consumers.  Access requires a prometheus-k8s RoleBinding in this namespace.
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     service.beta.openshift.io/serving-cert-secret-name: cluster-version-operator-serving-cert


### PR DESCRIPTION
To make it easier to see what these resources are for, especially once they become in-cluster resources and `git blame ...` is further away.

See [this example][1] in the upstream docs of using the `kubernetes.io/description` annotation for this purpose, although the key is not listed [in this reference][2].

[1]: https://github.com/kubernetes/website/blob/082116588c191f52de2003deb71ce7a304cc357d/content/en/examples/access/endpoints-aggregated.yaml#L5
[2]: https://github.com/kubernetes/website/blob/082116588c191f52de2003deb71ce7a304cc357d/content/en/docs/reference/labels-annotations-taints.md