### PR TITLE
pkg/payload: Log manifest exclusion

### DIFF
--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -1,6 +1,7 @@
 package payload
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -17,7 +18,7 @@ import (
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
-func Test_loadUpdatePayload(t *testing.T) {
+func TestLoadUpdate(t *testing.T) {
 	type args struct {
 		dir          string
 		releaseImage string
@@ -132,7 +133,7 @@ func mustRead(path string) []byte {
 	return data
 }
 
-func Test_Exclude(t *testing.T) {
+func Test_include(t *testing.T) {
 	tests := []struct {
 		name               string
 		exclude            string
@@ -140,7 +141,7 @@ func Test_Exclude(t *testing.T) {
 		profile            string
 		annotations        map[string]interface{}
 
-		isExcluded bool
+		expected error
 	}{
 		{
 			name:    "exclusion identifier set",
@@ -149,13 +150,13 @@ func Test_Exclude(t *testing.T) {
 			annotations: map[string]interface{}{
 				"exclude.release.openshift.io/identifier":                     "true",
 				"include.release.openshift.io/self-managed-high-availability": "true"},
-			isExcluded: true,
+			expected: errors.New("exclude.release.openshift.io/identifier=true"),
 		},
 		{
 			name:        "profile selection works",
 			profile:     "single-node",
 			annotations: map[string]interface{}{"include.release.openshift.io/self-managed-high-availability": "true"},
-			isExcluded:  true,
+			expected:    errors.New("include.release.openshift.io/single-node unset"),
 		},
 		{
 			name:        "profile selection works included",
@@ -169,7 +170,7 @@ func Test_Exclude(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "TechPreviewNoUpgrade",
 			},
-			isExcluded: true,
+			expected: errors.New("tech-preview excluded, and release.openshift.io/feature-gate=TechPreviewNoUpgrade"),
 		},
 		{
 			name:               "correct techpreview value is included if techpreview on",
@@ -179,7 +180,6 @@ func Test_Exclude(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "TechPreviewNoUpgrade",
 			},
-			isExcluded: false,
 		},
 		{
 			name:    "incorrect techpreview value is not excluded if techpreview off",
@@ -188,7 +188,7 @@ func Test_Exclude(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "Other",
 			},
-			isExcluded: true,
+			expected: errors.New("unrecognized value release.openshift.io/feature-gate=Other"),
 		},
 		{
 			name:               "incorrect techpreview value is not excluded if techpreview on",
@@ -198,19 +198,19 @@ func Test_Exclude(t *testing.T) {
 				"include.release.openshift.io/self-managed-high-availability": "true",
 				"release.openshift.io/feature-gate":                           "Other",
 			},
-			isExcluded: true,
+			expected: errors.New("unrecognized value release.openshift.io/feature-gate=Other"),
 		},
 		{
 			name:        "default profile selection excludes without annotation",
 			profile:     DefaultClusterProfile,
 			annotations: map[string]interface{}{},
-			isExcluded:  true,
+			expected:    errors.New("include.release.openshift.io/self-managed-high-availability unset"),
 		},
 		{
 			name:        "default profile selection excludes with no annotation",
 			profile:     DefaultClusterProfile,
 			annotations: nil,
-			isExcluded:  true,
+			expected:    errors.New("no annotations"),
 		},
 	}
 	for _, tt := range tests {
@@ -219,15 +219,15 @@ func Test_Exclude(t *testing.T) {
 			if tt.annotations != nil {
 				metadata["annotations"] = tt.annotations
 			}
-			ret := shouldExclude(tt.exclude, tt.includeTechPreview, tt.profile, &manifest.Manifest{
+			err := include(tt.exclude, tt.includeTechPreview, tt.profile, &manifest.Manifest{
 				Obj: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"metadata": metadata,
 					},
 				},
 			})
-			if ret != tt.isExcluded {
-				t.Errorf("(exclude: %v, profile: %v, annotations: %v) %v != %v", tt.exclude, tt.profile, tt.annotations, tt.isExcluded, ret)
+			if !reflect.DeepEqual(err, tt.expected) {
+				t.Errorf("(exclude: %v, profile: %v, annotations: %v) expected %v, but got %v", tt.exclude, tt.profile, tt.annotations, tt.expected, err)
 			}
 		})
 	}


### PR DESCRIPTION
We have a number of different annotations all working together now, so logging exclusions with our reasoning will help folks who are debugging "why is my manifest not being reconciled?".  And while this will create a number of logs for some profiles, we we already log each reconciled manifest with every sync cycle, so the volume increase isn't huge compared to our existing log rate.  This is primarily a dev-time issue, which argues against log spew for production clusters, but since 72599d323d (#694), there's been the dynamic tech-preview business, so there is now more utility in production logging around this than there was before.
