### PR TITLE
pkg/start: Log and continue when we fail to retrieve the feature gate

### DIFF
--- a/pkg/featurechangestopper/techpreviewchangestopper.go
+++ b/pkg/featurechangestopper/techpreviewchangestopper.go
@@ -94,7 +94,7 @@ func (c *TechPreviewChangeStopper) Run(ctx context.Context, shutdownFn context.C
 	}()
 	c.shutdownFn = shutdownFn
 
-	klog.Infof("Starting stop-on-techpreview-change controller")
+	klog.Infof("Starting stop-on-techpreview-change controller with %s %t.", configv1.TechPreviewNoUpgrade, c.startingTechPreviewState)
 
 	// wait for your secondary caches to fill before starting your work
 	if !cache.WaitForCacheSync(ctx.Done(), c.cacheSynced...) {
@@ -102,7 +102,7 @@ func (c *TechPreviewChangeStopper) Run(ctx context.Context, shutdownFn context.C
 	}
 
 	err := wait.PollImmediateUntilWithContext(ctx, 30*time.Second, c.runWorker)
-	klog.Infof("Shutting down stop-on-techpreview-change controller")
+	klog.Info("Shutting down stop-on-techpreview-change controller")
 	return err
 }
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -142,7 +142,7 @@ func (o *Options) Run(ctx context.Context) error {
 	case apierrors.IsNotFound(err):
 		includeTechPreview = false // if we have no featuregates, then we aren't tech preview
 	case err != nil:
-		return fmt.Errorf("error getting featuregate value: %v", err)
+		klog.Warningf("Error getting featuregate value: %v", err)
 	default:
 		includeTechPreview = gate.Spec.FeatureSet == configv1.TechPreviewNoUpgrade
 	}


### PR DESCRIPTION
To make it easier to differentiate between "cluster version operator is confused about the cluster's tech-preview-ness", "cluster-version operator has broken manifest exclusion logic", and "manifest is mis-setting an annotation".

WIP until we remove the `pkg/payload/payload.go` logging, which I'm using to help debug openshift/cluster-capi-operator#20.