### PR TITLE
OCPBUGS-1458: PR to reproduce network blips without polling

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -112,13 +112,6 @@ func ensureContainer(modified *bool, existing *corev1.Container, required corev1
 
 func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.EnvVar) {
 	for envidx := range required {
-		// Currently only CVO deployment uses this variable to inject internal LB host.
-		// This may result in an IP address being returned by API so assuming the
-		// returned value is correct.
-		if required[envidx].Name == "KUBERNETES_SERVICE_HOST" {
-			ensureEnvVarKubeService(*existing, &required[envidx])
-		}
-
 		if required[envidx].ValueFrom != nil {
 			ensureEnvVarSourceFieldRefDefault(required[envidx].ValueFrom.FieldRef)
 		}
@@ -126,14 +119,6 @@ func ensureEnvVar(modified *bool, existing *[]corev1.EnvVar, required []corev1.E
 	if !equality.Semantic.DeepEqual(required, *existing) {
 		*existing = required
 		*modified = true
-	}
-}
-
-func ensureEnvVarKubeService(existing []corev1.EnvVar, required *corev1.EnvVar) {
-	for envidx := range existing {
-		if existing[envidx].Name == required.Name {
-			required.Value = existing[envidx].Value
-		}
 	}
 }
 

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -1640,6 +1640,26 @@ func TestEnsureEnvVar(t *testing.T) {
 			},
 			expectedModified: false,
 		},
+		{
+			name: "CVO can inject LB into ENVVAR",
+			existing: []corev1.EnvVar{
+				{Name: "ENVVAR", Value: "127.0.0.1"},
+			},
+			input: []corev1.EnvVar{
+				{Name: "ENVVAR", Value: "api-int.ci-ln-vqs15yk-72292.gcp-2.ci.openshift.org"},
+			},
+			expectedModified: true,
+		},
+		{
+			name: "CVO can inject LB into KUBERNETES_SERVICE_HOST",
+			existing: []corev1.EnvVar{
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "127.0.0.1"},
+			},
+			input: []corev1.EnvVar{
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "api-int.ci-ln-vqs15yk-72292.gcp-2.ci.openshift.org"},
+			},
+			expectedModified: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -233,6 +233,7 @@ func Bool(b bool) *bool {
 }
 
 // BoolPtr is a function variable referring to Bool.
+//
 // Deprecated: Use Bool instead.
 var BoolPtr = Bool // for back-compat
 


### PR DESCRIPTION
This PR is only useful for me to reproduce installation-time network blips with cluster-bot
