### PR TITLE
Bug 2028217: lib/resourcemerge/apps: Default Deployment replicas to one

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -3,6 +3,7 @@ package resourcemerge
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/pointer"
 )
 
 // EnsureDeployment ensures that the existing matches the required.
@@ -10,7 +11,8 @@ import (
 func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
-	if required.Spec.Replicas != nil && *required.Spec.Replicas != *existing.Spec.Replicas {
+	ensureReplicasDefault(&required)
+	if existing.Spec.Replicas == nil || *required.Spec.Replicas != *existing.Spec.Replicas {
 		*modified = true
 		existing.Spec.Replicas = required.Spec.Replicas
 	}
@@ -30,6 +32,12 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 	}
 
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}
+
+func ensureReplicasDefault(required *appsv1.Deployment) {
+	if required.Spec.Replicas == nil {
+		required.Spec.Replicas = pointer.Int32(1)
+	}
 }
 
 // EnsureDaemonSet ensures that the existing matches the required.

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -23,29 +23,39 @@ func TestEnsureDeployment(t *testing.T) {
 			name: "different replica count",
 			existing: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(2)}},
+					Replicas: pointer.Int32(2)}},
 			required: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(3)}},
+					Replicas: pointer.Int32(3)}},
 
 			expectedModified: true,
 			expected: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(3)}},
+					Replicas: pointer.Int32(3)}},
 		},
 		{
 			name: "same replica count",
 			existing: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(2)}},
+					Replicas: pointer.Int32(2)}},
 			required: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(2)}},
+					Replicas: pointer.Int32(2)}},
 
 			expectedModified: false,
 			expected: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: int32Pointer(2)}},
+					Replicas: pointer.Int32(2)}},
+		},
+		{
+			name: "implicit replica count",
+			existing: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(2)}},
+			expectedModified: true,
+			expected: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(1)}},
 		},
 		{
 			name:     "existing-selector-nil-required-selector-non-nil",
@@ -82,8 +92,4 @@ func TestEnsureDeployment(t *testing.T) {
 func defaultDeployment(in *appsv1.Deployment, from appsv1.Deployment) {
 	modified := pointer.BoolPtr(false)
 	EnsureDeployment(modified, in, from)
-}
-
-func int32Pointer(i int32) *int32 {
-	return &i
 }


### PR DESCRIPTION
@tdosek and @vrutkovs noticed that, when a Deployment manifest leaves `replicas` unset, the CVO ignores the property.  This means that cluster admins can scale those Deployments up or, worse, down to 0, and the CVO will happily continue on without stomping them.  Auditing 4.9.10:

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.9.10-x86_64
Extracted release payload from digest sha256:e1853d68d8ff093ec353ca7078b6b6df1533729688bb016b8208263ee7423f66 created at 2021-12-01T09:19:24Z
$ for F in $(grep -rl 'kind: Deployment' manifests); do yaml2json < "${F}" | jq -r '.[] | select(.kind == "Deployment" and .spec.replicas == null).metadata | .namespace + " " + .name'; done | sort | uniq
openshift-cluster-machine-approver machine-approver
openshift-insights insights-operator
openshift-network-operator network-operator
```

Those are all important operators, and I'm fairly confident that none of their maintainers expect "cluster admin scales them down to 0" to be a supported UX.  We should have the CVO default Deployment `replicas` to 1 ([the type's default][1]), so admins who decide they don't want a network operator pod, etc., have to use some more explicit, alarming API to remove those pods (e.g. setting `spec.overrides` in the ClusterVersion object to assume control of the resource themselves).

Also replace `int32Pointer` with `pointer.Int32`.  Not clear to me why 80dc893514 (#256) had gone with a
local function.

[1]: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec