### PR TITLE
pkg/cvo/status.go: sort implicitly enabled caps

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -375,6 +376,7 @@ func setImplicitlyEnabledCapabilitiesCondition(config *configv1.ClusterVersion, 
 		for i, c := range implicitlyEnabled {
 			caps[i] = string(c)
 		}
+		sort.Strings(caps)
 		message = message + strings.Join([]string(caps), ", ")
 
 		resourcemerge.SetOperatorStatusCondition(&config.Status.Conditions, configv1.ClusterOperatorStatusCondition{


### PR DESCRIPTION
in condition message to avoid test failures caused by bg
sync timing that affects the order of the implicitly
enabled capabilities.