### PR TITLE
Dockerfile: Bump to Go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \


### PR DESCRIPTION
Fixes:

```console
$ ./hack/build-image.sh
...
[1/2] STEP 4/4: RUN hack/build-go.sh;     mkdir -p /tmp/build;     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
...
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
```
