### PR TITLE
Bug 2090150: pkg/cvo/sync_worker.go: Save overrides

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -419,6 +419,10 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 	err := w.loadUpdatedPayload(ctx, work, cvoOptrName)
 	w.lock.Lock()
 	if err != nil {
+		// save override changes if not first time through
+		if w.work != nil {
+			w.work.Overrides = overrides
+		}
 		return w.status.DeepCopy()
 	}
 


### PR DESCRIPTION
when payload load fails.