### PR TITLE
pkg/cincinnati: Set User-Agent for Cincinnati requests

### DIFF
--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -745,7 +745,7 @@ func TestGetUpdates(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
 
-			c := NewClient(clientID, nil)
+			c := NewClient(clientID, nil, "")
 
 			uri, err := url.Parse(ts.URL)
 			if err != nil {

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -67,8 +67,10 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 		return err
 	}
 
+	userAgent := optr.getUserAgent()
+
 	current, updates, conditionalUpdates, condition := calculateAvailableUpdatesStatus(ctx, string(config.Spec.ClusterID),
-		transport, upstream, desiredArch, currentArch, channel, optr.release.Version)
+		transport, userAgent, upstream, desiredArch, currentArch, channel, optr.release.Version)
 
 	if usedDefaultUpstream {
 		upstream = ""
@@ -211,7 +213,7 @@ func (optr *Operator) getDesiredArchitecture(update *configv1.Update) string {
 	return ""
 }
 
-func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, transport *http.Transport, upstream, desiredArch,
+func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, transport *http.Transport, userAgent, upstream, desiredArch,
 	currentArch, channel, version string) (configv1.Release, []configv1.Release, []configv1.ConditionalUpdate,
 	configv1.ClusterOperatorStatusCondition) {
 
@@ -269,7 +271,7 @@ func calculateAvailableUpdatesStatus(ctx context.Context, clusterID string, tran
 		}
 	}
 
-	current, updates, conditionalUpdates, err := cincinnati.NewClient(uuid, transport).GetUpdates(ctx, upstreamURI, desiredArch,
+	current, updates, conditionalUpdates, err := cincinnati.NewClient(uuid, transport, userAgent).GetUpdates(ctx, upstreamURI, desiredArch,
 		currentArch, channel, currentVersion)
 
 	if err != nil {

--- a/pkg/cvo/egress.go
+++ b/pkg/cvo/egress.go
@@ -10,7 +10,18 @@ import (
 
 	"golang.org/x/net/http/httpproxy"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/openshift/cluster-version-operator/pkg/version"
 )
+
+// Returns a User-Agent to be used for outgoing HTTP requests.
+//
+// https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3
+func (optr *Operator) getUserAgent() string {
+	token := "ClusterVersionOperator"
+	productVersion := version.Version
+	return fmt.Sprintf("%s/%s", token, productVersion)
+}
 
 // getTransport constructs an HTTP transport configuration, including
 // any custom proxy configuration.


### PR DESCRIPTION
So that it's easier to guess at the fraction of requests that are CVOs vs. other clients.  I'd like to set this for our signature requests too (`vendor/github.com/openshift/library-go/pkg/verify/store/sigstore`), but that would take some library-go requests first.