### PR TITLE
Consume post install static spec capabilities

### DIFF
--- a/hack/cluster-version-util/task_graph.go
+++ b/hack/cluster-version-util/task_graph.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/cluster-version-operator/lib/capability"
 	"github.com/openshift/cluster-version-operator/pkg/payload"
 )
 
@@ -30,7 +31,7 @@ func newTaskGraphCmd() *cobra.Command {
 
 func runTaskGraphCmd(cmd *cobra.Command, args []string) error {
 	manifestDir := args[0]
-	release, err := payload.LoadUpdate(manifestDir, "", "", false, payload.DefaultClusterProfile)
+	release, err := payload.LoadUpdate(manifestDir, "", "", false, payload.DefaultClusterProfile, capability.ClusterCapabilities{})
 	if err != nil {
 		return err
 	}

--- a/lib/capability/capability.go
+++ b/lib/capability/capability.go
@@ -1,0 +1,111 @@
+package capability
+
+import (
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	CapabilityAnnotation = "capability.openshift.io/name"
+
+	DefaultCapabilitySet = configv1.ClusterVersionCapabilitySetCurrent
+)
+
+type ClusterCapabilities struct {
+	KnownCapabilities   map[configv1.ClusterVersionCapability]struct{}
+	EnabledCapabilities map[configv1.ClusterVersionCapability]struct{}
+}
+
+// SetCapabilities populates and returns cluster capabilities from ClusterVersion capabilities spec.
+func SetCapabilities(config *configv1.ClusterVersion) ClusterCapabilities {
+	var capabilities ClusterCapabilities
+	capabilities.KnownCapabilities = setKnownCapabilities(config)
+	capabilities.EnabledCapabilities = setEnabledCapabilities(config)
+	return capabilities
+}
+
+// GetCapabilitiesStatus populates and returns ClusterVersion capabilities status from given capabilities.
+func GetCapabilitiesStatus(capabilities ClusterCapabilities) configv1.ClusterVersionCapabilitiesStatus {
+	var status configv1.ClusterVersionCapabilitiesStatus
+	for k := range capabilities.EnabledCapabilities {
+		status.EnabledCapabilities = append(status.EnabledCapabilities, k)
+	}
+	for k := range capabilities.KnownCapabilities {
+		status.KnownCapabilities = append(status.KnownCapabilities, k)
+	}
+	return status
+}
+
+// CheckResourceEnablement, given resource annotations and defined cluster capabilities, checks if the capability
+// annotation exists. If so, each capability name is validated against the known set of capabilities. Each valid
+// capability is then checked if it is disabled. If any invalid capabilities are found an error is returned listing
+// all invalid capabilities. Otherwise, if any disabled capabilities are found an error is returned listing all
+// disabled capabilities.
+func CheckResourceEnablement(annotations map[string]string, capabilities ClusterCapabilities) error {
+	val, ok := annotations[CapabilityAnnotation]
+	if !ok {
+		return nil
+	}
+	caps := strings.Split(val, "+")
+	numCaps := len(caps)
+	unknownCaps := make([]string, 0, numCaps)
+	disabledCaps := make([]string, 0, numCaps)
+
+	for _, c := range caps {
+		if _, ok = capabilities.KnownCapabilities[configv1.ClusterVersionCapability(c)]; !ok {
+			unknownCaps = append(unknownCaps, c)
+		} else if _, ok = capabilities.EnabledCapabilities[configv1.ClusterVersionCapability(c)]; !ok {
+			disabledCaps = append(disabledCaps, c)
+		}
+	}
+	if len(unknownCaps) > 0 {
+		return fmt.Errorf("unrecognized capability names: %s", strings.Join(unknownCaps, ", "))
+	}
+	if len(disabledCaps) > 0 {
+		return fmt.Errorf("disabled capabilities: %s", strings.Join(disabledCaps, ", "))
+	}
+	return nil
+}
+
+// setKnownCapabilities populates a map keyed by capability from all known capabilities as defined in ClusterVersion.
+func setKnownCapabilities(config *configv1.ClusterVersion) map[configv1.ClusterVersionCapability]struct{} {
+	known := make(map[configv1.ClusterVersionCapability]struct{})
+
+	for _, v := range configv1.ClusterVersionCapabilitySets {
+		for _, capability := range v {
+			if _, ok := known[capability]; ok {
+				continue
+			}
+			known[capability] = struct{}{}
+		}
+	}
+	return known
+}
+
+// setEnabledCapabilities populates a map keyed by capability from all enabled capabilities as defined in ClusterVersion.
+// DefaultCapabilitySet is used if a baseline capability set is not defined by ClusterVersion.
+func setEnabledCapabilities(config *configv1.ClusterVersion) map[configv1.ClusterVersionCapability]struct{} {
+	enabled := make(map[configv1.ClusterVersionCapability]struct{})
+
+	capSet := DefaultCapabilitySet
+
+	if config.Spec.Capabilities != nil && len(config.Spec.Capabilities.BaselineCapabilitySet) > 0 {
+		capSet = config.Spec.Capabilities.BaselineCapabilitySet
+	}
+
+	for _, v := range configv1.ClusterVersionCapabilitySets[capSet] {
+		enabled[v] = struct{}{}
+	}
+
+	if config.Spec.Capabilities != nil {
+		for _, v := range config.Spec.Capabilities.AdditionalEnabledCapabilities {
+			if _, ok := enabled[v]; ok {
+				continue
+			}
+			enabled[v] = struct{}{}
+		}
+	}
+	return enabled
+}

--- a/lib/capability/capability_test.go
+++ b/lib/capability/capability_test.go
@@ -1,0 +1,287 @@
+package capability
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestSetCapabilities(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          *configv1.ClusterVersion
+		wantKnownKeys   []string
+		wantEnabledKeys []string
+	}{
+		{name: "capabilities nil",
+			config: &configv1.ClusterVersion{},
+			// wantKnownKeys and wantEnabledKeys will be set to default set of capabilities by test
+		},
+		{name: "capabilities set not set",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{},
+				},
+			},
+			// wantKnownKeys and wantEnabledKeys will be set to default set of capabilities by test
+		},
+		{name: "set capabilities None",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+						BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
+					},
+				},
+			},
+			wantKnownKeys:   []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+			wantEnabledKeys: []string{},
+		},
+		{name: "set capabilities 4_11",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+						BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySet4_11,
+						AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{},
+					},
+				},
+			},
+			wantKnownKeys:   []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+			wantEnabledKeys: []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+		},
+		{name: "set capabilities vCurrent",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+						BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySetCurrent,
+						AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{},
+					},
+				},
+			},
+			wantKnownKeys:   []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+			wantEnabledKeys: []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+		},
+		{name: "set capabilities None with additional",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+						BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySetNone,
+						AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1", "cap2", "cap3"},
+					},
+				},
+			},
+			wantKnownKeys:   []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+			wantEnabledKeys: []string{"cap1", "cap2", "cap3"},
+		},
+		{name: "set capabilities 4_11 with additional",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					Capabilities: &configv1.ClusterVersionCapabilitiesSpec{
+						BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySet4_11,
+						AdditionalEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1", "cap2", "cap3"},
+					},
+				},
+			},
+			wantKnownKeys:   []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples)},
+			wantEnabledKeys: []string{string(configv1.ClusterVersionCapabilityOpenShiftSamples), "cap1", "cap2", "cap3"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caps := SetCapabilities(test.config)
+			if test.config.Spec.Capabilities == nil || (test.config.Spec.Capabilities != nil &&
+				len(test.config.Spec.Capabilities.BaselineCapabilitySet) == 0) {
+
+				test.wantKnownKeys = getDefaultCapabilities()
+				test.wantEnabledKeys = getDefaultCapabilities()
+			}
+			if len(caps.KnownCapabilities) != len(test.wantKnownKeys) {
+				t.Errorf("Incorrect number of KnownCapabilities keys, wanted: %q. KnownCapabilities returned: %v", test.wantKnownKeys, caps.KnownCapabilities)
+			}
+			for _, v := range test.wantKnownKeys {
+				if _, ok := caps.KnownCapabilities[configv1.ClusterVersionCapability(v)]; !ok {
+					t.Errorf("Missing KnownCapabilities key %q. KnownCapabilities returned : %v", v, caps.KnownCapabilities)
+				}
+			}
+			if len(caps.EnabledCapabilities) != len(test.wantEnabledKeys) {
+				t.Errorf("Incorrect number of EnabledCapabilities keys, wanted: %q. EnabledCapabilities returned: %v", test.wantEnabledKeys, caps.EnabledCapabilities)
+			}
+			for _, v := range test.wantEnabledKeys {
+				if _, ok := caps.EnabledCapabilities[configv1.ClusterVersionCapability(v)]; !ok {
+					t.Errorf("Missing EnabledCapabilities key %q. EnabledCapabilities returned : %v", v, caps.EnabledCapabilities)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCapabilitiesStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		caps       ClusterCapabilities
+		wantStatus configv1.ClusterVersionCapabilitiesStatus
+	}{
+		{name: "empty capabilities",
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{},
+			},
+			wantStatus: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{},
+			},
+		},
+		{name: "capabilities",
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+			},
+			wantStatus: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityOpenShiftSamples},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityOpenShiftSamples},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := GetCapabilitiesStatus(test.caps)
+			if len(config.KnownCapabilities) != len(test.wantStatus.KnownCapabilities) {
+				t.Errorf("Incorrect number of KnownCapabilities keys, wanted: %q. KnownCapabilities returned: %v",
+					test.wantStatus.KnownCapabilities, config.KnownCapabilities)
+			}
+			for _, v := range test.wantStatus.KnownCapabilities {
+				vFound := false
+				for _, cv := range config.KnownCapabilities {
+					if v == cv {
+						vFound = true
+						break
+					}
+					if !vFound {
+						t.Errorf("Missing KnownCapabilities key %q. KnownCapabilities returned : %v", v, config.KnownCapabilities)
+					}
+				}
+			}
+			if len(config.EnabledCapabilities) != len(test.wantStatus.EnabledCapabilities) {
+				t.Errorf("Incorrect number of EnabledCapabilities keys, wanted: %q. EnabledCapabilities returned: %v",
+					test.wantStatus.EnabledCapabilities, config.EnabledCapabilities)
+			}
+			for _, v := range test.wantStatus.EnabledCapabilities {
+				vFound := false
+				for _, cv := range config.EnabledCapabilities {
+					if v == cv {
+						vFound = true
+						break
+					}
+					if !vFound {
+						t.Errorf("Missing EnabledCapabilities key %q. EnabledCapabilities returned : %v", v, config.EnabledCapabilities)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCheckResourceEnablement(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		caps        ClusterCapabilities
+		wantError   string
+	}{
+		{name: "empty annotations"},
+		{name: "no capabilitity annotation",
+			annotations: map[string]string{"foo": "bar"},
+		},
+		{name: "known capabilitity annotation",
+			annotations: map[string]string{CapabilityAnnotation: string(configv1.ClusterVersionCapabilityOpenShiftSamples), "foo": "bar"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+			},
+		},
+		{name: "multiple enabled capabilitities annotation",
+			annotations: map[string]string{CapabilityAnnotation: "cap1+cap2"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+			},
+		},
+		{name: "multiple capabilitities annotation with spaces",
+			annotations: map[string]string{CapabilityAnnotation: " + cap1 +cap2+ "},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+			},
+			wantError: "unrecognized capability names:  ,  cap1 ,  ",
+		},
+		{name: "unrecognized capabilitity annotation",
+			annotations: map[string]string{CapabilityAnnotation: "cap1"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+			},
+			wantError: "unrecognized capability names: cap1",
+		},
+		{name: "unrecognized capabilitities, spaces",
+			annotations: map[string]string{CapabilityAnnotation: "cap1 + cap2"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+			},
+			wantError: "unrecognized capability names: cap1 ,  cap2",
+		},
+		{name: "invalid capabilitity annotation divider",
+			annotations: map[string]string{CapabilityAnnotation: "cap1,cap2,cap3,cap4"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+			},
+			wantError: "unrecognized capability names: cap1,cap2,cap3,cap4",
+		},
+		{name: "multiple unrecognized capabilitities annotation",
+			annotations: map[string]string{CapabilityAnnotation: "cap1+cap2+cap3+cap4"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+			},
+			wantError: "unrecognized capability names: cap1, cap2, cap3, cap4",
+		},
+		{name: "disabled capabilitity annotation",
+			annotations: map[string]string{CapabilityAnnotation: "cap1"},
+			caps: ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{},
+			},
+			wantError: "disabled capabilities: cap1",
+		},
+		{name: "multiple disabled capabilitities annotation",
+			annotations: map[string]string{CapabilityAnnotation: "cap1+cap2+cap3+cap4+cap5+cap6"},
+			caps: ClusterCapabilities{
+				KnownCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {},
+					"cap3": {}, "cap4": {}, "cap5": {}, "cap6": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}},
+			},
+			wantError: "disabled capabilities: cap4, cap5, cap6",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := CheckResourceEnablement(test.annotations, test.caps)
+			if len(test.wantError) == 0 {
+				if err != nil {
+					t.Errorf("Wanted no error, got error %q", err.Error())
+				}
+			} else if test.wantError != err.Error() {
+				t.Errorf("Wanted error %q, got error %q", test.wantError, err.Error())
+			}
+		})
+	}
+}
+
+func getDefaultCapabilities() []string {
+	var caps []string
+
+	for _, v := range configv1.ClusterVersionCapabilitySets[DefaultCapabilitySet] {
+		caps = append(caps, string(v))
+	}
+	return caps
+}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -207,6 +207,10 @@ func TestCVO_StartupAndSync(t *testing.T) {
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 			},
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"openshift-samples"},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"openshift-samples"},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 				// cleared failing status and set progressing
@@ -565,6 +569,10 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
 			},
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"openshift-samples"},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"openshift-samples"},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
 				// cleared failing status and set progressing
@@ -899,6 +907,10 @@ func TestCVO_StartupAndSyncPreconditionFailing(t *testing.T) {
 			ObservedGeneration: 1,
 			History: []configv1.UpdateHistory{
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
+			},
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"openshift-samples"},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"openshift-samples"},
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
@@ -2059,6 +2071,10 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{"openshift-samples"},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{"openshift-samples"},
+			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
 				// cleared failing status and set progressing
@@ -2236,7 +2252,7 @@ func TestCVO_RestartAndReconcile(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions = client.Actions()
-	if len(actions) != 1 {
+	if len(actions) != 2 {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	expectGet(t, actions[0], "clusterversions", "", "version")

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -201,6 +201,8 @@ func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1
 	desired := optr.mergeReleaseMetadata(status.Actual)
 	mergeOperatorHistory(config, desired, status.Verified, now, status.Completed > 0)
 
+	config.Status.Capabilities = status.CapabilitiesStatus
+
 	// update validation errors
 	var reason string
 	if len(validationErrs) > 0 {

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -413,7 +413,7 @@ func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {
 func (r *fakeSyncRecorder) Start(ctx context.Context, maxWorkers int, cvoOptrName string, lister configlistersv1.ClusterVersionLister) {
 }
 
-func (r *fakeSyncRecorder) Update(ctx context.Context, generation int64, desired configv1.Update, overrides []configv1.ComponentOverride, state payload.State, cvoOptrName string) *SyncWorkerStatus {
+func (r *fakeSyncRecorder) Update(ctx context.Context, generation int64, desired configv1.Update, config *configv1.ClusterVersion, state payload.State, cvoOptrName string) *SyncWorkerStatus {
 	r.Updates = append(r.Updates, desired)
 	return r.Returns
 }

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 
+	"github.com/openshift/cluster-version-operator/lib/capability"
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
@@ -487,7 +488,7 @@ func Test_TaskGraph_real(t *testing.T) {
 	if len(path) == 0 {
 		t.Skip("TEST_GRAPH_PATH unset")
 	}
-	p, err := LoadUpdate(path, "arbitrary/image:1", "", false, DefaultClusterProfile)
+	p, err := LoadUpdate(path, "arbitrary/image:1", "", false, DefaultClusterProfile, capability.ClusterCapabilities{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Implements initial, postinstall, support of static capabilities
per Jira [OTA-567](https://issues.redhat.com/browse/OTA-567).