### PR TITLE
Revert "Fix ups from gofmt 1.19 and yamllint"

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -11,40 +11,40 @@ spec:
     image: {{.ReleaseImage}}
     imagePullPolicy: Always
     args:
-    - "start"
-    - "--release-image={{.ReleaseImage}}"
-    - "--enable-auto-update=false"
-    - "--listen="
-    - "--v=2"
-    - "--kubeconfig=/etc/kubernetes/kubeconfig"
+      - "start"
+      - "--release-image={{.ReleaseImage}}"
+      - "--enable-auto-update=false"
+      - "--listen="
+      - "--v=2"
+      - "--kubeconfig=/etc/kubernetes/kubeconfig"
     securityContext:
       privileged: true
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
-    - mountPath: /etc/ssl/certs
-      name: etc-ssl-certs
-      readOnly: true
-    - mountPath: /etc/kubernetes/kubeconfig
-      name: kubeconfig
-      readOnly: true
+      - mountPath: /etc/ssl/certs
+        name: etc-ssl-certs
+        readOnly: true
+      - mountPath: /etc/kubernetes/kubeconfig
+        name: kubeconfig
+        readOnly: true
     env:
-    - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.
-      value: "6443"
-    - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.
-      value: "127.0.0.1"
-    - name: NODE_NAME
-      valueFrom:
-        fieldRef:
-        fieldPath: spec.nodeName
-    - name: CLUSTER_PROFILE
-      value: {{ .ClusterProfile }}
+      - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.
+        value: "6443"
+      - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.
+        value: "127.0.0.1"
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: CLUSTER_PROFILE
+        value: {{ .ClusterProfile }}
   dnsPolicy: ClusterFirstWithHostNet
   hostNetwork: true
   terminationGracePeriodSeconds: 130
   volumes:
-  - name: kubeconfig
-    hostPath:
-    path: /etc/kubernetes/kubeconfig
-  - name: etc-ssl-certs
-    hostPath:
-    path: /etc/ssl/certs
+    - name: kubeconfig
+      hostPath:
+        path: /etc/kubernetes/kubeconfig
+    - name: etc-ssl-certs
+      hostPath:
+        path: /etc/ssl/certs

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -27,45 +27,45 @@ spec:
         image: {{.ReleaseImage}}
         imagePullPolicy: IfNotPresent
         args:
-        - "start"
-        - "--release-image={{.ReleaseImage}}"
-        - "--enable-auto-update=false"
-        - "--listen=0.0.0.0:9099"
-        - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
-        - "--serving-key-file=/etc/tls/serving-cert/tls.key"
-        - "--v=2"
+          - "start"
+          - "--release-image={{.ReleaseImage}}"
+          - "--enable-auto-update=false"
+          - "--listen=0.0.0.0:9099"
+          - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
+          - "--serving-key-file=/etc/tls/serving-cert/tls.key"
+          - "--v=2"
         resources:
           requests:
             cpu: 20m
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /etc/ssl/certs
-          name: etc-ssl-certs
-          readOnly: true
-        - mountPath: /etc/cvo/updatepayloads
-          name: etc-cvo-updatepayloads
-          readOnly: true
-        - mountPath: /etc/tls/serving-cert
-          name: serving-cert
-          readOnly: true
-        - mountPath: /etc/tls/service-ca
-          name: service-ca
-          readOnly: true
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
-          readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: etc-ssl-certs
+            readOnly: true
+          - mountPath: /etc/cvo/updatepayloads
+            name: etc-cvo-updatepayloads
+            readOnly: true
+          - mountPath: /etc/tls/serving-cert
+            name: serving-cert
+            readOnly: true
+          - mountPath: /etc/tls/service-ca
+            name: service-ca
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
         env:
-        - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
-          value: "6443"
-        - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
-          value: "127.0.0.1"
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-            fieldPath: spec.nodeName
-        - name: CLUSTER_PROFILE
-          value: {{ .ClusterProfile }}
+          - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
+            value: "6443"
+          - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
+            value: "127.0.0.1"
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: CLUSTER_PROFILE
+            value: {{ .ClusterProfile }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       nodeSelector:
@@ -81,43 +81,43 @@ spec:
         effect: "NoSchedule"
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
-        effect: "NoSchedule"
+        effect: "NoSchedule" 
       - key: "node.kubernetes.io/unreachable"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120
+        tolerationSeconds: 120 
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120
+        tolerationSeconds: 120 
       volumes:
-      - name: etc-ssl-certs
-        hostPath:
-        path: /etc/ssl/certs
-      - name: etc-cvo-updatepayloads
-        hostPath:
-        path: /etc/cvo/updatepayloads
-      - name: serving-cert
-        secret:
-        secretName: cluster-version-operator-serving-cert
-      - name: service-ca
-        configMap:
-          name: openshift-service-ca.crt
-      - name: kube-api-access
-        projected:
-        defaultMode: 420
-        sources:
-        - serviceAccountToken:
-            expirationSeconds: 3600
-            path: token
-        - configMap:
-            items:
-            - key: ca.crt
-              path: ca.crt
-              name: kube-root-ca.crt
+        - name: etc-ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+        - name: etc-cvo-updatepayloads
+          hostPath:
+            path: /etc/cvo/updatepayloads
+        - name: serving-cert
+          secret:
+            secretName: cluster-version-operator-serving-cert
+        - name: service-ca
+          configMap:
+            name: openshift-service-ca.crt
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
             - downwardAPI:
                 items:
                 - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
                   path: namespace

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -59,8 +59,8 @@ spec:
         (
           (
             time()-cluster_version_operator_update_retrieval_timestamp_seconds
-          ) >= 3600
-          and ignoring(condition, name, reason)
+          ) >= 3600 
+          and ignoring(condition, name, reason) 
           (cluster_operator_conditions{name="version", condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"})
         )
       labels:

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -59,13 +59,13 @@ func (err *Error) Error() string {
 // GetUpdates fetches the current and next-applicable update payloads from the specified
 // upstream Cincinnati stack given the current version and channel. The command:
 //
-//  1. Downloads the update graph from the requested URI for the requested arch and channel.
-//  2. Finds the current version entry under .nodes.
-//  3. Finds recommended next-hop updates by searching .edges for updates from the current
-//     version. Returns a slice of target Releases with these unconditional recommendations.
-//  4. Finds conditionally recommended next-hop updates by searching .conditionalEdges for
-//     updates from the current version.  Returns a slice of ConditionalUpdates with these
-//     conditional recommendations.
+// 1. Downloads the update graph from the requested URI for the requested arch and channel.
+// 2. Finds the current version entry under .nodes.
+// 3. Finds recommended next-hop updates by searching .edges for updates from the current
+//    version. Returns a slice of target Releases with these unconditional recommendations.
+// 4. Finds conditionally recommended next-hop updates by searching .conditionalEdges for
+//    updates from the current version.  Returns a slice of ConditionalUpdates with these
+//    conditional recommendations.
 func (c Client) GetUpdates(ctx context.Context, uri *url.URL, arch string, channel string, version semver.Version) (configv1.Release, []configv1.Release, []configv1.ConditionalUpdate, error) {
 	var current configv1.Release
 	// Prepare parametrized cincinnati query.

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -142,18 +142,19 @@ func (w SyncWorkerStatus) DeepCopy() *SyncWorkerStatus {
 //
 // State transitions:
 //
-//	Initial: wait for valid Update(), report empty status
-//	  Update() -> Sync
-//	Sync: attempt to invoke the apply() method
-//	  apply() returns an error -> Error
-//	  apply() returns nil -> Reconciling
-//	Reconciling: invoke apply() no more often than reconcileInterval
-//	  Update() with different values -> Sync
-//	  apply() returns an error -> Error
-//	  apply() returns nil -> Reconciling
-//	Error: backoff until we are attempting every reconcileInterval
-//	  apply() returns an error -> Error
-//	  apply() returns nil -> Reconciling
+//   Initial: wait for valid Update(), report empty status
+//     Update() -> Sync
+//   Sync: attempt to invoke the apply() method
+//     apply() returns an error -> Error
+//     apply() returns nil -> Reconciling
+//   Reconciling: invoke apply() no more often than reconcileInterval
+//     Update() with different values -> Sync
+//     apply() returns an error -> Error
+//     apply() returns nil -> Reconciling
+//   Error: backoff until we are attempting every reconcileInterval
+//     apply() returns an error -> Error
+//     apply() returns nil -> Reconciling
+//
 type SyncWorker struct {
 	backoff       wait.Backoff
 	retriever     PayloadRetriever
@@ -421,7 +422,7 @@ func (w *SyncWorker) loadUpdatedPayload(ctx context.Context, work *SyncWork,
 // ignored unless this is the first time that Update has been called. The returned status represents either
 // the initial state or whatever the last recorded status was.
 // TODO: in the future it may be desirable for changes that alter desired to wait briefly before returning,
-// giving the sync loop the opportunity to observe our change and begin working towards it.
+//   giving the sync loop the opportunity to observe our change and begin working towards it.
 func (w *SyncWorker) Update(ctx context.Context, generation int64, desired configv1.Update, config *configv1.ClusterVersion,
 	state payload.State, cvoOptrName string) *SyncWorkerStatus {
 


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#844

Avoid:

```
bootkube.sh[8231]: Failed to create "0000_00_cluster-version-operator_03_deployment.yaml" deployments.v1.apps/cluster-version-operator -n openshift-cluster-version: Deployment.apps "cluster-version-operator" is invalid: spec.template.spec.containers[0].env[2].valueFrom: Invalid value: "": must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`
```

Sorry for overriding CI without looking closely enough :(