### PR TITLE
Bug 2103095: CVO should alert when the cluster's minor release enters its maintenance support phase in 4.8

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -60,6 +60,15 @@ spec:
         cluster_version_available_updates > 0
       labels:
         severity: info
+    - alert: MinorReleaseEnteredMaintenanceSupport
+      annotations:
+        summary: The current minor release 4.8 entered its maintenance support phase.
+        description: The current minor release 4.8 entered its maintenance support phase on January 27, 2022. Please change to the release channel 4.9 and update to a newer version before the end of the maintenance support phase. For more information on life cycle phases, refer to https://access.redhat.com/support/policy/updates/openshift/#ocp4_phases.
+      expr: |
+        vector(1)
+      labels:
+        severity: info
+        namespace: openshift-cluster-version        
   - name: cluster-operators
     rules:
     - alert: ClusterNotUpgradeable


### PR DESCRIPTION
This pull request will add an alert to the `release-4.8` branch informing users that the cluster's minor release has entered its maintenance support phase.

For now, have the CVO alert about this situation only in the minor release 4.8, which is already in the maintenance phase. Depending on how the users respond, we could potentially add the alert to other minor releases in the future.

This alert will notify the users so they are aware of this situation, and they can plan for upgrading to a newer minor release before the end of the maintenance phase.

The severity of the alert is set to `info` as this situation doesn't require immediate action, but the user should be aware of this information.

Pull request related to https://issues.redhat.com/browse/OTA-196