### PR TITLE
Bug 2039119: WIP: lib/resourceapply: Avoid Service hotlooping on FIXME

### DIFF
--- a/lib/resourcebuilder/resourcebuilder.go
+++ b/lib/resourcebuilder/resourcebuilder.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
+
 	imagev1 "github.com/openshift/api/image/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -175,7 +177,8 @@ func (b *builder) Do(ctx context.Context) error {
 	case *corev1.Service:
 		if b.modifier != nil {
 			b.modifier(typedObject)
-		}
+			klog.V(2).Infof("modifying service with %v", b.modifier)
+		} else {klog.V(2).Infof("no service modifier")}
 		if deleteReq, err := resourcedelete.DeleteServicev1(ctx, b.coreClientv1, typedObject,
 			updatingMode); err != nil {
 			return err

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -3,16 +3,23 @@ package resourcemerge
 import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // EnsureObjectMeta ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
 func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required metav1.ObjectMeta) {
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("ensure object meta already modified")}
 	setStringIfSet(modified, &existing.Namespace, required.Namespace)
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("namespace modified")}
 	setStringIfSet(modified, &existing.Name, required.Name)
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("name modified")}
 	mergeMap(modified, &existing.Labels, required.Labels)
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("labels modified")}
 	mergeMap(modified, &existing.Annotations, required.Annotations)
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("annotations modified")}
 	mergeOwnerRefs(modified, &existing.OwnerReferences, required.OwnerReferences)
+	if required.Namespace == "openshift-monitoring" && required.Name == "cluster-monitoring-operator" && *modified {klog.V(2).Infof("owner references modified")}
 }
 
 func setStringIfSet(modified *bool, existing *string, required string) {
@@ -48,6 +55,7 @@ func mergeOwnerRefs(modified *bool, existing *[]metav1.OwnerReference, required 
 				found = true
 				if !equality.Semantic.DeepEqual((*existing)[eidx], required[ridx]) {
 					*modified = true
+					klog.V(2).Infof("clobering owner ref: %v != %v", (*existing)[eidx], required[ridx])
 					(*existing)[eidx] = required[ridx]
 				}
 				break
@@ -55,6 +63,7 @@ func mergeOwnerRefs(modified *bool, existing *[]metav1.OwnerReference, required 
 		}
 		if !found {
 			*modified = true
+			klog.V(2).Infof("injecting owner ref: %v\n  into %v", required[ridx], *existing)
 			*existing = append(*existing, required[ridx])
 		}
 	}


### PR DESCRIPTION
From [rhbz#2039119][1]:

```console
$ grep -o 'Updating .*due to diff' cvo.log | sort | uniq -c
     18 Updating CronJob openshift-operator-lifecycle-manager/collect-profiles due to diff
     12 Updating Service openshift-monitoring/cluster-monitoring-operator due to diff
```

Adding some debug logging for now, but I'll update once I understand the source of the hotlooping.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2039119#c0