### PR TITLE
cluster-version-operator deployment is invalid

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
-            fieldPath: spec.nodeName
+              fieldPath: spec.nodeName
         - name: CLUSTER_PROFILE
           value: {{ .ClusterProfile }}
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Fix for: 

> bootkube.sh[8231]: Failed to create "0000_00_cluster-version-operator_03_deployment.yaml" deployments.v1.apps/cluster-version-operator -n openshift-cluster-version: Deployment.apps "cluster-version-operator" is invalid: spec.template.spec.containers[0].env[2].valueFrom: Invalid value: "": must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`
