### PR TITLE
Revert "admin-gates: Add ack-4.11-kube-1.25-api-removals-in-4.12 gate"

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -1,9 +1,5 @@
 apiVersion: v1
 kind: ConfigMap
-data:
-  ack-4.11-kube-1.25-api-removals-in-4.12: |
-      Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration. Please see
-      the knowledge article https://access.redhat.com/articles/6955381 for details and instructions.
 metadata:
   name: admin-gates
   namespace: openshift-config-managed


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#772

It's tripping up tech-preview informers like [this][1]:

```
: [sig-cluster-lifecycle] TestAdminAck should succeed [Suite:openshift/conformance/parallel]
Run #0: Failed	3m3s

{  fail [github.com/openshift/origin/test/extended/util/openshift/clusterversionoperator/adminack.go:117]: May  6 07:24:05.028: Error while waiting for Upgradeable to go AdminAckRequired with message "Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration. Please see\nthe knowledge article https://access.redhat.com/articles/6955381 for details and instructions.\n": timed out waiting for the condition
Upgradeable: Status=False, Reason=MultipleReasons, Message="Cluster should not be upgraded between minor versions for multiple reasons: AdminAckRequired,FeatureGates_RestrictedFeatureGates_TechPreviewNoUpgrade\n* Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration. Please see\nthe knowledge article https://access.redhat.com/articles/6955381 for details and instructions.\n\n* Cluster operator kube-apiserver should not be upgraded between minor versions: FeatureGatesUpgradeable: \"TechPreviewNoUpgrade\" does not allow updates".}
```

Opening a revert while we sort out the test issue.  CC @LalatenduMohanty 

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-azure-techpreview/1522457624627384320
