### PR TITLE
Pull arch from payload

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -93,6 +93,10 @@ type Operator struct {
 	// minimumUpdateCheckInterval is the minimum duration to check for updates from
 	// the upstream.
 	minimumUpdateCheckInterval time.Duration
+	// architecture identifies the current architecture being used to retrieve available updates
+	// from OSUS. It's possible values and how it's set are defined by the OSUS Cincinnati API's
+	// "arch" property.
+	architecture string
 	// payloadDir is intended for testing. If unset it will default to '/'
 	payloadDir string
 	// defaultUpstreamServer is intended for testing.
@@ -249,6 +253,7 @@ func (optr *Operator) InitializeFromPayload(ctx context.Context, restConfig *res
 
 	optr.release = update.Release
 	optr.releaseCreated = update.ImageRef.CreationTimestamp.Time
+	optr.SetArchitecture(update.Architecture)
 
 	httpClientConstructor := sigstore.NewCachedHTTPClientConstructor(optr.HTTPClient, nil)
 	configClient, err := coreclientsetv1.NewForConfig(restConfig)
@@ -583,6 +588,8 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// inform the config sync loop about our desired state
 	status := optr.configSync.Update(ctx, config.Generation, desired, config, state, optr.name)
+
+	optr.SetArchitecture(status.Architecture)
 
 	// write cluster version status
 	return optr.syncStatus(ctx, original, config, status, errs)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2361,7 +2361,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 		},
 		{
-			name: "report an error condition when channel isn't set",
+			name: "report an error condition when architecture isn't set",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
@@ -2396,6 +2396,49 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
+					Reason:  noArchitecture,
+					Message: "The set of architectures has not been configured.",
+				},
+			},
+		},
+		{
+			name: "report an error condition when channel isn't set",
+			handler: func(w http.ResponseWriter, req *http.Request) {
+				http.Error(w, "bad things", http.StatusInternalServerError)
+			},
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
+				release: configv1.Release{
+					Version: "v4.0.0",
+					Image:   "image/image:v4.0.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Image: "image/image:v4.0.1"},
+							},
+						},
+					},
+				),
+			},
+			wantUpdates: &availableUpdates{
+				Upstream:     "",
+				Channel:      "",
+				Architecture: "amd64",
+				Condition: configv1.ClusterOperatorStatusCondition{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionFalse,
 					Reason:  noChannel,
 					Message: "The update channel has not been configured.",
 				},
@@ -2408,6 +2451,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2431,8 +2475,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2448,6 +2493,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2478,8 +2524,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2509,6 +2556,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2540,8 +2588,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Current: configv1.Release{
 					Version:  "4.0.1",
 					Image:    "image/image:v4.0.1",
@@ -2574,6 +2623,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2605,9 +2655,10 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
-				Current:  configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
+				Current:      configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
 				Updates: []configv1.Release{
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
 					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -67,6 +68,9 @@ const (
 	// provide better visibility during install and upgrade of
 	// error conditions.
 	PrecreatingPayload
+
+	// heterogeneousArchitectureID identifies a payload architecture as heterogeneous.
+	heterogeneousArchitectureID = "multi"
 )
 
 // Initializing is true if the state is InitializingPayload.
@@ -108,6 +112,8 @@ type Update struct {
 	LoadedAt      time.Time
 
 	ImageRef *imagev1.ImageStream
+
+	Architecture string
 
 	// manifestHash is a hash of the manifests included in this payload
 	ManifestHash string
@@ -307,7 +313,7 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 		releaseDir = filepath.Join(dir, ReleaseManifestDir)
 	)
 
-	release, err := loadReleaseFromMetadata(releaseDir)
+	release, arch, err := loadReleaseFromMetadata(releaseDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,8 +331,9 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 	tasks := getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile)
 
 	return &Update{
-		Release:  release,
-		ImageRef: imageRef,
+		Release:      release,
+		ImageRef:     imageRef,
+		Architecture: arch,
 	}, tasks, nil
 }
 
@@ -350,33 +357,51 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []
 	}}
 }
 
-func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
+func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return release, err
+		return release, "", err
 	}
 
 	var metadata metadata
 	if err := json.Unmarshal(data, &metadata); err != nil {
-		return release, fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
+		return release, "", fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
 	}
 
 	if metadata.Kind != "cincinnati-metadata-v0" {
-		return release, fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
+		return release, "", fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
 	}
 
 	if metadata.Version == "" {
-		return release, errors.New("missing required Cincinnati metadata version")
+		return release, "", errors.New("missing required Cincinnati metadata version")
 	}
 
 	if _, err := semver.Parse(metadata.Version); err != nil {
-		return release, fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
+		return release, "", fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
 	}
 
 	release.Version = metadata.Version
 
+	var arch string
+	if archInterface, ok := metadata.Metadata["release.openshift.io/architecture"]; ok {
+		if archString, ok := archInterface.(string); ok {
+			if archString == heterogeneousArchitectureID {
+				arch = archString
+			} else {
+				return release, "", fmt.Errorf("Architecture from %s (%s) contains invalid value: %q. Valid value is %q.",
+					cincinnatiJSONFile, release.Version, archString, heterogeneousArchitectureID)
+			}
+			klog.V(2).Infof("Architecture from %s (%s) is heterogeneous: %q", cincinnatiJSONFile, release.Version, arch)
+		} else {
+			return release, "", fmt.Errorf("Architecture from %s (%s) is not a string: %v",
+				cincinnatiJSONFile, release.Version, archInterface)
+		}
+	} else {
+		arch = runtime.GOARCH
+		klog.V(2).Infof("Architecture from %s (%s) retrieved from runtime: %q", cincinnatiJSONFile, release.Version, arch)
+	}
 	if urlInterface, ok := metadata.Metadata["url"]; ok {
 		if urlString, ok := urlInterface.(string); ok {
 			release.URL = configv1.URL(urlString)
@@ -393,7 +418,7 @@ func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
 		}
 	}
 
-	return release, nil
+	return release, arch, nil
 }
 
 func loadImageReferences(releaseDir string) (*imagev1.ImageStream, error) {

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -23,10 +24,13 @@ import (
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
+var architecture string
+
 func init() {
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Lookup("v").Value.Set("2")
 	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
+	architecture = runtime.GOARCH
 }
 
 func TestLoadUpdate(t *testing.T) {
@@ -62,6 +66,7 @@ func TestLoadUpdate(t *testing.T) {
 						Name: "1.0.0-abc",
 					},
 				},
+				Architecture: architecture,
 				ManifestHash: "DL-FFQ2Uem8=",
 				Manifests: []manifest.Manifest{
 					{

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -511,6 +511,9 @@ metadata:
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", includeTechPreview, record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
+	arch := runtime.GOARCH
+	controllers.CVO.SetArchitecture(arch)
+
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
 	if err != nil {
 		t.Fatal(err)
@@ -535,7 +538,7 @@ metadata:
 		t.Logf("latest version:\n%s", printCV(lastCV))
 		t.Fatal("no request received at upstream URL")
 	}
-	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", runtime.GOARCH, id.String())
+	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", arch, id.String())
 	expectedQueryValues, err := url.ParseQuery(expectedQuery)
 	if err != nil {
 		t.Fatalf("could not parse expected query: %v", err)


### PR DESCRIPTION
and use when querying OSUS. Per https://issues.redhat.com/browse/OTA-655, heterogeneous cluster payloads will contain metadata key "architecture" set to "multi". Homogeneous cluster payloads are unchanged and will not contain the metadata key "architecture" in which case CVO will set the architecture using runtime.GOARCH.