### PR TITLE
Bug 2027585: pkg/cincinnati: Fix panic for conditional edges with risks after an invalid risk

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -219,6 +219,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 			if len(conditionalUpdates[i].Risks[j].MatchingRules) == 0 {
 				klog.Warningf("Conditional update to %s, risk %q, has empty pruned matchingRules; dropping this target to avoid rejections when pushing to the Kubernetes API server. Pruning results: %s", conditionalUpdates[i].Release.Version, risk.Name, err)
 				conditionalUpdates = append(conditionalUpdates[:i], conditionalUpdates[i+1:]...)
+				break
 			} else if err != nil {
 				klog.Warningf("Conditional update to %s, risk %q, has pruned matchingRules (although other valid, recognized matchingRules were given, and are sufficient to keep the conditional update): %s", conditionalUpdates[i].Release.Version, risk.Name, err)
 			}

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -497,6 +497,63 @@ func TestGetUpdates(t *testing.T) {
 			Channels: []string{"channel-a", "test-channel"},
 		},
 	}, {
+		name:    "condition with risks after invalid risk",
+		version: "4.1.0",
+		graph: `{
+  "nodes": [
+    {
+      "version": "4.1.0",
+      "payload": "quay.io/openshift-release-dev/ocp-release:4.1.0",
+      "metadata": {
+        "url": "https://example.com/errata/4.1.0",
+	"io.openshift.upgrades.graph.release.channels": "test-channel,channel-a"
+      }
+    },
+    {
+      "version": "4.1.1",
+      "payload": "quay.io/openshift-release-dev/ocp-release:4.1.1",
+      "metadata": {
+        "url": "https://example.com/errata/4.1.1",
+	"io.openshift.upgrades.graph.release.channels": "test-channel"
+      }
+    }
+  ],
+  "conditionalEdges": [
+    {
+      "edges": [{"from": "4.1.0", "to": "4.1.1"}],
+      "risks": [
+        {
+          "url": "https://example.com/bug/123",
+          "name": "BugA",
+          "message": "This risk has no recognized rules, and so the conditional update to 4.1.1 will be dropped to avoid rejections when pushing to the Kubernetes API server.",
+          "matchingRules": [
+            {
+              "type": "does-not-exist"
+            }
+          ]
+        },
+        {
+          "url": "https://example.com/bug/456",
+          "name": "BugB",
+          "message": "All 4.1.0 clusters are incompatible with 4.1.1.",
+          "matchingRules": [
+            {
+              "type": "Always"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`,
+		expectedQuery: "arch=test-arch&channel=test-channel&id=01234567-0123-0123-0123-0123456789ab&version=4.1.0",
+		current: configv1.Release{
+			Version:  "4.1.0",
+			Image:    "quay.io/openshift-release-dev/ocp-release:4.1.0",
+			URL:      "https://example.com/errata/4.1.0",
+			Channels: []string{"channel-a", "test-channel"},
+		},
+	}, {
 		name:    "unknown version",
 		version: "4.1.0",
 		graph: `{


### PR DESCRIPTION
[Avoid][1]:

```
6609 E1130 07:10:17.721916       1 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error:      index out of range [0] with length 0)
6610 goroutine 177 [running]:
6611 k8s.io/apimachinery/pkg/util/runtime.logPanic({0x196f5a0, 0xc000eee2d0})
6612         /go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85
6613 k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000af1680})
6614         /go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
6615 panic({0x196f5a0, 0xc000eee2d0})
6616         /usr/lib/golang/src/runtime/panic.go:1038 +0x215
6617 github.com/openshift/cluster-version-operator/pkg/cincinnati.Client.GetUpdates({{0xa2, 0x74, 0x1e, 0xaf, 0x95, 0xa0, 0x44, 0x40, 0x     97, 0x24, ...}, ...}, ...)
6618         /go/src/github.com/openshift/cluster-version-operator/pkg/cincinnati/cincinnati.go:218 +0x2f14
```

By breaking out of the loop over risks after we've hit a risk with issues that caused us to drop the conditional edge entirely.

Fixes a bug from #663.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2027585#c0