### PR TITLE
pkg/cvo/sync_worker: Log only changed enabled capabilities

### DIFF
--- a/lib/capability/capability.go
+++ b/lib/capability/capability.go
@@ -1,6 +1,7 @@
 package capability
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -19,8 +20,12 @@ type ClusterCapabilities struct {
 	ImplicitlyEnabledCapabilities []configv1.ClusterVersionCapability
 }
 
-func (c *ClusterCapabilities) Equal(capabilities *ClusterCapabilities) bool {
-	return reflect.DeepEqual(c.EnabledCapabilities, capabilities.EnabledCapabilities)
+func (c *ClusterCapabilities) Equal(capabilities *ClusterCapabilities) error {
+	if !reflect.DeepEqual(c.EnabledCapabilities, capabilities.EnabledCapabilities) {
+		return fmt.Errorf("enabled %v not equal to %v", c.EnabledCapabilities, capabilities.EnabledCapabilities)
+	}
+
+	return nil
 }
 
 type capabilitiesSort []configv1.ClusterVersionCapability

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -693,7 +693,7 @@ func equalSyncWork(a, b *SyncWork, context string) (equalVersion, equalOverrides
 
 	sameVersion := equalUpdate(a.Desired, b.Desired)
 	sameOverrides := reflect.DeepEqual(a.Overrides, b.Overrides)
-	sameCapabilities := a.Capabilities.Equal(&b.Capabilities)
+	capabilitiesError := a.Capabilities.Equal(&b.Capabilities)
 
 	var msgs []string
 	if !sameVersion {
@@ -702,13 +702,13 @@ func equalSyncWork(a, b *SyncWork, context string) (equalVersion, equalOverrides
 	if !sameOverrides {
 		msgs = append(msgs, fmt.Sprintf("overrides changed (%v to %v)", a.Overrides, b.Overrides))
 	}
-	if !sameCapabilities {
-		msgs = append(msgs, fmt.Sprintf("capabilities changed (%v to %v)", a.Capabilities, b.Capabilities))
+	if capabilitiesError != nil {
+		msgs = append(msgs, fmt.Sprintf("capabilities changed (%v)", capabilitiesError))
 	}
 	if len(msgs) > 0 {
 		klog.V(2).Infof("Detected while %s: %s", context, strings.Join(msgs, ", "))
 	}
-	return sameVersion, sameOverrides, sameCapabilities
+	return sameVersion, sameOverrides, capabilitiesError == nil
 }
 
 // updateStatus records the current status of the sync action for observation


### PR DESCRIPTION
Pivot `ClusterCapabilities.Equal` to return an error explaining the difference.  This allows me to use that tailored error in the `equalSyncWork` message, so I don't have to guess how `ClusterCapabilities.Equal` is implemented or log the whole capabilities structure.