### PR TITLE
Bug 2072389: Do not save desired update on load failures

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -2022,7 +2022,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 		t.Fatal(err)
 	}
 	actions = client.Actions()
-	if len(actions) != 1 {
+	if len(actions) != 2 {
 		t.Fatalf("%s", spew.Sdump(actions))
 	}
 	expectGet(t, actions[0], "clusterversions", "", "version")
@@ -2170,7 +2170,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "version",
-			ResourceVersion: "3",
+			ResourceVersion: "4",
 			Generation:      1,
 		},
 		Spec: configv1.ClusterVersionSpec{


### PR DESCRIPTION
since this will cause `equalSyncWork` to continually return `true` and no reattempt to load the payload will occur until the desired update is updated by the user again, e.g. image change or change to `force`. This was accomplished by moving `work` update, including the desired version, after the desired version payload has been successfully loaded.

See commit message for more details on precondition failures in general and the `RecentEtcdBackup` precondition specifically.