### PR TITLE
Bug 2079789: capability: Init prior known from CV status

### DIFF
--- a/lib/capability/capability.go
+++ b/lib/capability/capability.go
@@ -48,6 +48,15 @@ func SetCapabilities(config *configv1.ClusterVersion,
 	return capabilities
 }
 
+// GetCapabilitiesAsMap returns the slice of capabilities as a map with default values.
+func GetCapabilitiesAsMap(capabilities []configv1.ClusterVersionCapability) map[configv1.ClusterVersionCapability]struct{} {
+	caps := make(map[configv1.ClusterVersionCapability]struct{}, len(capabilities))
+	for _, c := range capabilities {
+		caps[c] = struct{}{}
+	}
+	return caps
+}
+
 // SetFromImplicitlyEnabledCapabilities, given implicitly enabled capabilities and cluster capabilities, updates
 // the latter with the given implicitly enabled capabilities and ensures each is in the enabled map. The updated
 // cluster capabilities are returned.
@@ -143,17 +152,12 @@ func setEnabledCapabilities(capabilitiesSpec *configv1.ClusterVersionCapabilitie
 	priorEnabled map[configv1.ClusterVersionCapability]struct{}) (map[configv1.ClusterVersionCapability]struct{},
 	[]configv1.ClusterVersionCapability) {
 
-	enabled := make(map[configv1.ClusterVersionCapability]struct{})
-
 	capSet := DefaultCapabilitySet
 
 	if capabilitiesSpec != nil && len(capabilitiesSpec.BaselineCapabilitySet) > 0 {
 		capSet = capabilitiesSpec.BaselineCapabilitySet
 	}
-
-	for _, v := range configv1.ClusterVersionCapabilitySets[capSet] {
-		enabled[v] = struct{}{}
-	}
+	enabled := GetCapabilitiesAsMap(configv1.ClusterVersionCapabilitySets[capSet])
 
 	if capabilitiesSpec != nil {
 		for _, v := range capabilitiesSpec.AdditionalEnabledCapabilities {

--- a/pkg/cvo/testdata/payloadcapabilitytest/test10/current/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test10/current/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap1"
+    }
+  }
+}

--- a/pkg/cvo/testdata/payloadcapabilitytest/test10/update/file_1.yaml
+++ b/pkg/cvo/testdata/payloadcapabilitytest/test10/update/file_1.yaml
@@ -1,0 +1,11 @@
+{
+  "kind": "Test",
+  "apiVersion": "k8s.io/v1",
+  "metadata": {
+    "name": "name1",
+    "namespace": "ns1",
+    "annotations": {
+      "capability.openshift.io/name": "cap2"
+    }
+  }
+}

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -155,7 +155,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "basic",
 			pathExt: "test1",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
@@ -187,7 +187,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "already implicitly enabled",
 			pathExt: "test5",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap2"},
 			},
@@ -200,7 +200,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "only add cap once",
 			pathExt: "test6",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
@@ -223,6 +223,9 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 					"cap7": {}, "cap8": {}, "cap9": {}, "cap10": {}, "cap11": {}, "cap12": {},
 					"cap13": {}, "cap14": {}, "cap15": {}, "cap16": {}, "cap17": {}, "cap18": {},
 					"cap19": {}, "cap20": {}, "cap21": {}, "cap22": {}, "cap23": {}, "cap24": {},
+					"cap111": {}, "cap112": {}, "cap113": {}, "cap114": {}, "cap115": {}, "cap116": {},
+					"cap117": {}, "cap118": {}, "cap119": {}, "cap1111": {}, "cap1113": {}, "cap1115": {},
+					"cap1110": {}, "cap1112": {}, "cap1114": {}, "cap1116": {},
 				},
 				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{
 					"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}, "cap6": {},
@@ -285,6 +288,18 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			},
 			wantImplicitLen: 1,
 		},
+		{
+			name:    "duplicate manifests",
+			pathExt: "test10",
+			capabilities: capability.ClusterCapabilities{
+				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+			},
+			wantImplicit: []configv1.ClusterVersionCapability{
+				configv1.ClusterVersionCapability("cap2"),
+			},
+			wantImplicitLen: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -297,6 +312,10 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			updateMans, err := readManifestFiles(path)
 			if err != nil {
 				t.Fatal(err)
+			}
+			// readManifestFiles does not allow dup manifests so hacking in here.
+			if tt.pathExt == "test10" {
+				updateMans = append(updateMans, updateMans[0])
 			}
 			caps := GetImplicitlyEnabledCapabilities(updateMans, currentMans, tt.capabilities)
 			if len(caps) != tt.wantImplicitLen {


### PR DESCRIPTION
so newly started CVO pod, including one which results from an upgrade, will be able to determine and set implicitly enabled capabilities.
Also made the following changes:
- Set `w.status` when `w.work == nil` so as not to clobber `CapabilitiesStatus`. `CapabilitiesStatus` would never had been set at that point in the code before this change.
- Duplicate manifests are handled by `GetImplicitlyEnabledCapabilities` by tainting in all applicable capabilities across the duplicated manifests.