### PR TITLE
OCPBUGS-2727: Do not fail precondition check for UnknownUpdate

### DIFF
--- a/pkg/payload/precondition/clusterversion/recommendedupdate.go
+++ b/pkg/payload/precondition/clusterversion/recommendedupdate.go
@@ -37,10 +37,11 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 	}
 	if err != nil {
 		return &precondition.Error{
-			Nested:  err,
-			Reason:  "UnknownError",
-			Message: err.Error(),
-			Name:    ru.Name(),
+			Nested:             err,
+			Reason:             "UnknownError",
+			Message:            err.Error(),
+			Name:               ru.Name(),
+			NonBlockingWarning: true,
 		}
 	}
 	for _, recommended := range clusterVersion.Status.AvailableUpdates {
@@ -61,7 +62,8 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 							Reason: condition.Reason,
 							Message: fmt.Sprintf("Update from %s to %s is not recommended:\n\n%s",
 								clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion, condition.Message),
-							Name: ru.Name(),
+							Name:               ru.Name(),
+							NonBlockingWarning: true,
 						}
 					default:
 						return &precondition.Error{
@@ -69,7 +71,8 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 							Message: fmt.Sprintf("Update from %s to %s is %s=%s: %s: %s",
 								clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion,
 								condition.Type, condition.Status, condition.Reason, condition.Message),
-							Name: ru.Name(),
+							Name:               ru.Name(),
+							NonBlockingWarning: true,
 						}
 					}
 				}
@@ -78,7 +81,8 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 				Reason: "UnknownConditionType",
 				Message: fmt.Sprintf("Update from %s to %s has a status.conditionalUpdates entry, but no Recommended condition.",
 					clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion),
-				Name: ru.Name(),
+				Name:               ru.Name(),
+				NonBlockingWarning: true,
 			}
 		}
 	}
@@ -88,13 +92,13 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 			Reason: "NoChannel",
 			Message: fmt.Sprintf("Configured channel is unset, so the recommended status of updating from %s to %s is unknown.",
 				clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion),
-			Name: ru.Name(),
+			Name:               ru.Name(),
+			NonBlockingWarning: true,
 		}
 	}
 
 	reason := "UnknownUpdate"
 	msg := ""
-
 	if retrieved := resourcemerge.FindOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.RetrievedUpdates); retrieved == nil {
 		msg = fmt.Sprintf("No %s, so the recommended status of updating from %s to %s is unknown.", configv1.RetrievedUpdates,
 			clusterVersion.Status.Desired.Version, releaseContext.DesiredVersion)
@@ -108,9 +112,10 @@ func (ru *RecommendedUpdate) Run(ctx context.Context, releaseContext preconditio
 
 	if msg != "" {
 		return &precondition.Error{
-			Reason:  reason,
-			Message: msg,
-			Name:    ru.Name(),
+			Reason:             reason,
+			Message:            msg,
+			Name:               ru.Name(),
+			NonBlockingWarning: true,
 		}
 	}
 	return nil

--- a/pkg/payload/precondition/precondition_test.go
+++ b/pkg/payload/precondition/precondition_test.go
@@ -21,7 +21,7 @@ func TestSummarize(t *testing.T) {
 	}, {
 		name:          "unrecognized error type",
 		errors:        []error{fmt.Errorf("random error")},
-		expectedBlock: true,
+		expectedBlock: false,
 		expectedError: "random error",
 	}, {
 		name:          "forced unrecognized error type",
@@ -42,7 +42,7 @@ func TestSummarize(t *testing.T) {
 	}, {
 		name:          "two unrecognized error types",
 		errors:        []error{fmt.Errorf("random error"), fmt.Errorf("random error 2")},
-		expectedBlock: true,
+		expectedBlock: false,
 		expectedError: `Multiple precondition checks failed:
 * random error
 * random error 2`,


### PR DESCRIPTION
With this change we will not fail precondition checks when a version is not in available updates. So users should be able to upgrade to any version with approriate client side overrides. For example using --allow-explicit-upgrade and --to-imge flags in "oc adm upgrade"

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>