### PR TITLE
Bug 2050946: Pass sharedInfromer instead of cvInformer to feature-gate-stopper

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -457,7 +457,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder, includeTechPreview boo
 			o.ClusterProfile,
 		),
 
-		StopOnFeatureGateChange: featurechangestopper.New(includeTechPreview, cvInformer.Config().V1().FeatureGates()),
+		StopOnFeatureGateChange: featurechangestopper.New(includeTechPreview, sharedInformers.Config().V1().FeatureGates()),
 	}
 
 	if o.EnableAutoUpdate {


### PR DESCRIPTION
`cvInformer` does not make sense for FeatureGate due to it filters out resources with name other than `version` by default,
which leads to the fact that FeatureGate will not be found there: https://github.com/openshift/cluster-version-operator/blob/a44a3c045fc81990994ed44a8159e942f257aec1/pkg/featurechangestopper/techpreviewchangestopper.go#L65
even in case if it is presented in the cluster.