### PR TITLE
pkg/cvo: Drop unused 'workers' argument from Operator.Run

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -329,7 +329,7 @@ func loadConfigMapVerifierDataFromUpdate(update *payload.Update, clientBuilder s
 // then attempts a clean shutdown limited by shutdownContext.Done().
 // Assumes runContext.Done() occurs before or simultaneously with
 // shutdownContext.Done().
-func (optr *Operator) Run(runContext context.Context, shutdownContext context.Context, workers int) error {
+func (optr *Operator) Run(runContext context.Context, shutdownContext context.Context) error {
 	defer optr.queue.ShutDown()
 	defer optr.availableUpdatesQueue.ShutDown()
 	defer optr.upgradeableQueue.ShutDown()

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -251,7 +251,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock *resourc
 					resultChannelCount++
 					go func() {
 						defer utilruntime.HandleCrash()
-						err := controllerCtx.CVO.Run(runContext, shutdownContext, 2)
+						err := controllerCtx.CVO.Run(runContext, shutdownContext)
 						resultChannel <- asyncResult{name: "main operator", error: err}
 					}()
 


### PR DESCRIPTION
The last consumer was removed way back in 90e9881bd5 (#45).