### PR TITLE
Bug 2000938: lib/resourcemerge/apps: Avoid hotlooping on implicit strategy

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -3,6 +3,7 @@ package resourcemerge
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
@@ -26,6 +27,7 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 		existing.Spec.Selector = required.Spec.Selector
 	}
 
+	ensureStrategyDefault(&required)
 	if !equality.Semantic.DeepEqual(existing.Spec.Strategy, required.Spec.Strategy) {
 		*modified = true
 		existing.Spec.Strategy = required.Spec.Strategy
@@ -37,6 +39,23 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 func ensureReplicasDefault(required *appsv1.Deployment) {
 	if required.Spec.Replicas == nil {
 		required.Spec.Replicas = pointer.Int32(1)
+	}
+}
+
+func ensureStrategyDefault(required *appsv1.Deployment) {
+	if len(required.Spec.Strategy.Type) == 0 || required.Spec.Strategy.Type == appsv1.RollingUpdateDeploymentStrategyType {
+		required.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
+		if required.Spec.Strategy.RollingUpdate == nil {
+			required.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+		}
+		if required.Spec.Strategy.RollingUpdate.MaxUnavailable == nil {
+			twentyFivePercent := intstr.FromString("25%")
+			required.Spec.Strategy.RollingUpdate.MaxUnavailable = &twentyFivePercent
+		}
+		if required.Spec.Strategy.RollingUpdate.MaxSurge == nil {
+			twentyFivePercent := intstr.FromString("25%")
+			required.Spec.Strategy.RollingUpdate.MaxSurge = &twentyFivePercent
+		}
 	}
 }
 

--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -6,11 +6,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
 func TestEnsureDeployment(t *testing.T) {
 	labelSelector := metav1.LabelSelector{}
+	twentyFivePercent := intstr.FromString("25%")
 	tests := []struct {
 		name     string
 		existing appsv1.Deployment
@@ -68,6 +70,36 @@ func TestEnsureDeployment(t *testing.T) {
 			expected: appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
 					Selector: &labelSelector}},
+		},
+		{
+			name: "implicit strategy",
+			existing: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge:       &twentyFivePercent,
+							MaxUnavailable: &twentyFivePercent,
+						},
+					},
+				},
+			},
+			required: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{},
+			},
+
+			expectedModified: false,
+			expected: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge:       &twentyFivePercent,
+							MaxUnavailable: &twentyFivePercent,
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
62a9f077ad (#650) added strategy reconciliation, but as described [in rhbz#2000938][1], the `DeepEqual` is generating false positive `modified` detection when comparing manifests with implicit strategies like:

```console
$ oc adm release extract --to manifests registry.ci.openshift.org/ocp/release:4.10.0-0.nightly-2021-12-23-153012
$ grep -c strategy: manifests/0000_50_service-ca-operator_05_deploy.yaml
0
```

With the in-cluster resources that have the server-injected defaults:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-aws/1478247345723281408/artifacts/e2e-aws/gather-extra/artifacts/deployments.json | jq '.items[] | select(.metadata.name == "service-ca-operator").spec.strategy'
{
  "rollingUpdate": {
    "maxSurge": "25%",
    "maxUnavailable": "25%"
  },
  "type": "RollingUpdate"
}
```

This commit bakes in some local knowledge of [the server-side defaults][2], so we can avoid hotlooping trying to clear the strategy (and having the API-server immediately feed the defaults back in).

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2000938#c3
[2]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy