### PR TITLE
Bug 2009845: pkg/cvo/sync_worker: Do not cancel sync workers on install-time target-version change

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -256,6 +256,9 @@ func (w *SyncWorker) Update(generation int64, desired configv1.Update, overrides
 	} else if !versionEqual && state == payload.InitializingPayload {
 		klog.Warningf("Ignoring detected version change from %v to %v during payload initialization", *oldDesired, work.Desired)
 		w.work.Desired = *oldDesired
+		if overridesEqual {
+			return w.status.DeepCopy()
+		}
 	}
 
 	// notify the sync loop that we changed config


### PR DESCRIPTION
Context:

1. bee2a5e634 (#713) was our initial attempt to respect overrides changes during install but reject target-release changes.  It [suffered from hot-looping on overrides-change detection][1], with:

    1. Change to overrides detected.
    2. Change not actually pushed into the sync workers.
    3. Sync workers canceled.
    4. Return to step i.

  and install didn't actually complete when overrides were set (e.g. because [the installer was inserting overrides during bootstrapping to keep the CVO from clobbering user-provided manifests][2]).

2. 11bca782a8 (#727), got CI flowing again while we worked up a fix.

3. 5c7ed6da32 (#728) restored something a lot like bee2a5e634.  It fixed the overrides-change/worker-cancel hotlooping by always passing updated overrides values through to thet sync workers.  But it introduced a very similar hot-loop for target-version changes, where:

    1. Change to target version detected.
    2. Change not actually pushed into the sync workers.
    3. Sync workers canceled.
    4. Return to step i.

  which would also fail installs.

This commit fixes that remaining issue with 5c7ed6da32, so now during install mode, when the version changes and overrides haven't changed, we no longer cancel the sync workers.  As in 5c7ed6da32, we will always pass any overrides changes on to the sync workers to avoid [the overrides hot-looping][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2009845#c8
[2]: https://github.com/openshift/installer/pull/5258