### PR TITLE
Bug 2009845: pkg/cvo/sync_worker: Use current state, not suggested state, for guarding Initializing->Updating

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -438,8 +438,8 @@ func (w *SyncWorker) calculateNext(work *SyncWork) bool {
 	if work.Empty() {
 		work.State = w.work.State
 		work.Attempt = 0
-	} else if changed && w.work.State != payload.InitializingPayload {
-		klog.V(2).Infof("Work changed, transitioning from %s and the suggested incoming %s state to %s", work.State, w.work.State, payload.UpdatingPayload)
+	} else if changed && work.State != payload.InitializingPayload {
+		klog.V(2).Infof("Work changed, transitioning from %s to %s", work.State, payload.UpdatingPayload)
 		work.State = payload.UpdatingPayload
 		work.Attempt = 0
 	}


### PR DESCRIPTION
Fixing a bug from 5c7ed6da32 (#728), where:

1. The bootstrap cluster-version operator does its happy thing.
2. With bootstrap winding down, the bootstrap CVO exits, in favor of a control-plane-hosted CVO.
3. Control-plane CVO acquires the leader lock, and [continues `Initializing`][e].
4. As a final bootstrap action, the installer [patches away its `spec.overrides` additions][1].
5. The control-plane CVO watcher gets notified after the `overrides` change, and [call `SyncWorker.Update`][f].
6. `SyncWorker.Update` notices that `w.work != nil`, so it ignores [its `state` argument][a], and [the newly-created work structure][b]'s `State` defaults to 0, because:

    ```console
    $ grep iota pkg/payload/payload.go
      UpdatingPayload State = iota
    ```

    and [`iota` starts at zero][2].  This is the bit I hadn't understood before.
7. `SyncWorker.calculateNext` sees [`changed` (because `!sameOverrides`)][d] and `w.work.State != payload.InitializingPayload` (because it defaulted to the `UpdatingPayload` zero value), and we'd get logs [like][3]:

    ```console
    $ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-serial/1488223505995534336/artifacts/e2e-aws-serial/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-79759cfdfd-h4fpr_cluster-version-operator.log | grep 'Work changed, transitioning from'
    I0131 19:10:19.526493       1 sync_worker.go:442] Work changed, transitioning from Initializing and the suggested incoming Updating state to Updating
    ```

With this commit, the sync worker respects the initial state passed in via `SyncWorker.Update` (which is [the `w.work == nil` case where `SyncWorker.Update` actually overrides the default state value][c]), but the sync worker ignores further `w.work.State` input, because it already knows its own state.

[1]: https://github.com/openshift/installer/pull/5258
[2]: https://go.dev/ref/spec#Iota
[3]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-aws-serial/1488223505995534336
[a]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/sync_worker.go#L208
[b]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/sync_worker.go#L212-L216
[c]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/sync_worker.go#L238-L239
[d]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/sync_worker.go#L434
[e]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/cvo.go#L568-L569
[f]: https://github.com/openshift/cluster-version-operator/blob/07295564ba659631396b6274171a78132b122bac/pkg/cvo/cvo.go#L577