### PR TITLE
resourcemerge: cleanup deprecated function calls

### DIFF
--- a/lib/resourcemerge/apps_test.go
+++ b/lib/resourcemerge/apps_test.go
@@ -107,7 +107,7 @@ func TestEnsureDeployment(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			defaultDeployment(&test.existing, test.existing)
 			defaultDeployment(&test.expected, test.expected)
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			EnsureDeployment(modified, &test.existing, test.required)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
@@ -122,6 +122,6 @@ func TestEnsureDeployment(t *testing.T) {
 
 // Ensures the structure contains any defaults not explicitly set by the test
 func defaultDeployment(in *appsv1.Deployment, from appsv1.Deployment) {
-	modified := pointer.BoolPtr(false)
+	modified := pointer.Bool(false)
 	EnsureDeployment(modified, in, from)
 }

--- a/lib/resourcemerge/batch_test.go
+++ b/lib/resourcemerge/batch_test.go
@@ -6,7 +6,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/pointer"
+	"k8s.io/utils/pointer"
 )
 
 func TestEnsureJob(t *testing.T) {
@@ -24,40 +24,40 @@ func TestEnsureJob(t *testing.T) {
 			name: "different backofflimit count",
 			existing: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(2)}},
+					BackoffLimit: pointer.Int32(2)}},
 			required: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(3)}},
+					BackoffLimit: pointer.Int32(3)}},
 
 			expectedModified: true,
 			expected: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(3)}},
+					BackoffLimit: pointer.Int32(3)}},
 		},
 		{
 			name: "same backofflimit count",
 			existing: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(2)}},
+					BackoffLimit: pointer.Int32(2)}},
 			required: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(2)}},
+					BackoffLimit: pointer.Int32(2)}},
 
 			expectedModified: false,
 			expected: batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32Ptr(2)}},
+					BackoffLimit: pointer.Int32(2)}},
 		},
 		{
 			name: "required-Selector not nil",
 			existing: batchv1.Job{
 				Spec: batchv1.JobSpec{
 					Selector:       &labelSelector,
-					ManualSelector: pointer.BoolPtr(false)}},
+					ManualSelector: pointer.Bool(false)}},
 			required: batchv1.Job{
 				Spec: batchv1.JobSpec{
 					Selector:       &labelSelector,
-					ManualSelector: pointer.BoolPtr(true)}},
+					ManualSelector: pointer.Bool(true)}},
 
 			expectedPanic: true,
 		},
@@ -79,7 +79,7 @@ func TestEnsureJob(t *testing.T) {
 			}()
 			defaultJob(&test.existing, test.existing)
 			defaultJob(&test.expected, test.expected)
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			EnsureJob(modified, &test.existing, test.required)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
@@ -94,6 +94,6 @@ func TestEnsureJob(t *testing.T) {
 
 // Ensures the structure contains any defaults not explicitly set by the test
 func defaultJob(in *batchv1.Job, from batchv1.Job) {
-	modified := pointer.BoolPtr(false)
+	modified := pointer.Bool(false)
 	EnsureJob(modified, in, from)
 }

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -3,12 +3,12 @@ package resourcemerge
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/utils/pointer"
 )
 
@@ -832,10 +832,10 @@ func TestEnsurePodSpec(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			defaultPodSpec(&test.existing, test.existing)
 			defaultPodSpec(&test.expected, test.expected)
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			ensurePodSpec(modified, &test.existing, test.input)
 
-			// This has to be done again to get defaults set on structures that didn't exixt before
+			// This has to be done again to get defaults set on structures that didn't exist before
 			// running ensurePodSpec (e.g. ContainerPort)
 			defaultPodSpec(&test.existing, test.existing)
 
@@ -844,7 +844,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			}
 
 			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
-				t.Errorf("unexpected: %s", diff.ObjectReflectDiff(test.expected, test.existing))
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
 			}
 		})
 	}
@@ -1281,14 +1281,14 @@ func TestEnsureServicePorts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			EnsureServicePorts(modified, &test.existing.Spec.Ports, test.input.Spec.Ports)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
 			}
 
 			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
-				t.Errorf("unexpected: %s", diff.ObjectReflectDiff(test.expected, test.existing))
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
 			}
 		})
 	}
@@ -1391,7 +1391,7 @@ func TestEnsureServiceType(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			EnsureServiceType(modified, &test.existing.Spec.Type, test.input.Spec.Type)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
@@ -1498,17 +1498,17 @@ func TestEnsureTolerations(t *testing.T) {
 				Key:               "node.kubernetes.io/not-ready",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}, {
 				Key:               "node.kubernetes.io/unreachable",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}, {
 				Key:               "node.kubernetes.io/not-ready",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}},
 			input: []corev1.Toleration{{
 				Key:      "node-role.kubernetes.io/master",
@@ -1530,12 +1530,12 @@ func TestEnsureTolerations(t *testing.T) {
 				Key:               "node.kubernetes.io/unreachable",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}, {
 				Key:               "node.kubernetes.io/not-ready",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}},
 			expectedModified: true,
 			expected: []corev1.Toleration{{
@@ -1554,12 +1554,12 @@ func TestEnsureTolerations(t *testing.T) {
 				Key:               "node.kubernetes.io/not-ready",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}, {
 				Key:               "node.kubernetes.io/unreachable",
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: pointer.Int64Ptr(120),
+				TolerationSeconds: pointer.Int64(120),
 			}, {
 				Key:      "node.kubernetes.io/not-ready",
 				Operator: corev1.TolerationOpExists,
@@ -1569,13 +1569,13 @@ func TestEnsureTolerations(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			ensureTolerations(modified, &test.existing, test.input)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
 			}
 			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
-				t.Errorf("unexpected: %s", diff.ObjectReflectDiff(test.expected, test.existing))
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
 			}
 		})
 	}
@@ -1612,7 +1612,7 @@ func TestEnsureEnvVar(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 
 			ensureEnvVar(modified, &test.existing, test.input)
 			if *modified != test.expectedModified {
@@ -1624,7 +1624,7 @@ func TestEnsureEnvVar(t *testing.T) {
 
 // Ensures the structure contains any defaults not explicitly set by the test
 func defaultPodSpec(in *corev1.PodSpec, from corev1.PodSpec) {
-	modified := pointer.BoolPtr(false)
+	modified := pointer.Bool(false)
 	ensurePodSpec(modified, in, from)
 }
 

--- a/lib/resourcemerge/meta_test.go
+++ b/lib/resourcemerge/meta_test.go
@@ -76,35 +76,35 @@ func TestMergeOwnerRefs(t *testing.T) {
 			UID: types.UID("uid-1"),
 		}},
 		input: []metav1.OwnerReference{{
-			Controller: pointer.BoolPtr(true),
+			Controller: pointer.Bool(true),
 			UID:        types.UID("uid-1"),
 		}},
 
 		expectedModified: true,
 		expected: []metav1.OwnerReference{{
-			Controller: pointer.BoolPtr(true),
+			Controller: pointer.Bool(true),
 			UID:        types.UID("uid-1"),
 		}},
 	}, {
 		existing: []metav1.OwnerReference{{
-			Controller: pointer.BoolPtr(false),
+			Controller: pointer.Bool(false),
 			UID:        types.UID("uid-1"),
 		}},
 		input: []metav1.OwnerReference{{
-			Controller: pointer.BoolPtr(true),
+			Controller: pointer.Bool(true),
 			UID:        types.UID("uid-1"),
 		}},
 
 		expectedModified: true,
 		expected: []metav1.OwnerReference{{
-			Controller: pointer.BoolPtr(true),
+			Controller: pointer.Bool(true),
 			UID:        types.UID("uid-1"),
 		}},
 	}}
 
 	for idx, test := range tests {
 		t.Run(fmt.Sprintf("test#%d", idx), func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			mergeOwnerRefs(modified, &test.existing, test.input)
 			if *modified != test.expectedModified {
 				t.Fatalf("mismatch modified got: %v want: %v", *modified, test.expectedModified)

--- a/lib/resourcemerge/rbac_test.go
+++ b/lib/resourcemerge/rbac_test.go
@@ -3,13 +3,13 @@ package resourcemerge
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/utils/pointer"
 )
 
-func TestEnsureClusterRoleBindingsv1(t *testing.T) {
+func TestEnsureClusterRole2Bindingsv1(t *testing.T) {
 	tests := []struct {
 		name     string
 		existing rbacv1.ClusterRoleBinding
@@ -264,14 +264,14 @@ func TestEnsureClusterRoleBindingsv1(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			modified := pointer.BoolPtr(false)
+			modified := pointer.Bool(false)
 			EnsureClusterRoleBinding(modified, &test.existing, test.input)
 			if *modified != test.expectedModified {
 				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
 			}
 
 			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
-				t.Errorf("unexpected: %s", diff.ObjectReflectDiff(test.expected, test.existing))
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
 			}
 		})
 	}


### PR DESCRIPTION
These warnings are annoying for anyone new (like me) who opens the codebase in GoLand, and prevent new code from being efficiently checked while writing.

- `pointer.BoolPtr` -> `pointer.Bool`
- `pointer.Int*Ptr` -> `pointer.Int*`
- `diff.ObjectReflectDiff` -> `cmp.Diff`