### PR TITLE
Bug 2110590: pkg/cvo/updatepayload: Set 'readOnlyRootFilesystem: false'

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -180,7 +180,8 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 			Name:      "payloads",
 		}}
 		container.SecurityContext = &corev1.SecurityContext{
-			Privileged: pointer.BoolPtr(true),
+			Privileged:             pointer.BoolPtr(true),
+			ReadOnlyRootFilesystem: pointer.BoolPtr(false),
 		}
 		container.Resources = corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
This blocks us from being associated with SecurityContextConstraints that set `readOnlyRootFilesystem: true`, because from [the upstream docs][1]:

> The set of SCCs that admission uses to authorize a pod are determined by the user identity and groups that the user belongs to.  Additionally, if the pod specifies a service account, the set of allowable SCCs includes any constraints accessible to the service account.
>
> Admission uses the following approach to create the final security context for the pod:
>
> 1. Retrieve all SCCs available for use.
> 2. Generate field values for security context settings that were not specified on the request.
> 3. Validate the final settings against the available constraints.

If we leave `readOnlyRootFilesystem` implicit, we may get associated with a SCC that set `readOnlyRootFilesystem: true`, and the `version-*` actions will [fail like][2]:

```console
$ oc -n openshift-cluster-version get pods
NAME                                        READY   STATUS    RESTARTS   AGE
cluster-version-operator-6b5c8ff5c8-4bmxx   1/1     Running   0          33m
version-4.10.20-smvt9-6vqwc                 0/1     Error     0          10s
$ oc -n openshift-cluster-version logs version-4.10.20-smvt9-6vqwc
oc logs version-4.10.20-smvt9-6vqwc
mv: cannot remove '/manifests/0000_00_cluster-version-operator_00_namespace.yaml': Read-only file system
mv: cannot remove '/manifests/0000_00_cluster-version-operator_01_adminack_configmap.yaml': Read-only file system
...
```

For a similar change in another repository, see openshift/cluster-openshift-apiserver-operator#437.

Also likely relevant, 4.10 both [grew `pod-security.kubernetes.io/*` annotations][4] and [cleared the `openshift.io/run-level` annotation][5].

```console
$ git --no-pager log --oneline -3 origin/release-4.10 -- install/0000_00_cluster-version-operator_00_namespace.yaml
539e9449 (origin/pr/623) Fix run-level label to empty string.
f58dd1c5 (origin/pr/686) install: Add description annotations to manifests
6e5e23e3 (origin/pr/668) podsecurity: enforce privileged for openshift-cluster-version namespace
```

None of those were in 4.9:

```console
$ git --no-pager log --oneline -1 origin/release-4.9 -- install/0000_00_cluster-version-operator_00_namespace.yaml
70097361 (origin/pr/543) Add management workload annotations
```

And all of them landed in 4.10 via master (so they're in 4.10 before it GAed, and in 4.11 and later too):

```console
$ git --no-pager log --oneline -4 origin/master -- install/0000_00_cluster-version-operator_00_namespace.yaml
539e9449 (origin/pr/623) Fix run-level label to empty string.
```

[1]: https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2110590#c0
[3]: https://github.com/openshift/cluster-openshift-apiserver-operator/pull/437
[4]: https://github.com/openshift/cluster-version-operator/pull/668
[5]: https://github.com/openshift/cluster-version-operator/pull/623