### PR TITLE
Restore 'Pull arch from payload' and fix

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -93,6 +93,10 @@ type Operator struct {
 	// minimumUpdateCheckInterval is the minimum duration to check for updates from
 	// the upstream.
 	minimumUpdateCheckInterval time.Duration
+	// architecture identifies the current architecture being used to retrieve available updates
+	// from OSUS. It's possible values and how it's set are defined by the OSUS Cincinnati API's
+	// "arch" property.
+	architecture string
 	// payloadDir is intended for testing. If unset it will default to '/'
 	payloadDir string
 	// defaultUpstreamServer is intended for testing.
@@ -249,6 +253,7 @@ func (optr *Operator) InitializeFromPayload(ctx context.Context, restConfig *res
 
 	optr.release = update.Release
 	optr.releaseCreated = update.ImageRef.CreationTimestamp.Time
+	optr.SetArchitecture(update.Architecture)
 
 	httpClientConstructor := sigstore.NewCachedHTTPClientConstructor(optr.HTTPClient, nil)
 	configClient, err := coreclientsetv1.NewForConfig(restConfig)
@@ -583,6 +588,8 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// inform the config sync loop about our desired state
 	status := optr.configSync.Update(ctx, config.Generation, desired, config, state, optr.name)
+
+	optr.SetArchitecture(status.Architecture)
 
 	// write cluster version status
 	return optr.syncStatus(ctx, original, config, status, errs)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2361,7 +2361,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 		},
 		{
-			name: "report an error condition when channel isn't set",
+			name: "report an error condition when architecture isn't set",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
@@ -2396,6 +2396,49 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
+					Reason:  noArchitecture,
+					Message: "The set of architectures has not been configured.",
+				},
+			},
+		},
+		{
+			name: "report an error condition when channel isn't set",
+			handler: func(w http.ResponseWriter, req *http.Request) {
+				http.Error(w, "bad things", http.StatusInternalServerError)
+			},
+			optr: &Operator{
+				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
+				release: configv1.Release{
+					Version: "v4.0.0",
+					Image:   "image/image:v4.0.1",
+				},
+				namespace: "test",
+				name:      "default",
+				client: fake.NewSimpleClientset(
+					&configv1.ClusterVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Spec: configv1.ClusterVersionSpec{
+							ClusterID: configv1.ClusterID(id),
+							Channel:   "",
+						},
+						Status: configv1.ClusterVersionStatus{
+							History: []configv1.UpdateHistory{
+								{Image: "image/image:v4.0.1"},
+							},
+						},
+					},
+				),
+			},
+			wantUpdates: &availableUpdates{
+				Upstream:     "",
+				Channel:      "",
+				Architecture: "amd64",
+				Condition: configv1.ClusterOperatorStatusCondition{
+					Type:    configv1.RetrievedUpdates,
+					Status:  configv1.ConditionFalse,
 					Reason:  noChannel,
 					Message: "The update channel has not been configured.",
 				},
@@ -2408,6 +2451,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Image: "image/image:v4.0.1",
 				},
@@ -2431,8 +2475,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2448,6 +2493,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2478,8 +2524,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2509,6 +2556,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2540,8 +2588,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
 				Current: configv1.Release{
 					Version:  "4.0.1",
 					Image:    "image/image:v4.0.1",
@@ -2574,6 +2623,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 			optr: &Operator{
 				defaultUpstreamServer: "http://localhost:8080/graph",
+				architecture:          "amd64",
 				release: configv1.Release{
 					Version: "4.0.1",
 					Image:   "image/image:v4.0.1",
@@ -2605,9 +2655,10 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				),
 			},
 			wantUpdates: &availableUpdates{
-				Upstream: "",
-				Channel:  "fast",
-				Current:  configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
+				Upstream:     "",
+				Channel:      "fast",
+				Architecture: "amd64",
+				Current:      configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
 				Updates: []configv1.Release{
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
 					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -109,10 +109,11 @@ type SyncWorkerStatus struct {
 	Done  int
 	Total int
 
-	Completed   int
-	Reconciling bool
-	Initial     bool
-	VersionHash string
+	Completed    int
+	Reconciling  bool
+	Initial      bool
+	VersionHash  string
+	Architecture string
 
 	LastProgress time.Time
 
@@ -370,7 +371,8 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 				work.Capabilities)
 		}
 		w.payload = payloadUpdate
-		msg = fmt.Sprintf("Payload loaded version=%q image=%q", desired.Version, desired.Image)
+		msg = fmt.Sprintf("Payload loaded version=%q image=%q architecture=%q", desired.Version, desired.Image,
+			payloadUpdate.Architecture)
 		w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeNormal, "PayloadLoaded", msg)
 		reporter.ReportPayload(LoadPayloadStatus{
 			Failure:            nil,
@@ -380,7 +382,8 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 			Update:             desired,
 			LastTransitionTime: time.Now(),
 		})
-		klog.V(2).Infof("Payload loaded from %s with hash %s", desired.Image, payloadUpdate.ManifestHash)
+		klog.V(2).Infof("Payload loaded from %s with hash %s, architecture %s", desired.Image, payloadUpdate.ManifestHash,
+			payloadUpdate.Architecture)
 	}
 	return implicitlyEnabledCaps, nil
 }
@@ -507,6 +510,9 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 	w.work.Capabilities = capability.SetFromImplicitlyEnabledCapabilities(implicit, w.work.Capabilities)
 	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = w.work.Capabilities.ImplicitlyEnabledCapabilities
 	w.status.CapabilitiesStatus.Status = capability.GetCapabilitiesStatus(w.work.Capabilities)
+
+	// Update syncWorker status with architecture of newly loaded payload.
+	w.status.Architecture = w.payload.Architecture
 
 	// notify the sync loop that we changed config
 	if w.cancelFn != nil {
@@ -858,12 +864,13 @@ func (w *SyncWorker) apply(ctx context.Context, work *SyncWork, maxWorkers int, 
 	total := len(payloadUpdate.Manifests)
 	cr := &consistentReporter{
 		status: SyncWorkerStatus{
-			Generation:  work.Generation,
-			Initial:     work.State.Initializing(),
-			Reconciling: work.State.Reconciling(),
-			VersionHash: payloadUpdate.ManifestHash,
-			Actual:      payloadUpdate.Release,
-			Verified:    payloadUpdate.VerifiedImage,
+			Generation:   work.Generation,
+			Initial:      work.State.Initializing(),
+			Reconciling:  work.State.Reconciling(),
+			VersionHash:  payloadUpdate.ManifestHash,
+			Architecture: w.status.Architecture,
+			Actual:       payloadUpdate.Release,
+			Verified:     payloadUpdate.VerifiedImage,
 		},
 		completed: work.Completed,
 		version:   payloadUpdate.Release.Version,

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -67,6 +68,9 @@ const (
 	// provide better visibility during install and upgrade of
 	// error conditions.
 	PrecreatingPayload
+
+	// heterogeneousArchitectureID identifies a payload architecture as heterogeneous.
+	heterogeneousArchitectureID = "multi"
 )
 
 // Initializing is true if the state is InitializingPayload.
@@ -108,6 +112,8 @@ type Update struct {
 	LoadedAt      time.Time
 
 	ImageRef *imagev1.ImageStream
+
+	Architecture string
 
 	// manifestHash is a hash of the manifests included in this payload
 	ManifestHash string
@@ -307,7 +313,7 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 		releaseDir = filepath.Join(dir, ReleaseManifestDir)
 	)
 
-	release, err := loadReleaseFromMetadata(releaseDir)
+	release, arch, err := loadReleaseFromMetadata(releaseDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,8 +331,9 @@ func loadUpdatePayloadMetadata(dir, releaseImage, clusterProfile string) (*Updat
 	tasks := getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile)
 
 	return &Update{
-		Release:  release,
-		ImageRef: imageRef,
+		Release:      release,
+		ImageRef:     imageRef,
+		Architecture: arch,
 	}, tasks, nil
 }
 
@@ -350,33 +357,51 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []
 	}}
 }
 
-func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
+func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return release, err
+		return release, "", err
 	}
 
 	var metadata metadata
 	if err := json.Unmarshal(data, &metadata); err != nil {
-		return release, fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
+		return release, "", fmt.Errorf("unmarshal Cincinnati metadata: %w", err)
 	}
 
 	if metadata.Kind != "cincinnati-metadata-v0" {
-		return release, fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
+		return release, "", fmt.Errorf("unrecognized Cincinnati metadata kind %q", metadata.Kind)
 	}
 
 	if metadata.Version == "" {
-		return release, errors.New("missing required Cincinnati metadata version")
+		return release, "", errors.New("missing required Cincinnati metadata version")
 	}
 
 	if _, err := semver.Parse(metadata.Version); err != nil {
-		return release, fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
+		return release, "", fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
 	}
 
 	release.Version = metadata.Version
 
+	var arch string
+	if archInterface, ok := metadata.Metadata["release.openshift.io/architecture"]; ok {
+		if archString, ok := archInterface.(string); ok {
+			if archString == heterogeneousArchitectureID {
+				arch = archString
+			} else {
+				return release, "", fmt.Errorf("Architecture from %s (%s) contains invalid value: %q. Valid value is %q.",
+					cincinnatiJSONFile, release.Version, archString, heterogeneousArchitectureID)
+			}
+			klog.V(2).Infof("Architecture from %s (%s) is heterogeneous: %q", cincinnatiJSONFile, release.Version, arch)
+		} else {
+			return release, "", fmt.Errorf("Architecture from %s (%s) is not a string: %v",
+				cincinnatiJSONFile, release.Version, archInterface)
+		}
+	} else {
+		arch = runtime.GOARCH
+		klog.V(2).Infof("Architecture from %s (%s) retrieved from runtime: %q", cincinnatiJSONFile, release.Version, arch)
+	}
 	if urlInterface, ok := metadata.Metadata["url"]; ok {
 		if urlString, ok := urlInterface.(string); ok {
 			release.URL = configv1.URL(urlString)
@@ -393,7 +418,7 @@ func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
 		}
 	}
 
-	return release, nil
+	return release, arch, nil
 }
 
 func loadImageReferences(releaseDir string) (*imagev1.ImageStream, error) {

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -23,10 +24,13 @@ import (
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
+var architecture string
+
 func init() {
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Lookup("v").Value.Set("2")
 	_ = flag.CommandLine.Lookup("alsologtostderr").Value.Set("true")
+	architecture = runtime.GOARCH
 }
 
 func TestLoadUpdate(t *testing.T) {
@@ -62,6 +66,7 @@ func TestLoadUpdate(t *testing.T) {
 						Name: "1.0.0-abc",
 					},
 				},
+				Architecture: architecture,
 				ManifestHash: "DL-FFQ2Uem8=",
 				Manifests: []manifest.Manifest{
 					{

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -511,6 +511,9 @@ metadata:
 	worker := cvo.NewSyncWorker(retriever, cvo.NewResourceBuilder(cfg, cfg, nil, nil), 5*time.Second, wait.Backoff{Steps: 3}, "", includeTechPreview, record.NewFakeRecorder(100), payload.DefaultClusterProfile)
 	controllers.CVO.SetSyncWorkerForTesting(worker)
 
+	arch := runtime.GOARCH
+	controllers.CVO.SetArchitecture(arch)
+
 	lock, err := createResourceLock(cb, options.Namespace, options.Name)
 	if err != nil {
 		t.Fatal(err)
@@ -535,7 +538,7 @@ metadata:
 		t.Logf("latest version:\n%s", printCV(lastCV))
 		t.Fatal("no request received at upstream URL")
 	}
-	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", runtime.GOARCH, id.String())
+	expectedQuery := fmt.Sprintf("arch=%s&channel=test-channel&id=%s&version=0.0.1", arch, id.String())
 	expectedQueryValues, err := url.ParseQuery(expectedQuery)
 	if err != nil {
 		t.Fatalf("could not parse expected query: %v", err)


### PR DESCRIPTION
by first restoring https://github.com/openshift/cluster-version-operator/commit/0b8e83f9f405b0b62e781edbb0d1c87c5f2cc45b.
Ths issue was that the 'SyncWorkerStatus.Architecture' was being clobbered
at
https://github.com/openshift/cluster-version-operator/blob/9d57cfc612dec8e6b5d67d34e5f00474f3c09032/pkg/cvo/sync_worker.go#L860.