### PR TITLE
Bug 2050946: pkg/featurechangestopper: Seed queue to guard against incorrect startingTechPreviewState

### DIFF
--- a/pkg/featurechangestopper/techpreviewchangestopper.go
+++ b/pkg/featurechangestopper/techpreviewchangestopper.go
@@ -40,6 +40,7 @@ func New(
 		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "feature-gate-stopper"),
 	}
 
+	c.queue.Add("cluster") // seed an initial sync, in case startingTechPreviewState is wrong
 	featureGateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Add("cluster")


### PR DESCRIPTION
As described in the bug, some 4.10 jobs that set `TechPreviewNoUpgrade` very early during install are running into trouble like:

1. Early in bootstrap, something sets `TechPreviewNoUpgrade`.
2. Cluster-version operator comes up, and attempts to figure out the current `featureSet`.  But because the Kubernetes API is also still coming up, that fails on an error [like][2]:

    ```console
    $ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-techpreview/1489537240471179264/artifacts/e2e-aws-techpreview/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-76cd65b7bb-4p945_cluster-version-operator.log | grep 'Error getting featuregate value\|tech'
    W0204 10:10:40.126809       1 start.go:142] Error getting featuregate value: Get "https://127.0.0.1:6443/apis/config.openshift.io/v1/featuregates/cluster": dial tcp 127.0.0.1:6443: connect: connection refused
    I0204 10:19:53.097129       1 techpreviewchangestopper.go:97] Starting stop-on-techpreview-change controller with TechPreviewNoUpgrade false.
    ```

3. The `TechPreviewChangeStopper` waits for any FeatureGate changes, but we don't get any.
4. CVO happily spends hours without synchronizing any of the requested `TechPreviewNoUpgrade` manifests.

Step 2 was originally fatal, but I'd softened it in 90b14542ae (#706).  Here are the relevant cases, and how they'd behave with the different approaches:

1. No Kube-API hiccup on the initial FeatureGate fetch.  All implementations handle this well.
2. Kube-API hiccup on the initial FeatureGate fetch.
    1. And the actual FeatureGate value was not `TechPreviewNoUpgrade`.  Before 90b14542ae, this would have caused a useless CVO container restart.  Since 90b14542ae, and unchanged in this commit, the CVO container's default:

          ```go
          includeTechPreview := false
          ```

          is correct, and we correctly ignore the hiccup.

    2. The actual FeatureGate value was `TechPreviewNoUpgrade`.  Before 90b14542ae, this would cause a useful CVO container restart.  From 90b14542ae until this commit, we'd hit the bug case where we'd go an unbounded amount of time failing to reconcile the `TechPreviewNoUpgrade` manifests the user was asking for.  With this commit, we notice the divergence right after the informer caches sync, and restart the CVO container.

[2]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-techpreview/1489537240471179264