### PR TITLE
Revert "Pull arch from payload"

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
 )
 
-const noArchitecture string = "NoArchitecture"
 const noChannel string = "NoChannel"
 
 // syncAvailableUpdates attempts to retrieve the latest updates and update the status of the ClusterVersion
@@ -35,9 +35,8 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 		usedDefaultUpstream = true
 		upstream = optr.defaultUpstreamServer
 	}
-
+	arch := runtime.GOARCH
 	channel := config.Spec.Channel
-	arch := optr.getArchitecture()
 
 	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
 	u := optr.getAvailableUpdates()
@@ -47,9 +46,6 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 		klog.V(2).Infof("Retrieving available updates again, because more than %s has elapsed since %s", optr.minimumUpdateCheckInterval, u.LastAttempt)
 	} else if channel != u.Channel {
 		klog.V(2).Infof("Retrieving available updates again, because the channel has changed from %q to %q", u.Channel, channel)
-	} else if arch != u.Architecture {
-		klog.V(2).Infof("Retrieving available updates again, because the architecture has changed from %q to %q",
-			u.Architecture, arch)
 	} else if upstream == u.Upstream || (upstream == optr.defaultUpstreamServer && u.Upstream == "") {
 		klog.V(2).Infof("Available updates were recently retrieved, with less than %s elapsed since %s, will try later.", optr.minimumUpdateCheckInterval, u.LastAttempt)
 		return nil
@@ -71,7 +67,6 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 	au := &availableUpdates{
 		Upstream:           upstream,
 		Channel:            config.Spec.Channel,
-		Architecture:       arch,
 		Current:            current,
 		Updates:            updates,
 		ConditionalUpdates: conditionalUpdates,
@@ -87,9 +82,8 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 }
 
 type availableUpdates struct {
-	Upstream     string
-	Channel      string
-	Architecture string
+	Upstream string
+	Channel  string
 
 	// LastAttempt records the time of the most recent attempt at update
 	// retrieval, regardless of whether it was successful.
@@ -121,7 +115,6 @@ func (u *availableUpdates) NeedsUpdate(original *configv1.ClusterVersion) *confi
 	if u == nil {
 		return nil
 	}
-	// Architecture could change but does not reside in ClusterVersion
 	if u.Upstream != string(original.Spec.Upstream) || u.Channel != original.Spec.Channel {
 		return nil
 	}
@@ -167,7 +160,6 @@ func (optr *Operator) setAvailableUpdates(u *availableUpdates) {
 	if u != nil && (optr.availableUpdates == nil ||
 		optr.availableUpdates.Upstream != u.Upstream ||
 		optr.availableUpdates.Channel != u.Channel ||
-		optr.availableUpdates.Architecture != u.Architecture ||
 		success) {
 		u.LastSyncOrConfigChange = u.LastAttempt
 	} else if optr.availableUpdates != nil {
@@ -182,20 +174,6 @@ func (optr *Operator) getAvailableUpdates() *availableUpdates {
 	optr.statusLock.Lock()
 	defer optr.statusLock.Unlock()
 	return optr.availableUpdates
-}
-
-// getArchitecture returns the currently determined cluster architecture.
-func (optr *Operator) getArchitecture() string {
-	optr.statusLock.Lock()
-	defer optr.statusLock.Unlock()
-	return optr.architecture
-}
-
-// SetArchitecture sets the cluster architecture.
-func (optr *Operator) SetArchitecture(architecture string) {
-	optr.statusLock.Lock()
-	defer optr.statusLock.Unlock()
-	optr.architecture = architecture
 }
 
 func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, transport *http.Transport, upstream, arch, channel, version string) (configv1.Release, []configv1.Release, []configv1.ConditionalUpdate, configv1.ClusterOperatorStatusCondition) {
@@ -225,7 +203,7 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, tran
 
 	if len(arch) == 0 {
 		return cvoCurrent, nil, nil, configv1.ClusterOperatorStatusCondition{
-			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: noArchitecture,
+			Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse, Reason: "NoArchitecture",
 			Message: "The set of architectures has not been configured.",
 		}
 	}

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -93,10 +93,6 @@ type Operator struct {
 	// minimumUpdateCheckInterval is the minimum duration to check for updates from
 	// the upstream.
 	minimumUpdateCheckInterval time.Duration
-	// architecture identifies the current architecture being used to retrieve available updates
-	// from OSUS. It's possible values and how it's set are defined by the OSUS Cincinnati API's
-	// "arch" property.
-	architecture string
 	// payloadDir is intended for testing. If unset it will default to '/'
 	payloadDir string
 	// defaultUpstreamServer is intended for testing.
@@ -253,7 +249,6 @@ func (optr *Operator) InitializeFromPayload(ctx context.Context, restConfig *res
 
 	optr.release = update.Release
 	optr.releaseCreated = update.ImageRef.CreationTimestamp.Time
-	optr.SetArchitecture(update.Architecture)
 
 	httpClientConstructor := sigstore.NewCachedHTTPClientConstructor(optr.HTTPClient, nil)
 	configClient, err := coreclientsetv1.NewForConfig(restConfig)
@@ -588,8 +583,6 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// inform the config sync loop about our desired state
 	status := optr.configSync.Update(ctx, config.Generation, desired, config, state, optr.name)
-
-	optr.SetArchitecture(status.Architecture)
 
 	// write cluster version status
 	return optr.syncStatus(ctx, original, config, status, errs)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2361,7 +2361,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 		},
 		{
-			name: "report an error condition when architecture isn't set",
+			name: "report an error condition when channel isn't set",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
@@ -2396,49 +2396,6 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
-					Reason:  noArchitecture,
-					Message: "The set of architectures has not been configured.",
-				},
-			},
-		},
-		{
-			name: "report an error condition when channel isn't set",
-			handler: func(w http.ResponseWriter, req *http.Request) {
-				http.Error(w, "bad things", http.StatusInternalServerError)
-			},
-			optr: &Operator{
-				defaultUpstreamServer: "http://localhost:8080/graph",
-				architecture:          "amd64",
-				release: configv1.Release{
-					Version: "v4.0.0",
-					Image:   "image/image:v4.0.1",
-				},
-				namespace: "test",
-				name:      "default",
-				client: fake.NewSimpleClientset(
-					&configv1.ClusterVersion{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "default",
-						},
-						Spec: configv1.ClusterVersionSpec{
-							ClusterID: configv1.ClusterID(id),
-							Channel:   "",
-						},
-						Status: configv1.ClusterVersionStatus{
-							History: []configv1.UpdateHistory{
-								{Image: "image/image:v4.0.1"},
-							},
-						},
-					},
-				),
-			},
-			wantUpdates: &availableUpdates{
-				Upstream:     "",
-				Channel:      "",
-				Architecture: "amd64",
-				Condition: configv1.ClusterOperatorStatusCondition{
-					Type:    configv1.RetrievedUpdates,
-					Status:  configv1.ConditionFalse,
 					Reason:  noChannel,
 					Message: "The update channel has not been configured.",
 				},
@@ -2451,7 +2408,6 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
-				architecture:          "amd64",
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2475,9 +2431,8 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream:     "",
-				Channel:      "fast",
-				Architecture: "amd64",
+				Upstream: "",
+				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2493,7 +2448,6 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
-				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2524,9 +2478,8 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream:     "",
-				Channel:      "fast",
-				Architecture: "amd64",
+				Upstream: "",
+				Channel:  "fast",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2556,7 +2509,6 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
-				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2588,9 +2540,8 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream:     "",
-				Channel:      "fast",
-				Architecture: "amd64",
+				Upstream: "",
+				Channel:  "fast",
 				Current: configv1.Release{
 					Version:  "4.0.1",
 					Image:    "image/image:v4.0.1",
@@ -2623,7 +2574,6 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
-				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2655,10 +2605,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream:     "",
-				Channel:      "fast",
-				Architecture: "amd64",
-				Current:      configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
+				Upstream: "",
+				Channel:  "fast",
+				Current:  configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
 				Updates: []configv1.Release{
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
 					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -109,11 +109,10 @@ type SyncWorkerStatus struct {
 	Done  int
 	Total int
 
-	Completed    int
-	Reconciling  bool
-	Initial      bool
-	VersionHash  string
-	Architecture string
+	Completed   int
+	Reconciling bool
+	Initial     bool
+	VersionHash string
 
 	LastProgress time.Time
 
@@ -371,8 +370,7 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 				work.Capabilities)
 		}
 		w.payload = payloadUpdate
-		msg = fmt.Sprintf("Payload loaded version=%q image=%q architecture=%q", desired.Version, desired.Image,
-			payloadUpdate.Architecture)
+		msg = fmt.Sprintf("Payload loaded version=%q image=%q", desired.Version, desired.Image)
 		w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeNormal, "PayloadLoaded", msg)
 		reporter.ReportPayload(LoadPayloadStatus{
 			Failure:            nil,
@@ -382,8 +380,7 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 			Update:             desired,
 			LastTransitionTime: time.Now(),
 		})
-		klog.V(2).Infof("Payload loaded from %s with hash %s, architecture %s", desired.Image, payloadUpdate.ManifestHash,
-			payloadUpdate.Architecture)
+		klog.V(2).Infof("Payload loaded from %s with hash %s", desired.Image, payloadUpdate.ManifestHash)
 	}
 	return implicitlyEnabledCaps, nil
 }
@@ -510,9 +507,6 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 	w.work.Capabilities = capability.SetFromImplicitlyEnabledCapabilities(implicit, w.work.Capabilities)
 	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = w.work.Capabilities.ImplicitlyEnabledCapabilities
 	w.status.CapabilitiesStatus.Status = capability.GetCapabilitiesStatus(w.work.Capabilities)
-
-	// Update syncWorker status with architecture of newly loaded payload.
-	w.status.Architecture = w.payload.Architecture
 
 	// notify the sync loop that we changed config
 	if w.cancelFn != nil {

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -68,9 +67,6 @@ const (
 	// provide better visibility during install and upgrade of
 	// error conditions.
 	PrecreatingPayload
-
-	// heterogeneousArchitectureID identifies a payload architecture as heterogeneous.
-	heterogeneousArchitectureID = "multi"
 )
 
 // Initializing is true if the state is InitializingPayload.
@@ -112,8 +108,6 @@ type Update struct {
 	LoadedAt      time.Time
 
 	ImageRef *imagev1.ImageStream
-
-	Architecture string
 
 	// manifestHash is a hash of the manifests included in this payload
 	ManifestHash string
@@ -313,7 +307,7 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 		releaseDir = filepath.Join(dir, ReleaseManifestDir)
 	)
 
-	release, arch, err := loadReleaseFromMetadata(releaseDir)
+	release, err := loadReleaseFromMetadata(releaseDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -331,9 +325,8 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 	tasks := getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile)
 
 	return &Update{
-		Release:      release,
-		ImageRef:     imageRef,
-		Architecture: arch,
+		Release:  release,
+		ImageRef: imageRef,
 	}, tasks, nil
 }
 
@@ -357,51 +350,33 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []
 	}}
 }
 
-func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error) {
+func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return release, "", err
+		return release, err
 	}
 
 	var metadata metadata
 	if err := json.Unmarshal(data, &metadata); err != nil {
-		return release, "", fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
+		return release, fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
 	}
 
 	if metadata.Kind != "cincinnati-metadata-v0" {
-		return release, "", fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
+		return release, fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
 	}
 
 	if metadata.Version == "" {
-		return release, "", errors.New("missing required Cincinnati metadata version")
+		return release, errors.New("missing required Cincinnati metadata version")
 	}
 
 	if _, err := semver.Parse(metadata.Version); err != nil {
-		return release, "", fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
+		return release, fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
 	}
 
 	release.Version = metadata.Version
 
-	var arch string
-	if archInterface, ok := metadata.Metadata["release.openshift.io/architecture"]; ok {
-		if archString, ok := archInterface.(string); ok {
-			if archString == heterogeneousArchitectureID {
-				arch = archString
-			} else {
-				return release, "", fmt.Errorf("Architecture from %s (%s) contains invalid value: %q. Valid value is %q.",
-					cincinnatiJSONFile, release.Version, archString, heterogeneousArchitectureID)
-			}
-			klog.V(2).Infof("Architecture from %s (%s) is heterogeneous: %q", cincinnatiJSONFile, release.Version, arch)
-		} else {
-			return release, "", fmt.Errorf("Architecture from %s (%s) is not a string: %v",
-				cincinnatiJSONFile, release.Version, archInterface)
-		}
-	} else {
-		arch = runtime.GOARCH
-		klog.V(2).Infof("Architecture from %s (%s) retrieved from runtime: %q", cincinnatiJSONFile, release.Version, arch)
-	}
 	if urlInterface, ok := metadata.Metadata["url"]; ok {
 		if urlString, ok := urlInterface.(string); ok {
 			release.URL = configv1.URL(urlString)
@@ -418,7 +393,7 @@ func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error
 		}
 	}
 
-	return release, arch, nil
+	return release, nil
 }
 
 func loadImageReferences(releaseDir string) (*imagev1.ImageStream, error) {

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,13 +23,10 @@ import (
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
-var architecture string
-
 func init() {
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Lookup("v").Value.Set("2")
 	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
-	architecture = runtime.GOARCH
 }
 
 func TestLoadUpdate(t *testing.T) {
@@ -66,7 +62,6 @@ func TestLoadUpdate(t *testing.T) {
 						Name: "1.0.0-abc",
 					},
 				},
-				Architecture: architecture,
 				ManifestHash: "DL-FFQ2Uem8=",
 				Manifests: []manifest.Manifest{
 					{

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -511,9 +511,6 @@ metadata:
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", includeTechPreview, record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
-	arch := runtime.GOARCH
-	controllers.CVO.SetArchitecture(arch)
-
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
 	if err != nil {
 		t.Fatal(err)
@@ -538,7 +535,7 @@ metadata:
 		t.Logf("latest version:\n%s", printCV(lastCV))
 		t.Fatal("no request received at upstream URL")
 	}
-	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", arch, id.String())
+	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", runtime.GOARCH, id.String())
 	expectedQueryValues, err := url.ParseQuery(expectedQuery)
 	if err != nil {
 		t.Fatalf("could not parse expected query: %v", err)


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#796 ; tracked by [TRT-441](https://issues.redhat.com/browse/TRT-441)

Per [TRT policy](https://github.com/openshift/enhancements/blob/725a118640d7b9fa8c6f720f2adb841de654fac5/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this (what I believe to be a) breaking change to get ci and/or nightly payloads flowing again.

```
[sig-instrumentation][Late] Alerts shouldn't report any unexpected alerts in firing or pending state [Suite:openshift/conformance/parallel]:

alert CannotRetrieveUpdates fired for 78 seconds with labels: {endpoint="metrics", instance="10.0.131.99:9099", job="cluster-version-operator", namespace="openshift-cluster-version", pod="cluster-version-operator-7b559749b8-fgff9", service="cluster-version-operator", severity="warning"}
Ginkgo exit error 1: exit with code 1}

$ oc get clusterversion version -o yaml
...
  conditions:
  - lastTransitionTime: "2022-08-01T19:38:29Z"
    message: The set of architectures has not been configured.
    reason: NoArchitecture
    status: "False"
    type: RetrievedUpdates
...
```


NOTE: At this time, I'm trying to determine if this is the breaking change by running the 4.12 ci blocking jobs that starting failing [on this 4.12-ci payload run](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.ci/release/4.12.0-0.ci-2022-08-01-192043).

If this revert merges, ... To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem.  You can test your revert with this command in the PR `/payload 4.12 ci blocking`.

cc: [jottofar](https://github.com/jottofar)