### PR TITLE
OCPBUGS-1458: Allow CVO to update `KUBERNETES_SERVICE_HOST` with LB address

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -112,13 +112,6 @@ func ensureContainer(modified *bool, existing *corev1.Container, required corev1
 
 func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.EnvVar) {
 	for envidx := range required {
-		// Currently only CVO deployment uses this variable to inject internal LB host.
-		// This may result in an IP address being returned by API so assuming the
-		// returned value is correct.
-		if required[envidx].Name == "KUBERNETES_SERVICE_HOST" {
-			ensureEnvVarKubeService(*existing, &required[envidx])
-		}
-
 		if required[envidx].ValueFrom != nil {
 			ensureEnvVarSourceFieldRefDefault(required[envidx].ValueFrom.FieldRef)
 		}
@@ -126,14 +119,6 @@ func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.E
 	if !equality.Semantic.DeepEqual(required, *existing) {
 		*existing = required
 		*modified = true
-	}
-}
-
-func ensureEnvVarKubeService(existing []corev1.EnvVar, required *corev1.EnvVar) {
-	for envidx := range existing {
-		if existing[envidx].Name == required.Name {
-			required.Value = existing[envidx].Value
-		}
 	}
 }
 

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -1640,6 +1640,26 @@ func TestEnsureEnvVar(t *testing.T) {
 			},
 			expectedModified: false,
 		},
+		{
+			name: "CVO can inject LB into ENVVAR",
+			existing: []corev1.EnvVar{
+				{Name: "ENVVAR", Value: "127.0.0.1"},
+			},
+			input: []corev1.EnvVar{
+				{Name: "ENVVAR", Value: "api-int.ci-ln-vqs15yk-72292.gcp-2.ci.openshift.org"},
+			},
+			expectedModified: true,
+		},
+		{
+			name: "CVO can inject LB into KUBERNETES_SERVICE_HOST",
+			existing: []corev1.EnvVar{
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "127.0.0.1"},
+			},
+			input: []corev1.EnvVar{
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "api-int.ci-ln-vqs15yk-72292.gcp-2.ci.openshift.org"},
+			},
+			expectedModified: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The problem was identified to be a broken substitution of internal load balancer into `KUBERNETES_SERVICE_HOST` by Trevor and David (see my [JIRA comment](https://issues.redhat.com/browse/OCPBUGS-1458?focusedCommentId=21090756&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21090756) and related [Slack thread](https://coreos.slack.com/archives/C011CSSPBLK/p1664925995946479?thread_ts=1661182025.992649&cid=C011CSSPBLK)).

CVO injects the LB hostname in the [`ModifyDeployment`](https://github.com/openshift/cluster-version-operator/blob/dc1ad0aef5f3e1b88074448d21445a5bddb6b05b/lib/resourcebuilder/apps.go#L19) fine, but then the deployment gets applied in [`ApplyDeployment`](https://github.com/openshift/cluster-version-operator/blob/dc1ad0aef5f3e1b88074448d21445a5bddb6b05b/lib/resourceapply/apps.go#L17) and the  `EnsureDeployment`->`ensurePodTemplateSpec`->`ensurePodSpec`->`ensureContainers`->`ensureContainer`->`ensureEnvVar` chain stomps the updated value in `required` by the old value from `existing` and reverts the injection.

This behavior was added intentionally in https://github.com/openshift/cluster-version-operator/pull/559 as a part of a fix for various hot-looping issues. The substitution apparently caused some hot-looping issues in the past ([slack thread](https://coreos.slack.com/archives/CEGKQ43CP/p1620934857402200?thread_ts=1620895567.367100&cid=CEGKQ43CP)). I have tested removing the special handling `KUBERNETES_SERVICE_HOST` thoroughly, and saw no problematic behavior. After fixing other hot-looping problems in https://github.com/openshift/cluster-version-operator/pull/855 to eliminate noise, no new hot-loops occurs with `KUBERNETES_SERVICE_HOST` handling removed.

Even with the substitution fix, I observed further network problems in CVO ([example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/851/pull-ci-openshift-cluster-version-operator-master-e2e-agnostic/1584592473953406976/artifacts/e2e-agnostic/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-dd6bdb766-qdctn_cluster-version-operator_previous.log)):

```
F1024 17:40:24.591942       1 start.go:29] error: Get "https://api-int.ci-op-02b7hikv-3302f.ci.azure.devcluster.openshift.com:6443/apis/config.openshift.io/v1/featuregates/cluster": dial tcp: lookup api-int.ci-op-02b7hikv-3302f.ci.azure.devcluster.openshift.com on 172.30.0.10:53: read udp 169.254.169.2:48475->172.30.0.10:53: i/o timeout
```

To get rid of these, I added a client-side poll to CVO, but I currently fail to reproduce the issue in https://github.com/openshift/cluster-version-operator/pull/859, so maybe the `i/o timeout` issues were just some co-indidental disruption bug that we happened to fix in the meantime? Not sure.