### PR TITLE
[WIP] Bug 2033497: Adding CannotEvaluateConditionalUpdates alert

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -123,7 +123,7 @@ spec:
         summary: Cluster version operator is not able to evaluate conditional update graphs for {{ "{{ $value | humanizeDuration }}" }}.
         description: Failure to evaluate conditional updates means CVO will not be able to evaluate if an conditional edge is applicable to the cluster or not.
       expr: |
-        (time()-cluster_version_unknown_conditional_update_condition) >= 3600
+        (time()-cluster_version_unknown_conditional_update_condition) >= 600
       for: 10m
       labels:
         severity: warning

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -118,3 +118,12 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: CannotEvaluateConditionalUpdates
+      annotations:
+        summary: Cluster version operator is not able to evaluate conditional update graphs for {{ "{{ $value | humanizeDuration }}" }}.
+        description: Failure to evaluate conditional updates means CVO will not be able to evaluate if an conditional edge is applicable to the cluster or not.
+      expr: |
+        (time()-cluster_version_unknown_conditional_update_condition) >= 3600
+      for: 10m
+      labels:
+        severity: warning

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -31,6 +31,8 @@ const (
 	// and indicates the cluster is not healthy.
 	ClusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
 
+	ConditionalUpdateRecommendedType = "Recommended"
+
 	// MaxHistory is the maximum size of ClusterVersion history. Once exceeded
 	// ClusterVersion history will be pruned. It is declared here and passed
 	// into the pruner function to allow easier testing.


### PR DESCRIPTION
[OTA-530](https://issues.redhat.com/browse/OTA-530): If there are issues evaluating a conditional update
 the operator will set the Unknown status on the Recommended condition.
The warning-level CannotEvaluateConditionalUpdates alert will fire if
 lastTransitionTime for any Recommended=Unknown condition is over an hour old.

As per https://github.com/openshift/enhancements/blob/2cc2d9b331532c852878a7c793f3a754914c824e/enhancements/update/targeted-update-edge-blocking.md#cluster-version-operator-support-for-the-enhanced-schema

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>