### PR TITLE
Bug 2091770: pkg/cvo/updatepayload: Guard against 'rm -fR -whatever' with ./*

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -204,7 +204,7 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 					InitContainers: []corev1.Container{
 						setContainerDefaults(corev1.Container{
 							Name:       "cleanup",
-							Command:    []string{"sh", "-c", "rm -fR *"},
+							Command:    []string{"sh", "-c", "rm -fR ./*"},
 							WorkingDir: baseDir,
 						}),
 						setContainerDefaults(corev1.Container{


### PR DESCRIPTION
[Avoiding][1]:

```console
$ tar -xOz must-gather/namespaces/openshift-cluster-version/pods/version-4.10.16-dk76g-6qdx2/cleanup/cleanup/logs/current.log <02527285_must-gather-20220531_022021Z.tar.gz
2022-05-31T02:13:19.710822157Z rm: invalid option -- 'c'
2022-05-31T02:13:19.710822157Z Try 'rm ./-cgXkuYo_RfOyhs3_AZGxQ' to remove the file '-cgXkuYo_RfOyhs3_AZGxQ'.
2022-05-31T02:13:19.710822157Z Try 'rm --help' for more information.
```

The version-specific filenames are MD5s of the image pullspec which are then encoded with `RawURLEncoding`.  [`RawURLEncoding` uses the encoding from RFC 4648][2].  RFC 4648's URL encoding [includes `-` for decimal 62][3].

We could use `rm -fR -- *`, but I don't see `--` specified [in POSIX][4].  `./*` is a POSIX-compliant way to avoid `rm` misinterpreting filenames that happen to start with a dash as command line options.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2091770#c2
[2]: https://pkg.go.dev/encoding/base64#pkg-variables
[3]: https://www.rfc-editor.org/rfc/rfc4648.html#section-5
[4]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/rm.html