### PR TITLE
OCPBUGS-1251: Add admin-gate ack-4.11-kube-1.25-api-removals-in-4.12

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -1,5 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
+data:
+  ack-4.11-kube-1.25-api-removals-in-4.12: |-
+      Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6955381 for details and instructions.
 metadata:
   name: admin-gates
   namespace: openshift-config-managed


### PR DESCRIPTION
Reverting the last revert as we want to add this just before 4.12 feature freeze. This reverts commit f27e7b57c1a2bee0a4670887c233899c32126491.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>