### PR TITLE
Bug 2028602: lib/resourcemerge/apps: Default Deployment replicas to one

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -10,7 +10,8 @@ import (
 func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
-	if required.Spec.Replicas != nil && *required.Spec.Replicas != *existing.Spec.Replicas {
+	ensureReplicasDefault(&required)
+	if existing.Spec.Replicas == nil || *required.Spec.Replicas != *existing.Spec.Replicas {
 		*modified = true
 		existing.Spec.Replicas = required.Spec.Replicas
 	}
@@ -25,6 +26,12 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 	}
 
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}
+
+func ensureReplicasDefault(required *appsv1.Deployment) {
+	if required.Spec.Replicas == nil {
+		required.Spec.Replicas = int32Pointer(1)
+	}
 }
 
 // EnsureDaemonSet ensures that the existing matches the required.
@@ -42,4 +49,8 @@ func EnsureDaemonSet(modified *bool, existing *appsv1.DaemonSet, required appsv1
 	}
 
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}
+
+func int32Pointer(i int32) *int32 {
+	return &i
 }

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -48,6 +48,16 @@ func TestEnsureDeployment(t *testing.T) {
 					Replicas: int32Pointer(2)}},
 		},
 		{
+			name: "implicit replica count",
+			existing: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Pointer(2)}},
+			expectedModified: true,
+			expected: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Pointer(1)}},
+		},
+		{
 			name:     "existing-selector-nil-required-selector-non-nil",
 			existing: appsv1.Deployment{},
 			required: appsv1.Deployment{
@@ -82,8 +92,4 @@ func TestEnsureDeployment(t *testing.T) {
 func defaultDeployment(in *appsv1.Deployment, from appsv1.Deployment) {
 	modified := pointer.BoolPtr(false)
 	EnsureDeployment(modified, in, from)
-}
-
-func int32Pointer(i int32) *int32 {
-	return &i
 }


### PR DESCRIPTION
Picking #698 back to 4.9, but without `pointer.Int32`, which [isn't part of 4.9's vendored `pointer` package][1].

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/700/pull-ci-openshift-cluster-version-operator-release-4.9-golangci-lint/1466469531768590336#1:build-log.txt%3A16