### PR TITLE
OCPBUGS-1402: pkg/cvo/sync_worker.go: remove Lock/Unlock

### DIFF
--- a/pkg/cvo/testdata/payloadtest-3/release-manifests/0000_10_a_file.yaml
+++ b/pkg/cvo/testdata/payloadtest-3/release-manifests/0000_10_a_file.yaml
@@ -1,0 +1,6 @@
+kind: Test
+apiVersion: v1
+metadata:
+  name: file-yaml
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/cvo/testdata/payloadtest-3/release-manifests/image-references
+++ b/pkg/cvo/testdata/payloadtest-3/release-manifests/image-references
@@ -1,0 +1,4 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: 1.0.1-abc

--- a/pkg/cvo/testdata/payloadtest-3/release-manifests/release-metadata
+++ b/pkg/cvo/testdata/payloadtest-3/release-manifests/release-metadata
@@ -1,0 +1,10 @@
+{
+  "kind": "cincinnati-metadata-v0",
+  "version": "1.0.1-abc",
+  "previous": [
+    "1.0.0-abc"
+  ],
+  "metadata": {
+    "url": "https://example.com/v1.0.1-abc"
+  }
+}


### PR DESCRIPTION
from `SyncWorker.updateLoadStatus` and `SyncWorker.Update`. This then keeps SyncWorker locked during the entire `Update` call not allowing occurrences as described by https://bugzilla.redhat.com/show_bug.cgi?id=2118289#c1. With this change `SyncWorker` must already be locked before `SyncWorker.updateLoadStatus` is called. But currently only `SyncWorker.Update` calls `SyncWorker.updateLoadStatus`.