### PR TITLE
OCPBUGS-569: CVO History Pruner return not assigned to config.Status.History

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -134,7 +134,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Rele
 	}
 
 	// Prune least informative history entry when at maxHistory.
-	prune(config.Status.History, MaxHistory)
+	config.Status.History = prune(config.Status.History, MaxHistory)
 
 	config.Status.Desired = desired
 }


### PR DESCRIPTION
reported in [OCPBUGS-569](https://issues.redhat.com/browse/OCPBUGS-569), cvo history method `prune` return is not assigned to status.history, resulting in history not being pruned, and `prune` method running in loops as seen in cvo log:  
```
cluster-version-operator-669594b4cd-h89ch.log:I0824 13:24:37.889213       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.nightly-2022-08-23-223922 at index 99 with rank -99.990000.
cluster-version-operator-669594b4cd-h89ch.log:I0824 13:24:52.886216       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.nightly-2022-08-23-223922 at index 99 with rank -99.990000.
cluster-version-operator-669594b4cd-h89ch.log:I0824 13:25:07.887131       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.nightly-2022-08-23-223922 at index 99 with rank -99.990000.
cluster-version-operator-669594b4cd-h89ch.log:I0824 13:25:22.886281       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.nightly-2022-08-23-223922 at index 99 with rank -99.990000.
cluster-version-operator-669594b4cd-h89ch.log:I0824 13:25:37.888316       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.nightly-2022-08-23-223922 at index 99 with rank -99.990000.
```


tested on cluster bot build with 100 upgrade and rollback cycles. before the fix the history grown beyond 100, and cvo log contained multiple prune messages trying to prune. with the fix, in the last cycle cvo successfully pruned (the oldest partial history[-2] in this case) item, and there was 1 pruning message only in cvo log, as expected:  
```
╰─ grep Pruning *.log
cluster-version-operator-9b9868b46-mm2rw.log:I0826 12:22:58.871969       1 status_history.go:69] Pruning an older update of less importance version 4.12.0-0.ci.test-2022-08-26-112653-ci-ln-cm0zivt-latest at index 99 with rank -99.990000.
```
