### PR TITLE
lib/capability: Sort all slices after building them

### DIFF
--- a/lib/capability/capability.go
+++ b/lib/capability/capability.go
@@ -79,6 +79,7 @@ func GetKnownCapabilities() []configv1.ClusterVersionCapability {
 	for _, v := range configv1.ClusterVersionCapabilitySets {
 		known = append(known, v...)
 	}
+	sort.Sort(capabilitiesSort(known))
 	return known
 }
 
@@ -115,6 +116,7 @@ func GetImplicitlyEnabledCapabilities(enabledManifestCaps []configv1.ClusterVers
 			}
 		}
 	}
+	sort.Sort(capabilitiesSort(caps))
 	return caps
 }
 
@@ -174,5 +176,6 @@ func setEnabledCapabilities(capabilitiesSpec *configv1.ClusterVersionCapabilitie
 			enabled[k] = struct{}{}
 		}
 	}
+	sort.Sort(capabilitiesSort(implicitlyEnabled))
 	return enabled, implicitlyEnabled
 }


### PR DESCRIPTION
We'd already been sorting the two status properties before attaching them to ClusterVersion, but we also use some of the underlying data internally, e.g. in `TestCVO_InitImplicitlyEnabledCaps`.  By sorting after we build each slice, we don't need to worry about slice-consumers being surprised by order instability.