### PR TITLE
Bug 2026560: lib/resourcemerge/core: Merge volumeMounts by mountPath

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -317,12 +317,12 @@ func ensureServicePortDefaults(servicePort *corev1.ServicePort) {
 func ensureVolumeMounts(modified *bool, existing *[]corev1.VolumeMount, required []corev1.VolumeMount) {
 	// any volume mount we specify, we require
 	exists := struct{}{}
-	requiredNames := make(map[string]struct{}, len(required))
+	requiredMountPaths := make(map[string]struct{}, len(required))
 	for _, requiredVolumeMount := range required {
-		requiredNames[requiredVolumeMount.Name] = exists
+		requiredMountPaths[requiredVolumeMount.MountPath] = exists
 		var existingCurr *corev1.VolumeMount
 		for j, curr := range *existing {
-			if curr.Name == requiredVolumeMount.Name {
+			if curr.MountPath == requiredVolumeMount.MountPath {
 				existingCurr = &(*existing)[j]
 				break
 			}
@@ -337,7 +337,7 @@ func ensureVolumeMounts(modified *bool, existing *[]corev1.VolumeMount, required
 
 	// any unrecognized volume mount, we remove
 	for eidx := len(*existing) - 1; eidx >= 0; eidx-- {
-		if _, ok := requiredNames[(*existing)[eidx].Name]; !ok {
+		if _, ok := requiredMountPaths[(*existing)[eidx].MountPath]; !ok {
 			*modified = true
 			*existing = append((*existing)[:eidx], (*existing)[eidx+1:]...)
 		}

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -503,7 +503,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "modify volumes on container",
+			name: "modify volume path on container",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -578,6 +578,81 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "modify volume name on container",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume-a",
+								MountPath: "/mnt",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume-a",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume-b",
+								MountPath: "/mnt",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume-b",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "test-config-map",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume-b",
+								MountPath: "/mnt",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume-b",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "test-config-map",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "remove container volumes",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -609,6 +684,77 @@ func TestEnsurePodSpec(t *testing.T) {
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{Name: "test"},
+				},
+			},
+		},
+		{
+			name: "remove container volumes with masking name",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume",
+								MountPath: "/mnt/a",
+							},
+							{
+								Name:      "test-volume",
+								MountPath: "/mnt/b",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume",
+								MountPath: "/mnt/a",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test",
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test-volume",
+								MountPath: "/mnt/a",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "test-volume",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We had been merging by name since `ensureVolumeMounts` landed in 83faa6e716 (#654).  But as pointed out in [rhbz#2026560][1], a single volume may be mounted at multiple paths.  With this commit, I'm pivoting to merge by `mountPath`, [which is the `patchMergeKey`][2] (and it makes sense that you wouldn't have multiple volumes mounted at the same path).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2026560
[2]: https://github.com/kubernetes/api/blob/1d6faf224f146dd002553f55cd9fcaaaa0dc00cb/core/v1/types.go#L2367