### PR TITLE
Bug 1951835: Handle report only sync errors

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -1012,7 +1012,10 @@ func (w *SyncWorker) apply(ctx context.Context, work *SyncWork, maxWorkers int, 
 
 	// update the status
 	cr.Complete()
-	return apierrors.NewAggregate(reportEffectErrors)
+	if len(reportEffectErrors) > 0 {
+		_ = cr.Errors(reportEffectErrors)
+	}
+	return nil
 }
 
 var (


### PR DESCRIPTION
that are returned as `UpdateEffectReport` during payload initialization by allowing payload initialization to complete successfully and setting the `ClusterStatusFailing` condition.