### PR TITLE
Bug 2070805: pkg/cvo/updatepayload: Restore shell for rm globbing

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -202,8 +202,9 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						setContainerDefaults(corev1.Container{
-							Name:    "cleanup",
-							Command: []string{"rm", "-fR", filepath.Join(baseDir, "*")},
+							Name:       "cleanup",
+							Command:    []string{"sh", "-c", "rm -fR *"},
+							WorkingDir: baseDir,
 						}),
 						setContainerDefaults(corev1.Container{
 							Name:    "make-temporary-directory",


### PR DESCRIPTION
Some background on recent changes:

* 507b474632 (#760) attempted to add CVO-side directory removal, but that failed because the CVO mounts the shared volume `readOnly: true`.

* a5af89d34e (#765) shifted removal into the job itself.  As far as I can tell, this worked.

* c45a981302 (#765) addressed concerns with unquoted shell arguments by pivoting to `initContainers` and dropping the shell.  This broke the `*` pathname expansion that `rm` depends on to find directories to remove.

This commit returns to using the shell to invoke the `rm` call, so we get [pathname expansion][1] back.  But I avoid the possibility of unquoted argument injection by using `workingDir` to bring in `baseDir`.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_06