### PR TITLE
Implicitly enable capabilities on updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/openshift/api v0.0.0-20220325173635-8107b7a38e53
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220329193146-715792ed530d
+	github.com/openshift/library-go v0.0.0-20220407182450-db47826e7275
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220329193146-715792ed530d h1:uEOiLtoPeRfnsust0rTediph3fYqUxBVgJ5zWVMnxwY=
-github.com/openshift/library-go v0.0.0-20220329193146-715792ed530d/go.mod h1:5a5oGzRGu6XjtAmChVlwstxp0MWDGh7fIXlN34mFiLA=
+github.com/openshift/library-go v0.0.0-20220407182450-db47826e7275 h1:OxtWEHhHDsjGbxbGL7ivDXjZmyujHuEsQaaxih3LsXw=
+github.com/openshift/library-go v0.0.0-20220407182450-db47826e7275/go.mod h1:5a5oGzRGu6XjtAmChVlwstxp0MWDGh7fIXlN34mFiLA=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/cvo/testdata/payloadcapabilitytest/test1/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test1/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test1/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test1/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test2/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test2/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test2/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test2/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Diff",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test3/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test3/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test3/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test3/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test4/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test4/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test4/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test4/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test5/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test5/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test5/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test5/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test6/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test6/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test6/current/file_2.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test6/current/file_2.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name2",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test6/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test6/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test6/update/file_2.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test6/update/file_2.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name2",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1+cap3+cap5+cap7"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_2.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_2.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name2",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1+cap2+cap4+cap6+cap8"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_3.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_3.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name3",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2+cap9+cap11+cap13+cap15"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_4.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_4.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name4",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap10+cap12+cap14+cap16"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_5.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_5.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name5",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap17+cap19+cap21+cap23"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_6.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/current/file_6.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name6",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap18+cap20+cap22+cap24"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap111+cap113+cap115+cap117"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_2.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_2.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name2",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap111+cap112+cap114+cap116+cap118"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_3.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_3.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name3",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap112+cap119+cap1111+cap1113+cap1115"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_4.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_4.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name4",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1110+cap1112+cap1114+cap1116"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_5.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_5.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name5",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap17+cap19+cap21+cap23"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_6.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test7/update/file_6.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name6",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap18+cap20+cap22+cap24"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test8/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test8/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test9/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test9/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -1,7 +1,10 @@
 package payload
 
 import (
+	"errors"
+	"flag"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -11,12 +14,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 
+	"github.com/openshift/cluster-version-operator/lib/capability"
 	"github.com/openshift/library-go/pkg/manifest"
 )
+
+func init() {
+	klog.InitFlags(flag.CommandLine)
+	_ = flag.CommandLine.Lookup("v").Value.Set("2")
+	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
+}
 
 func TestLoadUpdate(t *testing.T) {
 	type args struct {
@@ -126,6 +137,206 @@ func TestLoadUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
+	const testsPath = "../cvo/testdata/payloadcapabilitytest/"
+
+	tests := []struct {
+		name               string
+		pathExt            string
+		updateAnnotations  map[string]interface{}
+		currentAnnotations map[string]interface{}
+		capabilities       capability.ClusterCapabilities
+		wantImplicit       []configv1.ClusterVersionCapability
+		wantImplicitLen    int
+	}{
+		{
+			name:    "basic",
+			pathExt: "test1",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap2"),
+			},
+			wantImplicitLen: 1,
+		},
+		{
+			name:    "different manifest",
+			pathExt: "test2",
+		},
+		{
+			name:    "current manifest not enabled",
+			pathExt: "test3",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+			},
+		},
+		{
+			name:    "new cap already enabled",
+			pathExt: "test4",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+			},
+		},
+		{
+			name:    "already implicitly enabled",
+			pathExt: "test5",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap2"},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap2"),
+			},
+			wantImplicitLen: 1,
+		},
+		{
+			name:    "only add cap once",
+			pathExt: "test6",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap2"),
+			},
+			wantImplicitLen: 1,
+		},
+		{
+			/*
+				Grep manifest file data to understand results:
+				$ grep cap ../cvo/testdata/payloadcapabilitytest/test7/current/fil*
+				grep cap ../cvo/testdata/payloadcapabilitytest/test7/update/fil*
+			*/
+
+			name:    "complex",
+			pathExt: "test7",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities: map[configv1.ClusterVersionCapability]struct{}{
+					"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}, "cap6": {},
+					"cap7": {}, "cap8": {}, "cap9": {}, "cap10": {}, "cap11": {}, "cap12": {},
+					"cap13": {}, "cap14": {}, "cap15": {}, "cap16": {}, "cap17": {}, "cap18": {},
+					"cap19": {}, "cap20": {}, "cap21": {}, "cap22": {}, "cap23": {}, "cap24": {},
+				},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{
+					"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}, "cap6": {},
+					"cap7": {}, "cap8": {}, "cap9": {}, "cap10": {}, "cap11": {}, "cap12": {},
+					"cap13": {}, "cap14": {}, "cap15": {}, "cap16": {}, "cap17": {}, "cap18": {},
+					"cap19": {}, "cap20": {}, "cap21": {}, "cap22": {}, "cap23": {}, "cap24": {},
+				},
+				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+					configv1.ClusterVersionCapability("cap000"),
+					configv1.ClusterVersionCapability("cap111"),
+					configv1.ClusterVersionCapability("cap112"),
+					configv1.ClusterVersionCapability("cap113"),
+					configv1.ClusterVersionCapability("cap114"),
+				},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap000"),
+				configv1.ClusterVersionCapability("cap111"),
+				configv1.ClusterVersionCapability("cap112"),
+				configv1.ClusterVersionCapability("cap113"),
+				configv1.ClusterVersionCapability("cap114"),
+				configv1.ClusterVersionCapability("cap115"),
+				configv1.ClusterVersionCapability("cap116"),
+				configv1.ClusterVersionCapability("cap117"),
+				configv1.ClusterVersionCapability("cap118"),
+				configv1.ClusterVersionCapability("cap119"),
+				configv1.ClusterVersionCapability("cap1110"),
+				configv1.ClusterVersionCapability("cap1111"),
+				configv1.ClusterVersionCapability("cap1112"),
+				configv1.ClusterVersionCapability("cap1113"),
+				configv1.ClusterVersionCapability("cap1114"),
+				configv1.ClusterVersionCapability("cap1115"),
+				configv1.ClusterVersionCapability("cap1116"),
+			},
+			wantImplicitLen: 17,
+		},
+		{
+			name:    "no update manifests",
+			pathExt: "test8",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1"},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap1"),
+			},
+			wantImplicitLen: 1,
+		},
+		{
+			name:    "no current manifests",
+			pathExt: "test9",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1"},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap1"),
+			},
+			wantImplicitLen: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := testsPath + tt.pathExt + "/current"
+			currentMans, err := readManifestFiles(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path = testsPath + tt.pathExt + "/update"
+			updateMans, err := readManifestFiles(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			caps := GetImplicitlyEnabledCapabilities(updateMans, currentMans, tt.capabilities)
+			if len(caps) != tt.wantImplicitLen {
+				t.Errorf("Incorrect number of implicitly enabled keys, wanted: %d. Implicitly enabled capabilities returned: %v", tt.wantImplicitLen, caps)
+			}
+			for _, wanted := range tt.wantImplicit {
+				found := false
+				for _, have := range caps {
+					if wanted == have {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Missing implicitly enabled capability %q. Implicitly enabled capabilities returned : %v", wanted, caps)
+				}
+			}
+		})
+	}
+}
+
+func readManifestFiles(path string) ([]manifest.Manifest, error) {
+	readFiles, err := ioutil.ReadDir(path)
+
+	// no dir for nil tests
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	files := []string{}
+	for _, f := range readFiles {
+		if !f.IsDir() {
+			files = append(files, path+"/"+f.Name())
+		}
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+	return manifest.ManifestsFromFiles(files)
 }
 
 func mustRead(path string) []byte {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/openshift/client-go/image/clientset/versioned/scheme
 github.com/openshift/client-go/image/clientset/versioned/typed/image/v1
 github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
-# github.com/openshift/library-go v0.0.0-20220329193146-715792ed530d
+# github.com/openshift/library-go v0.0.0-20220407182450-db47826e7275
 ## explicit
 github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/leaderelection


### PR DESCRIPTION
per [OTA-574](https://issues.redhat.com/browse/OTA-574). For each manifest in the updated payload, if the manifest is enabled in
the current payload ensure any disabled capability in the updated manifest is enabled. These capabilities are then added to the list of "implicitly enabled" capabilities.