### PR TITLE
OCPBUGS-9133: pkg/cvo/metrics: Connect ClusterVersion to ClusterOperatorDown and ClusterOperatorDegraded

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -96,7 +96,7 @@ spec:
     - alert: ClusterOperatorDown
       annotations:
         summary: Cluster operator has not been available for 10 minutes.
-        description: The {{ "{{ $labels.name }}" }} operator may be down or disabled because {{ "{{ $labels.reason }}" }}, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+        description: The {{ "{{ $labels.name }}" }} operator may be down or disabled because {{ "{{ $labels.reason }}" }}, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to '{{ "{{ if eq $labels.name \"version\" }}oc adm upgrade{{ else }}oc get -o yaml clusteroperator {{ $labels.name }}{{ end }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDown.md
       expr: |
         max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator"} == 0)
@@ -106,13 +106,15 @@ spec:
     - alert: ClusterOperatorDegraded
       annotations:
         summary: Cluster operator has been degraded for 30 minutes.
-        description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{ $labels.reason }}" }}, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+        description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{ $labels.reason }}" }}, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to '{{ "{{ if eq $labels.name \"version\" }}oc adm upgrade{{ else }}oc get -o yaml clusteroperator {{ $labels.name }}{{ end }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
       expr: |
         max by (namespace, name, reason)
         (
           (
-            cluster_operator_conditions{job="cluster-version-operator", condition="Degraded"}
+            cluster_operator_conditions{job="cluster-version-operator", name!="version", condition="Degraded"}
+            or on (namespace, name)
+            cluster_operator_conditions{job="cluster-version-operator", name="version", condition="Failing"}
             or on (namespace, name)
             group by (namespace, name) (cluster_operator_up{job="cluster-version-operator"})
           ) == 1
@@ -123,7 +125,7 @@ spec:
     - alert: ClusterOperatorFlapping
       annotations:
         summary: Cluster operator up status is changing often.
-        description: The  {{ "{{ $labels.name }}" }} operator behavior might cause upgrades to be unstable. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+        description: The  {{ "{{ $labels.name }}" }} operator behavior might cause upgrades to be unstable. For more information refer to '{{ "{{ if eq $labels.name \"version\" }}oc adm upgrade{{ else }}oc get -o yaml clusteroperator {{ $labels.name }}{{ end }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
       expr: |
         max by (namespace, name) (changes(cluster_operator_up{job="cluster-version-operator"}[2m]) > 2)
       for: 10m

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -69,11 +69,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				releaseCreated: time.Unix(3, 0),
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "", "version": "", "invoker": ""})
 			},
 		},
 		{
@@ -85,11 +87,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "", "version": "", "invoker": ""})
 			},
 		},
 		{
@@ -225,12 +229,14 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 3 {
+				if len(metrics) != 5 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1", "reason": "NoAvailableCondition"})
-				expectMetric(t, metrics[2], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
+				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "version": "10.1.5-1", "reason": "NoAvailableCondition"})
+				expectMetric(t, metrics[4], 1, map[string]string{"type": ""})
 			},
 		},
 		{
@@ -256,13 +262,15 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 4 {
+				if len(metrics) != 6 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
-				expectMetric(t, metrics[1], 0, map[string]string{"name": "test", "version": "10.1.5-1"})
-				expectMetric(t, metrics[2], 0, map[string]string{"name": "test", "condition": "Available"})
-				expectMetric(t, metrics[3], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
+				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "version": "10.1.5-1"})
+				expectMetric(t, metrics[4], 0, map[string]string{"name": "test", "condition": "Available"})
+				expectMetric(t, metrics[5], 1, map[string]string{"type": ""})
 			},
 		},
 		{
@@ -289,14 +297,16 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 5 {
+				if len(metrics) != 7 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": "10.1.5-1"})
-				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available"})
-				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "condition": "Degraded"})
-				expectMetric(t, metrics[4], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
+				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "version": "10.1.5-1"})
+				expectMetric(t, metrics[4], 1, map[string]string{"name": "test", "condition": "Available"})
+				expectMetric(t, metrics[5], 1, map[string]string{"name": "test", "condition": "Degraded"})
+				expectMetric(t, metrics[6], 1, map[string]string{"type": ""})
 			},
 		},
 		{
@@ -321,14 +331,16 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 5 {
+				if len(metrics) != 7 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
-				expectMetric(t, metrics[1], 1, map[string]string{"name": "test", "version": ""})
-				expectMetric(t, metrics[2], 1, map[string]string{"name": "test", "condition": "Available", "reason": ""})
-				expectMetric(t, metrics[3], 0, map[string]string{"name": "test", "condition": "Custom", "reason": "CustomReason"})
-				expectMetric(t, metrics[4], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 0, map[string]string{"type": "current", "version": "", "image": "", "from_version": ""})
+				expectMetric(t, metrics[3], 1, map[string]string{"name": "test", "version": ""})
+				expectMetric(t, metrics[4], 1, map[string]string{"name": "test", "condition": "Available", "reason": ""})
+				expectMetric(t, metrics[5], 0, map[string]string{"name": "test", "condition": "Custom", "reason": "CustomReason"})
+				expectMetric(t, metrics[6], 1, map[string]string{"type": ""})
 			},
 		},
 		{
@@ -424,15 +436,16 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 6 {
+				if len(metrics) != 7 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
 				expectMetric(t, metrics[0], 2, map[string]string{"type": "initial", "version": "", "image": "", "from_version": ""})
 				expectMetric(t, metrics[1], 2, map[string]string{"type": "cluster", "version": "0.0.2", "image": "test/image:1", "from_version": ""})
 				expectMetric(t, metrics[2], 5, map[string]string{"type": "desired", "version": "1.0.0", "image": "test/image:2", "from_version": ""})
-				expectMetric(t, metrics[3], 1, map[string]string{"name": "version", "condition": "Available", "reason": "Because stuff"})
-				expectMetric(t, metrics[4], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "from_version": ""})
-				expectMetric(t, metrics[5], 1, map[string]string{"type": ""})
+				expectMetric(t, metrics[3], 1, map[string]string{"name": "version", "version": "", "reason": "Because stuff"})
+				expectMetric(t, metrics[4], 1, map[string]string{"name": "version", "condition": "Available", "reason": "Because stuff"})
+				expectMetric(t, metrics[5], 0, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1", "from_version": ""})
+				expectMetric(t, metrics[6], 1, map[string]string{"type": ""})
 			},
 		},
 		{
@@ -532,11 +545,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "openshift-install", "version": "v0.0.2", "invoker": "jane"})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "openshift-install", "version": "v0.0.2", "invoker": "jane"})
 			},
 		},
 		{
@@ -561,11 +576,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "openshift-install", "version": "v0.0.2", "invoker": "jane"})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "openshift-install", "version": "v0.0.2", "invoker": "jane"})
 			},
 		},
 		{
@@ -584,11 +601,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "other", "version": "v0.0.1", "invoker": "bill"})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "other", "version": "v0.0.1", "invoker": "bill"})
 			},
 		},
 		{
@@ -606,11 +625,13 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 2 {
+				if len(metrics) != 4 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
-				expectMetric(t, metrics[1], 1, map[string]string{"type": "openshift-install", "version": "<missing>", "invoker": "<missing>"})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[3], 1, map[string]string{"type": "openshift-install", "version": "<missing>", "invoker": "<missing>"})
 			},
 		},
 		{
@@ -626,10 +647,12 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				},
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 1 {
+				if len(metrics) != 3 {
 					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
 				}
-				expectMetric(t, metrics[0], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
+				expectMetric(t, metrics[0], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[1], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[2], 3, map[string]string{"type": "current", "version": "0.0.2", "image": "test/image:1"})
 			},
 		},
 	}
@@ -716,18 +739,20 @@ func Test_operatorMetrics_CollectTransitions(t *testing.T) {
 				eventRecorder: record.NewFakeRecorder(100),
 			},
 			wants: func(t *testing.T, metrics []prometheus.Metric) {
-				if len(metrics) != 5 {
-					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
-				}
 				sort.Slice(metrics, func(i, j int) bool {
 					a, b := metricParts(t, metrics[i], "name", "condition"), metricParts(t, metrics[j], "name", "condition")
 					return a < b
 				})
+				if len(metrics) != 7 {
+					t.Fatalf("Unexpected metrics %s", spew.Sdump(metrics))
+				}
 				expectMetric(t, metrics[0], 1, map[string]string{"type": ""})
 				expectMetric(t, metrics[1], 3, map[string]string{"name": "test", "condition": "Available"})
 				expectMetric(t, metrics[2], 2, map[string]string{"name": "test", "condition": "Custom"})
 				expectMetric(t, metrics[3], 2, map[string]string{"name": "test", "condition": "Unknown"})
-				expectMetric(t, metrics[4], 0, map[string]string{"type": "current", "version": "", "image": ""})
+				expectMetric(t, metrics[4], 0, map[string]string{"name": "version", "condition": "Available", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[5], 0, map[string]string{"name": "version", "version": "", "reason": "ClusterVersionNotFound"})
+				expectMetric(t, metrics[6], 0, map[string]string{"type": "current", "version": "", "image": ""})
 			},
 		},
 	}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -247,6 +247,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 						}
 						klog.Infof("Failed to initialize from payload; shutting down: %v", err)
 						resultChannel <- asyncResult{name: "payload initialization", error: firstError}
+						return
 					}
 
 					resultChannelCount++


### PR DESCRIPTION
By adding `cluster_operator_up` handling for ClusterVersion, with `version` as the component name, the same way we handle `cluster_operator_conditions`.  This plugs us into `ClusterOperatorDown` (based on `cluster_operator_up`) and `ClusterOperatorDegraded` (based on both `cluster_operator_conditions` and `cluster_operator_up`).

I've adjusted the `ClusterOperatorDegraded` rule so that it fires on ClusterVersion `Failing=True` and does not fire on `Failing=False`.  Thinking through an update from before:

1. Outgoing CVO does not serve `cluster_operator_up{name="version"}`.
2. User requests an update to a release with this change.
3. New CVO comes in, starts serving `cluster_operator_up{name="version"}`.
4. Old `ClusterOperatorDegraded` no matching `cluster_operator_conditions{name="version",condition="Degraded"}`, falls through to `cluster_operator_up{name="version"}`, and starts cooking the `for: 30m`.
5. If we go more than 30m before updating the `ClusterOperatorDegraded` rule to understand `Failing`, `ClusterOperatorDegraded` would fire.

We'll need to backport the `ClusterOperatorDegraded` `expr` change to one 4.y release before the CVO-metrics change lands to get:

1. Outgoing CVO does not serve `cluster_operator_up{name="version"}`.
2. User requests an update to a release with the `expr` change.
3. Incoming `ClusterOperatorDegraded` sees no `cluster_operator_conditions{name="version",condition="Degraded"}`, `cluster_operator_conditions{name="version",condition="Failing"}` (we hope), or `cluster_operator_up{name="version"}`, so it doesn't fire.  Unless we are `Failing=True`, in which case, hooray, we'll start alerting about it.
4. User requests an update to a release with the CVO-metrics change.
5. New CVO starts serving `cluster_operator_up{name="version"}`, just like the fresh-modern-install situation, and everything is great.

The missing-ClusterVersion metrics don't matter all that much today, because the CVO has been creating replacement ClusterVersion since at least 90e9881bd5 (#45).  But it will become more important with #741, which is planning on removing that default creation.  When there is no ClusterVersion, we expect `ClusterOperatorDown` to fire.
