### PR TITLE
Revert "admin-gates: Add ack-4.11-kube-1.25-api-removals-in-4.12 gate"

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -1,9 +1,5 @@
 apiVersion: v1
 kind: ConfigMap
-data:
-  ack-4.11-kube-1.25-api-removals-in-4.12: |
-      Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration. Please see
-      the knowledge article https://access.redhat.com/articles/6955381 for details and instructions.
 metadata:
   name: admin-gates
   namespace: openshift-config-managed


### PR DESCRIPTION
This reverts commit f159829988ab7db53460ae725d4ebfbfb7641e1c.

We are reverting this because we want to merge with around 4.12 feature
freeze. Right now it is too early to add this.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>