### PR TITLE
pkg/payload: Log load-time manifest exclusion at V(2)

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -191,7 +191,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, includeTechPreview 
 			filteredMs := []manifest.Manifest{}
 			for _, manifest := range ms {
 				if err := include(excludeIdentifier, includeTechPreview, profile, capabilities, &manifest); err != nil {
-					klog.V(5).Infof("excluding %s group=%s kind=%s namespace=%s name=%s: %v\n", manifest.OriginalFilename, manifest.GVK.Group, manifest.GVK.Kind, manifest.Obj.GetNamespace(), manifest.Obj.GetName(), err)
+					klog.V(2).Infof("excluding %s group=%s kind=%s namespace=%s name=%s: %v\n", manifest.OriginalFilename, manifest.GVK.Group, manifest.GVK.Kind, manifest.Obj.GetNamespace(), manifest.Obj.GetName(), err)
 					continue
 				}
 				filteredMs = append(filteredMs, manifest)


### PR DESCRIPTION
We moved from `--v=5` to `--v=2` with c4a10047f3 (#721).  But this `V(5)` logging slipped through via the parallel 5d343a503d (#712).  Catch it up, to restore exclusion logging.