### PR TITLE
Bug 2108858: lib/resourcemerge: change SecurityContext reconcile

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -18,7 +18,7 @@ func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1
 	mergeMap(modified, &existing.Data, required.Data)
 }
 
-// EnsureServiceAccount ensures that the existing mathces the required.
+// EnsureServiceAccount ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
 func EnsureServiceAccount(modified *bool, existing *corev1.ServiceAccount, required corev1.ServiceAccount) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
@@ -466,12 +466,13 @@ func ensureVolumeSourceDefaults(required *corev1.VolumeSource) {
 }
 
 func ensureSecurityContextPtr(modified *bool, existing **corev1.SecurityContext, required *corev1.SecurityContext) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return
@@ -490,12 +491,13 @@ func ensureSecurityContext(modified *bool, existing *corev1.SecurityContext, req
 }
 
 func ensureCapabilitiesPtr(modified *bool, existing **corev1.Capabilities, required *corev1.Capabilities) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return
@@ -619,12 +621,13 @@ func ensureAffinity(modified *bool, existing *corev1.Affinity, required corev1.A
 }
 
 func ensurePodSecurityContextPtr(modified *bool, existing **corev1.PodSecurityContext, required *corev1.PodSecurityContext) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return
@@ -676,12 +679,13 @@ func ensurePodSecurityContext(modified *bool, existing *corev1.PodSecurityContex
 }
 
 func ensureSELinuxOptionsPtr(modified *bool, existing **corev1.SELinuxOptions, required *corev1.SELinuxOptions) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return
@@ -734,12 +738,13 @@ func setBool(modified *bool, existing *bool, required bool) {
 }
 
 func setBoolPtr(modified *bool, existing **bool, required *bool) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return
@@ -758,6 +763,9 @@ func setInt32Ptr(modified *bool, existing **int32, required *int32) {
 	if *existing == nil && required == nil {
 		return
 	}
+
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
 	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
@@ -774,12 +782,13 @@ func setInt64(modified *bool, existing *int64, required int64) {
 }
 
 func setInt64Ptr(modified *bool, existing **int64, required *int64) {
-	// if we have no required, then we don't care what someone else has set
-	if required == nil {
+	if *existing == nil && required == nil {
 		return
 	}
 
-	if *existing == nil {
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
 		*modified = true
 		*existing = required
 		return

--- a/lib/resourcemerge/meta_test.go
+++ b/lib/resourcemerge/meta_test.go
@@ -14,6 +14,8 @@ import (
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
+	_ = flag.CommandLine.Lookup("v").Value.Set("2")
+	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
 }
 
 func TestMergeOwnerRefs(t *testing.T) {


### PR DESCRIPTION
to handle securityContext changes differently. Since https://github.com/openshift/cluster-version-operator/commit/d9f6718, if a securityContext is not explicitly specified in the manifest the resource's securityContext will remain unchanged and it will continue to use the securityContext setting of the currently running resource (if there is one). We're not sure of the exact reason the logic was originally developed in this manner but this change joins a series of similar previous tightenings, including https://github.com/openshift/cluster-version-operator/commit/02bb9ba829174d799e418aeedfbd88bf572a35a0 (lib/resourcemerge/core: Clear env and envFrom if unset in
manifest, 2021-04-20, https://github.com/openshift/cluster-version-operator/pull/549) and https://github.com/openshift/cluster-version-operator/commit/ca299b8871e11ef1bd231e7b011be6920541e7ec (lib/resourcemerge: remove ports which are no longer required, 2020-02-13, https://github.com/openshift/cluster-version-operator/pull/322).

Reconciliation has been changed such that the entire securityContext structure, or any sub field of it, will be cleared if not specified in the manifest. This change affects Deployments, Jobs, and DaemonSets. It affects the securityContext found in both a PodSpec and a Container. Since the functions setInt64Ptr and setBoolPtr have been changed the impact is wide affecting ServiceAccounts, the PodSpec fields ShareProcessNamespace and TerminationGracePeriodSeconds, and the Job fields
ActiveDeadlineSeconds and ManualSelector.

For example, prior to this change assume Deployment machine-api-operator is running on the cluster with the following:

securityContext:
    runAsNonRoot: true
    runAsUser: 65534

and during an upgrade the Deployment machine-api-operator no longer specifies a securityContext. The resulting upgraded Deployment machine-api-operator will still have the original securityContext:

securityContext:
    runAsNonRoot: true
    runAsUser: 65534

Similarly, there is no way to remove, or clear, a securityContext field such as `runAsUser`. You can only modify it.

After this change the above scenario will correctly result in the Deployment machine-api-operator not specifying securityContext upon upgrade completion.

The changes apply to both the `SecurityContext` [1] within a `Container` and the `PodSecurityContext` [2] within a `PodSpec`.

[1] https://github.com/openshift/cluster-version-operator/blob/e0c92036a1939705638e2c0d5daf798a5ef966e9/vendor/k8s.io/api/core/v1/types.go#L2429
[2] https://github.com/openshift/cluster-version-operator/blob/e0c92036a1939705638e2c0d5daf798a5ef966e9/vendor/k8s.io/api/core/v1/types.go#L2429