### PR TITLE
Bug 2029785: pkg/cincinnati: Fix panic for conditional edges overlapping with unconditional edges

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -205,6 +205,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, chann
 			if conditionalUpdate.Release.Image == updates[i].Image {
 				klog.Warningf("Update to %s listed as both a conditional and unconditional update; preferring the conditional update.", conditionalUpdate.Release.Version)
 				updates = append(updates[:i], updates[i+1:]...)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Like fa40743276 (#679), but for [rhbz#2029785][1]:

```
3095 E1207 08:39:42.972092       1 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error:      index out of range [0] with length 0)
3096 goroutine 169 [running]:
3097 k8s.io/apimachinery/pkg/util/runtime.logPanic({0x196f5a0, 0xc0013b4be8})
3098         /go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x85
3099 k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc001a7dd90})
3100         /go/src/github.com/openshift/cluster-version-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
3101 panic({0x196f5a0, 0xc0013b4be8})
3102         /usr/lib/golang/src/runtime/panic.go:1038 +0x215
3103 github.com/openshift/cluster-version-operator/pkg/cincinnati.Client.GetUpdates({{0xca, 0x13, 0x92, 0x7c, 0xb6, 0xf0, 0x47, 0x7f, 0x     86, 0xc6, ...}, ...}, ...)
3104         /go/src/github.com/openshift/cluster-version-operator/pkg/cincinnati/cincinnati.go:205 +0x3230
```

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2029785#c0