### PR TITLE
Bug 2033499: Populate acceptedRisks in ClusterVersion History

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -888,6 +888,7 @@ func (optr *Operator) defaultPreconditionChecks() precondition.List {
 	return []precondition.Precondition{
 		preconditioncv.NewUpgradeable(optr.cvLister),
 		preconditioncv.NewRecentEtcdBackup(optr.cvLister, optr.coLister),
+		preconditioncv.NewRecommendedUpdate(optr.cvLister),
 	}
 }
 

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -631,7 +631,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			Desired:            desired,
 			ObservedGeneration: 1,
 			History: []configv1.UpdateHistory{
-				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime},
+				{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, AcceptedRisks: "The update cannot be verified: some random error"},
 			},
 			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
 				EnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
@@ -670,6 +670,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(2, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -695,6 +696,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(3, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -721,6 +723,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(4, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -747,6 +750,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(5, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -797,7 +801,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 				KnownCapabilities:   []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
 			},
 			History: []configv1.UpdateHistory{
-				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime, AcceptedRisks: "The update cannot be verified: some random error"},
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
@@ -834,6 +838,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(1, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -860,6 +865,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(2, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -886,6 +892,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(3, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -913,6 +920,7 @@ func TestCVO_StartupAndSyncUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(4, 0),
 				Update:             configv1.Update{Version: "1.0.0-abc", Image: "image/image:1"},
 			},
@@ -1515,6 +1523,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.1-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(1, 0),
 				Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1", Force: true},
 			},
@@ -1558,7 +1567,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 				KnownCapabilities:   []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
 			},
 			History: []configv1.UpdateHistory{
-				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime, AcceptedRisks: "The update cannot be verified: some random error"},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -2353,6 +2362,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 			loadPayloadStatus: LoadPayloadStatus{
 				Step:               "PayloadLoaded",
 				Message:            "Payload loaded version=\"1.0.1-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+				AcceptedRisks:      "The update cannot be verified: some random error",
 				LastTransitionTime: time.Unix(1, 0),
 				Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1", Force: true},
 			},
@@ -2397,7 +2407,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 				KnownCapabilities:   []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
 			},
 			History: []configv1.UpdateHistory{
-				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+				{State: configv1.CompletedUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime, AcceptedRisks: "The update cannot be verified: some random error"},
 				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
@@ -2438,6 +2448,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		loadPayloadStatus: LoadPayloadStatus{
 			Step:               "PayloadLoaded",
 			Message:            "Payload loaded version=\"1.0.1-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+			AcceptedRisks:      "The update cannot be verified: some random error",
 			LastTransitionTime: time.Unix(4, 0),
 			Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1", Force: true},
 		},
@@ -2717,6 +2728,152 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 					Message: "Payload loaded version=\"1.0.1-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\""},
 			},
 		},
+	})
+}
+
+func TestCVO_UpgradePreconditionFailingAcceptedRisks(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest("testdata/payloadtest-2")
+
+	// Setup: a successful sync from a previous run, and the operator at the same image as before
+	//
+	o.release.Image = "image/image:0"
+	o.release.Version = "1.0.0-abc"
+	desired := configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+			Generation:      1,
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID:     clusterUID,
+			Channel:       "fast",
+			DesiredUpdate: &configv1.Update{Version: desired.Version, Image: desired.Image},
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the image version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "DL-FFQ2Uem8=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer shutdownFn()
+
+	worker := o.configSync.(*SyncWorker)
+	worker.preconditions = []precondition.Precondition{&testPreconditionAlwaysFail{PreConditionName: "PreCondition1"}, &testPreconditionAlwaysFail{PreConditionName: "PreCondition2"}}
+
+	go worker.Start(ctx, 1, o.name, o.cvLister)
+
+	// Step 1: The operator should report that it is blocked on precondition checks failing
+	//
+	client.ClearActions()
+	err := o.sync(ctx, o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	verifyCVSingleUpdate(t, actions)
+
+	verifyAllStatus(t, worker.StatusCh(),
+		SyncWorkerStatus{
+			Actual:     configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation: 1,
+			loadPayloadStatus: LoadPayloadStatus{
+				Step:               "RetrievePayload",
+				Message:            "Retrieving and verifying payload version=\"1.0.1-abc\" image=\"image/image:1\"",
+				LastTransitionTime: time.Unix(1, 0),
+				Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1"},
+			},
+		},
+		SyncWorkerStatus{
+			Actual:       configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"},
+			Generation:   1,
+			LastProgress: time.Unix(1, 0),
+			loadPayloadStatus: LoadPayloadStatus{
+				Step:               "PreconditionChecks",
+				Message:            "Preconditions failed for payload loaded version=\"1.0.1-abc\" image=\"image/image:1\": Multiple precondition checks failed:\n* Precondition \"PreCondition1\" failed because of \"CheckFailure\": PreCondition1 will always fail.\n* Precondition \"PreCondition2\" failed because of \"CheckFailure\": PreCondition2 will always fail.",
+				LastTransitionTime: time.Unix(2, 0),
+				Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1"},
+				Failure:            &payload.UpdateError{Reason: "UpgradePreconditionCheckFailed", Message: "Multiple precondition checks failed:\n* Precondition \"PreCondition1\" failed because of \"CheckFailure\": PreCondition1 will always fail.\n* Precondition \"PreCondition2\" failed because of \"CheckFailure\": PreCondition2 will always fail.", Name: "PreconditionCheck"},
+			},
+		},
+	)
+
+	client.ClearActions()
+	err = o.sync(ctx, o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual := cvs["version"].(*configv1.ClusterVersion)
+
+	// Step 2: Force through precondtion failures and ensure accepted risks are populated
+	//
+	// set an update
+	copied := configv1.Update{
+		Version: desired.Version,
+		Image:   desired.Image,
+		Force:   true,
+	}
+	actual.Spec.DesiredUpdate = &copied
+	//
+	// ensure the sync worker tells the sync loop about it
+	err = o.sync(ctx, o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitForStatus(t, 8, 3, worker.StatusCh(), waitForPayloadLoaded)
+	verifyFinalStatus(t, "Step 2", 10, true, worker.StatusCh(), SyncWorkerStatus{
+		Total:       3,
+		VersionHash: "DL-FFQ2Uem8=", Architecture: architecture,
+		Actual: configv1.Release{
+			Version: "1.0.1-abc",
+			Image:   "image/image:1",
+			URL:     configv1.URL("https://example.com/v1.0.1-abc"),
+		},
+		LastProgress: time.Unix(2, 0),
+		Generation:   1,
+		CapabilitiesStatus: CapabilityStatus{
+			Status: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
+				KnownCapabilities:   []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityConsole, configv1.ClusterVersionCapabilityInsights, configv1.ClusterVersionCapabilityStorage, configv1.ClusterVersionCapabilityBaremetal, configv1.ClusterVersionCapabilityMarketplace, configv1.ClusterVersionCapabilityOpenShiftSamples},
+			},
+		},
+		loadPayloadStatus: LoadPayloadStatus{
+			Step:               "PayloadLoaded",
+			Message:            "Payload loaded version=\"1.0.1-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\"",
+			AcceptedRisks:      "Forced through blocking failures: Multiple precondition checks failed:\n* Precondition \"PreCondition1\" failed because of \"CheckFailure\": PreCondition1 will always fail.\n* Precondition \"PreCondition2\" failed because of \"CheckFailure\": PreCondition2 will always fail.",
+			LastTransitionTime: time.Unix(3, 0),
+			Update:             configv1.Update{Version: "1.0.1-abc", Image: "image/image:1", Force: true},
+		},
+	},
+		acceptedRisksPopulated,
+	)
+
+	// wait for loaded payload to be sync'ed
+	waitForStatus(t, 8, 3, worker.StatusCh(), waitForCompleted)
+	actions = client.Actions()
+	t.Logf("%#v", actions)
+
+	// confirm history updated
+	checkStatus(t, actions[2], "update", "clusterversions", "status", "", []configv1.UpdateHistory{
+		{State: configv1.PartialUpdate, Image: "image/image:1", Version: "1.0.1-abc", StartedTime: defaultStartedTime, AcceptedRisks: "Forced through blocking failures: Multiple precondition checks failed:\n* Precondition \"PreCondition1\" failed because of \"CheckFailure\": PreCondition1 will always fail.\n* Precondition \"PreCondition2\" failed because of \"CheckFailure\": PreCondition2 will always fail."},
+		{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime, Verified: true},
 	})
 }
 
@@ -3863,6 +4020,10 @@ func verifyAllStatusOptionalDone(t *testing.T, stepName string, ignoreDone bool,
 
 func finalStatusIndicatorCompleted(status SyncWorkerStatus) bool {
 	return status.Completed == 3
+}
+
+func acceptedRisksPopulated(status SyncWorkerStatus) bool {
+	return status.loadPayloadStatus.AcceptedRisks != ""
 }
 
 func verifyFinalStatus(t *testing.T, name string, maxLoopCount int, ignoreFields bool, ch <-chan SyncWorkerStatus,

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -4025,7 +4025,7 @@ func expectUpdateStatus(t *testing.T, a ktesting.Action, resource, namespace str
 
 // checkStatus is a generic function used to verify only a portion of a CreateAction as defined by the
 // generic type arguments.
-func checkStatus[S configv1.ClusterVersionCapabilitiesStatus | []configv1.ClusterOperatorStatusCondition |
+func checkStatus[S configv1.ClusterVersionCapabilitiesStatus | []configv1.ClusterOperatorStatusCondition | []configv1.UpdateHistory |
 	*configv1.ClusterVersion](t *testing.T, a ktesting.Action, verb string, resource, subresource, namespace string, expect S) {
 
 	t.Helper()
@@ -4069,6 +4069,10 @@ func checkStatus[S configv1.ClusterVersionCapabilitiesStatus | []configv1.Cluste
 			} else if _, ok := any(expect).(configv1.ClusterVersionCapabilitiesStatus); ok {
 				if !reflect.DeepEqual(expect, in.Status.Capabilities) {
 					t.Fatalf("expected ClusterVersionCapabilitiesStatus not equal to actual:\n%v\n%v", expect, in.Status.Capabilities)
+				}
+			} else if _, ok := any(expect).([]configv1.UpdateHistory); ok {
+				if !reflect.DeepEqual(expect, in.Status.History) {
+					t.Fatalf("expected History not equal to actual:\n%v\n%v", expect, in.Status.History)
 				}
 			} else {
 				if !reflect.DeepEqual(expect, in.Status.Conditions) {

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -56,7 +56,7 @@ func mergeEqualVersions(current *configv1.UpdateHistory, desired configv1.Releas
 	return false
 }
 
-func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Release, verified bool, now metav1.Time, completed bool) {
+func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Release, verified bool, now metav1.Time, completed bool, acceptedRisksMsg string) {
 	// if we have no image, we cannot reproduce the update later and so it cannot be part of the history
 	if len(desired.Image) == 0 {
 		// make the array empty
@@ -72,8 +72,9 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Rele
 			Version: desired.Version,
 			Image:   desired.Image,
 
-			State:       configv1.PartialUpdate,
-			StartedTime: now,
+			State:         configv1.PartialUpdate,
+			StartedTime:   now,
+			AcceptedRisks: acceptedRisksMsg,
 		})
 	}
 
@@ -91,6 +92,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Rele
 				last.CompletionTime = &now
 			}
 		}
+		last.AcceptedRisks = acceptedRisksMsg
 	} else {
 		klog.V(2).Infof("must add a new history entry completed=%t desired=%#v != last=%#v", completed, desired, last)
 		if last.CompletionTime == nil {
@@ -105,6 +107,7 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Rele
 					State:          configv1.CompletedUpdate,
 					StartedTime:    now,
 					CompletionTime: &now,
+					AcceptedRisks:  acceptedRisksMsg,
 				},
 			}, config.Status.History...)
 		} else {
@@ -113,8 +116,9 @@ func mergeOperatorHistory(config *configv1.ClusterVersion, desired configv1.Rele
 					Version: desired.Version,
 					Image:   desired.Image,
 
-					State:       configv1.PartialUpdate,
-					StartedTime: now,
+					State:         configv1.PartialUpdate,
+					StartedTime:   now,
+					AcceptedRisks: acceptedRisksMsg,
 				},
 			}, config.Status.History...)
 		}
@@ -194,7 +198,13 @@ func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1
 		}
 	}
 	desired := optr.mergeReleaseMetadata(status.Actual)
-	mergeOperatorHistory(config, desired, status.Verified, now, status.Completed > 0)
+
+	risksMsg := ""
+	if desired.Image == status.loadPayloadStatus.Update.Image {
+		risksMsg = status.loadPayloadStatus.AcceptedRisks
+	}
+
+	mergeOperatorHistory(config, desired, status.Verified, now, status.Completed > 0, risksMsg)
 
 	config.Status.Capabilities = status.CapabilitiesStatus.Status
 
@@ -504,7 +514,7 @@ func (optr *Operator) syncFailingStatus(ctx context.Context, original *configv1.
 		LastTransitionTime: now,
 	})
 
-	mergeOperatorHistory(config, optr.currentVersion(), false, now, false)
+	mergeOperatorHistory(config, optr.currentVersion(), false, now, false, "")
 
 	updated, err := applyClusterVersionStatus(ctx, optr.client.ConfigV1(), config, original)
 	optr.rememberLastUpdate(updated)

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -559,3 +559,20 @@ func (pf *testPrecondition) Run(_ context.Context, _ precondition.ReleaseContext
 		Name:    pf.Name(),
 	}
 }
+
+type testPreconditionAlwaysFail struct {
+	PreConditionName string
+}
+
+func (pf *testPreconditionAlwaysFail) Name() string {
+	return pf.PreConditionName
+}
+
+func (pf *testPreconditionAlwaysFail) Run(_ context.Context, _ precondition.ReleaseContext) error {
+	return &precondition.Error{
+		Nested:  nil,
+		Reason:  "CheckFailure",
+		Message: fmt.Sprintf("%s will always fail.", pf.Name()),
+		Name:    pf.Name(),
+	}
+}

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -92,6 +92,7 @@ func (w SyncWork) Empty() bool {
 type LoadPayloadStatus struct {
 	Step               string
 	Message            string
+	AcceptedRisks      string
 	Failure            error
 	Update             configv1.Update
 	Verified           bool
@@ -299,18 +300,24 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 			})
 			return nil, err
 		}
+		acceptedRisksMsg := ""
 		if info.VerificationError != nil {
-			msg := ""
 			for err := info.VerificationError; err != nil; err = errors.Unwrap(err) {
 				details := err.Error()
-				if !strings.Contains(msg, details) {
-					// library-go/pkg/verify wraps the details, but does not include them
-					// in the top-level error string.  If we have an error like that,
-					// include the details here.
-					msg = fmt.Sprintf("%s\n%s", msg, details)
+
+				// library-go/pkg/verify wraps the details, but does not include them
+				// in the top-level error string.  If we have an error like that,
+				// include the details here.
+
+				if acceptedRisksMsg == "" {
+					acceptedRisksMsg = details
+					continue
+				}
+				if !strings.Contains(acceptedRisksMsg, details) {
+					acceptedRisksMsg = fmt.Sprintf("%s\n%s", acceptedRisksMsg, details)
 				}
 			}
-			w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeWarning, "RetrievePayload", msg)
+			w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeWarning, "RetrievePayload", acceptedRisksMsg)
 		}
 
 		w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeNormal, "LoadPayload", "Loading payload version=%q image=%q", desired.Version, desired.Image)
@@ -375,6 +382,12 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 					return nil, err
 				} else {
 					w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeWarning, "PreconditionWarn", "precondition warning for payload loaded version=%q image=%q: %v", desired.Version, desired.Image, err)
+
+					if acceptedRisksMsg == "" {
+						acceptedRisksMsg = err.Error()
+					} else {
+						acceptedRisksMsg = fmt.Sprintf("%s\n%s", acceptedRisksMsg, err.Error())
+					}
 				}
 			}
 			w.eventRecorder.Eventf(cvoObjectRef, corev1.EventTypeNormal, "PreconditionsPassed", "preconditions passed for payload loaded version=%q image=%q", desired.Version, desired.Image)
@@ -391,6 +404,7 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 			Failure:            nil,
 			Step:               "PayloadLoaded",
 			Message:            msg,
+			AcceptedRisks:      acceptedRisksMsg,
 			Verified:           info.Verified,
 			Update:             desired,
 			LastTransitionTime: time.Now(),

--- a/pkg/payload/precondition/clusterversion/recommendedupdate.go
+++ b/pkg/payload/precondition/clusterversion/recommendedupdate.go
@@ -1,0 +1,120 @@
+package clusterversion
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
+	precondition "github.com/openshift/cluster-version-operator/pkg/payload/precondition"
+)
+
+// RecommendedUpdate checks if clusterversion is upgradeable currently.
+type RecommendedUpdate struct {
+	key    string
+	lister configv1listers.ClusterVersionLister
+}
+
+// NewRecommendedUpdate returns a new RecommendedUpdate precondition check.
+func NewRecommendedUpdate(lister configv1listers.ClusterVersionLister) *RecommendedUpdate {
+	return &RecommendedUpdate{
+		key:    "version",
+		lister: lister,
+	}
+}
+
+// Run runs the RecommendedUpdate precondition.
+// Returns PreconditionError when possible, if the requested target release is Recommended=False.
+func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext precondition.ReleaseContext) error {
+	clusterVersion, err := ru.lister.Get(ru.key)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return nil
+	}
+	if err != nil {
+		return &precondition.Error{
+			Nested:  err,
+			Reason:  "UnknownError",
+			Message: err.Error(),
+			Name:    ru.Name(),
+		}
+	}
+	for _, recommended := range clusterVersion.Status.AvailableUpdates {
+		if recommended.Version == releaseContext.DesiredVersion {
+			return nil
+		}
+	}
+
+	for _, conditionalUpdate := range clusterVersion.Status.ConditionalUpdates {
+		if conditionalUpdate.Release.Version == releaseContext.DesiredVersion {
+			for _, condition := range conditionalUpdate.Conditions {
+				if condition.Type == "Recommended" {
+					switch condition.Status {
+					case metav1.ConditionTrue:
+						return nil
+					case metav1.ConditionFalse:
+						return &precondition.Error{
+							Reason: condition.Reason,
+							Message: fmt.Sprintf("Update from %s to %s is not recommended:\n\n%s",
+								clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion, condition.Message),
+							Name: ru.Name(),
+						}
+					default:
+						return &precondition.Error{
+							Reason: condition.Reason,
+							Message: fmt.Sprintf("Update from %s to %s is %s=%s: %s: %s",
+								clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion,
+								condition.Type, condition.Status, condition.Reason, condition.Message),
+							Name: ru.Name(),
+						}
+					}
+				}
+			}
+			return &precondition.Error{
+				Reason: "UnknownConditionType",
+				Message: fmt.Sprintf("Update from %s to %s has a status.conditionalUpdates entry, but no Recommended condition.",
+					clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion),
+				Name: ru.Name(),
+			}
+		}
+	}
+
+	if clusterVersion.Spec.Channel == "" {
+		return &precondition.Error{
+			Reason: "NoChannel",
+			Message: fmt.Sprintf("Configured channel is unset, so the recommended status of updating from %s to %s is unknown.",
+				clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion),
+			Name: ru.Name(),
+		}
+	}
+
+	reason := "UnknownUpdate"
+	msg := ""
+
+	if retrieved := resourcemerge.FindOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.RetrievedUpdates); retrieved == nil {
+		msg = fmt.Sprintf("No %s, so the recommended status of updating from %s to %s is unknown.", configv1.RetrievedUpdates,
+			clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion)
+	} else if retrieved.Status == configv1.ConditionTrue {
+		msg = fmt.Sprintf("%s=%s (%s), so the update from %s to %s is probably neither recommended nor supported.", retrieved.Type,
+			retrieved.Status, retrieved.Reason, clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion)
+	} else {
+		msg = fmt.Sprintf("%s=%s (%s), so the recommended status of updating from %s to %s is unknown.", retrieved.Type,
+			retrieved.Status, retrieved.Reason, clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion)
+	}
+
+	if msg != "" {
+		return &precondition.Error{
+			Reason:  reason,
+			Message: msg,
+			Name:    ru.Name(),
+		}
+	}
+	return nil
+}
+
+// Name returns Name for the precondition.
+func (ru *RecommendedUpdate) Name() string { return "ClusterVersionRecommendedUpdate" }

--- a/pkg/payload/precondition/clusterversion/recommendedupdate_test.go
+++ b/pkg/payload/precondition/clusterversion/recommendedupdate_test.go
@@ -1,0 +1,137 @@
+package clusterversion
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-version-operator/pkg/payload/precondition"
+)
+
+func TestRecommendedUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	targetVersion := "4.3.2"
+	tests := []struct {
+		name               string
+		channel            string
+		availableUpdates   []configv1.Release
+		conditionalUpdates []configv1.ConditionalUpdate
+		conditions         []configv1.ClusterOperatorStatusCondition
+		expected           string
+	}{
+		{
+			name:             "recommended",
+			availableUpdates: []configv1.Release{{Version: targetVersion}},
+		},
+		{
+			name:     "no relevant data",
+			channel:  "stable-4.3",
+			expected: "No RetrievedUpdates, so the recommended status of updating from 4.3.0 to 4.3.2 is unknown.",
+		},
+		{
+			name: "Recommended=True",
+			conditionalUpdates: []configv1.ConditionalUpdate{{
+				Release: configv1.Release{Version: targetVersion},
+				Conditions: []metav1.Condition{{
+					Type:    "Recommended",
+					Status:  metav1.ConditionTrue,
+					Reason:  "RecommendedReason",
+					Message: "For some reason, this update is recommended.",
+				}},
+			}},
+		},
+		{
+			name: "Recommended=False",
+			conditionalUpdates: []configv1.ConditionalUpdate{{
+				Release: configv1.Release{Version: targetVersion},
+				Conditions: []metav1.Condition{{
+					Type:    "Recommended",
+					Status:  metav1.ConditionFalse,
+					Reason:  "FalseReason",
+					Message: "For some reason, this update is not recommended.",
+				}},
+			}},
+			expected: "Update from 4.3.0 to 4.3.2 is not recommended:\n\nFor some reason, this update is not recommended.",
+		},
+		{
+			name: "Recommended=Unknown",
+			conditionalUpdates: []configv1.ConditionalUpdate{{
+				Release: configv1.Release{Version: targetVersion},
+				Conditions: []metav1.Condition{{
+					Type:    "Recommended",
+					Status:  metav1.ConditionUnknown,
+					Reason:  "UnknownReason",
+					Message: "For some reason, we cannot decide if this update is recommended.",
+				}},
+			}},
+			expected: "Update from 4.3.0 to 4.3.2 is Recommended=Unknown: UnknownReason: For some reason, we cannot decide if this update is recommended.",
+		},
+		{
+			name: "Unknown condition type",
+			conditionalUpdates: []configv1.ConditionalUpdate{{
+				Release: configv1.Release{Version: targetVersion},
+				Conditions: []metav1.Condition{{
+					Type:    "Unknown",
+					Status:  metav1.ConditionTrue,
+					Reason:  "NotUsed",
+					Message: "Not used.",
+				}},
+			}},
+			expected: "Update from 4.3.0 to 4.3.2 has a status.conditionalUpdates entry, but no Recommended condition.",
+		},
+		{
+			name:    "RetrievedUpdates=True",
+			channel: "stable-4.3",
+			conditions: []configv1.ClusterOperatorStatusCondition{{
+				Type:    configv1.RetrievedUpdates,
+				Status:  configv1.ConditionTrue,
+				Reason:  "TrueReason",
+				Message: "Not used.",
+			}},
+			expected: "RetrievedUpdates=True (TrueReason), so the update from 4.3.0 to 4.3.2 is probably neither recommended nor supported.",
+		},
+		{
+			name:    "RetrievedUpdates=False",
+			channel: "stable-4.3",
+			conditions: []configv1.ClusterOperatorStatusCondition{{
+				Type:    configv1.RetrievedUpdates,
+				Status:  configv1.ConditionFalse,
+				Reason:  "FalseReason",
+				Message: "For some reason, we cannot retrieve update recommendations.",
+			}},
+			expected: "RetrievedUpdates=False (FalseReason), so the recommended status of updating from 4.3.0 to 4.3.2 is unknown.",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterVersion := &configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Spec:       configv1.ClusterVersionSpec{Channel: testCase.channel},
+				Status: configv1.ClusterVersionStatus{
+					Desired:            configv1.Release{Version: "4.3.0"},
+					AvailableUpdates:   testCase.availableUpdates,
+					ConditionalUpdates: testCase.conditionalUpdates,
+					Conditions:         testCase.conditions,
+				},
+			}
+			cvLister := fakeClusterVersionLister(t, clusterVersion)
+			instance := NewRecommendedUpdate(cvLister)
+			err := instance.Run(ctx, precondition.ReleaseContext{DesiredVersion: targetVersion})
+			switch {
+			case err != nil && len(testCase.expected) == 0:
+				t.Error(err)
+			case err != nil && err.Error() == testCase.expected:
+			case err != nil && err.Error() != testCase.expected:
+				t.Errorf("got %q, but expected %q", err, testCase.expected)
+			case err == nil && len(testCase.expected) == 0:
+			case err == nil && len(testCase.expected) != 0:
+				t.Errorf("got %q, but expected %q", err, testCase.expected)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
by merging in https://github.com/wking/cluster-version-operator/commit/5613130c7817b6d37773ea1c1a3028b8546185c1#diff-854cd9a3f8419eead65da9983aa2a7efb35a8e76a8eeb20082304987a05c0c01R76 and adding pieces to get the accepted risks message into history by first saving in `SyncWorkerStatus.loadPayloadStatus`.