### PR TITLE
WIP: lib/resourcemerge: change PodTemplateSpec reconcile

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -33,6 +33,7 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 		existing.Spec.Strategy = required.Spec.Strategy
 	}
 
+	//ensurePodTemplateSpecDeployment(true, modified, &existing.Spec.Template, required.Spec.Template)
 	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
 }
 

--- a/lib/resourcemerge/meta_test.go
+++ b/lib/resourcemerge/meta_test.go
@@ -14,6 +14,8 @@ import (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
+	_ = flag.CommandLine.Lookup("v").Value.Set("2")
+	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
 }
 
 func TestMergeOwnerRefs(t *testing.T) {


### PR DESCRIPTION
to handle `kind: Deployment` differently. Before this change securityContext changes, if not explicitly specified in the manifest, remain unchanged and continue to use the securityContext setting of the currently running resource (if there is one).

Reconciliation of Deployment securityContext changes has been changed such that the entire securityContext structure, or any sub field of it, will be cleared if not specified in the manifest.

For example, prior to this change assume Deployment `machine-api-operator` is running on the cluster with the following:

  securityContext:
        runAsNonRoot: true
        runAsUser: 65534

and during an upgrade the Deployment `machine-api-operator` no longer specifies a securityContext. The resulting upgraded  Deployment `machine-api-operator` will still have the original securityContext:

  securityContext:
        runAsNonRoot: true
        runAsUser: 65534

Similarly, there is no way to remove, or clear, a securityContext field such as runAsUser. You can only modify it.

After this change the above scenario will correctly result in the Deployment `machine-api-operator` not specifying securityContext upon upgrade completion.

The changes apply to both the `SecurityContext` [1] within a `Container` and the `PodSecurityContext` [2] within a `PodSpec`.

[1] https://github.com/openshift/cluster-version-operator/blob/e0c92036a1939705638e2c0d5daf798a5ef966e9/vendor/k8s.io/api/core/v1/types.go#L2429
[2] https://github.com/openshift/cluster-version-operator/blob/e0c92036a1939705638e2c0d5daf798a5ef966e9/vendor/k8s.io/api/core/v1/types.go#L2429