### PR TITLE
OCPBUGS-702: Fix removing `caBundle` field of CRDs when `...inject-cabundle=true`

### DIFF
--- a/lib/resourcemerge/apiext.go
+++ b/lib/resourcemerge/apiext.go
@@ -12,18 +12,45 @@ import (
 // modified is set to true when existing had to be updated with required.
 func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextv1.CustomResourceDefinition, required apiextv1.CustomResourceDefinition) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	ensureCustomResourceDefinitionV1Defaults(&required)
+	ensureCustomResourceDefinitionV1CaBundle(&required, *existing)
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}
 
-	// apply defaults to blue print
+func ensureCustomResourceDefinitionV1Defaults(required *apiextv1.CustomResourceDefinition) {
 	if len(required.Spec.Names.Singular) == 0 {
 		required.Spec.Names.Singular = strings.ToLower(required.Spec.Names.Kind)
 	}
 	if len(required.Spec.Names.ListKind) == 0 {
 		required.Spec.Names.ListKind = required.Spec.Names.Kind + "List"
 	}
+}
 
-	// we stomp everything
-	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
-		*modified = true
-		existing.Spec = required.Spec
+// ensureCustomResourceDefinitionV1CaBundle ensures that the field
+// spec.Conversion.Webhook.ClientConfig.CABundle of a CRD is not managed by the CVO when
+// the service-ca controller is responsible for the field.
+func ensureCustomResourceDefinitionV1CaBundle(required *apiextv1.CustomResourceDefinition, existing apiextv1.CustomResourceDefinition) {
+	if val, ok := existing.ObjectMeta.Annotations[injectCABundleAnnotation]; !ok || val != "true" {
+		return
+	}
+	req := required.Spec.Conversion
+	if req == nil ||
+		req.Webhook == nil ||
+		req.Webhook.ClientConfig == nil {
+		return
+	}
+	if req.Strategy != apiextv1.WebhookConverter {
+		// The service CA bundle is only injected by the service-ca controller into
+		// the CRD if the CRD is configured to use a webhook for conversion
+		return
+	}
+	exc := existing.Spec.Conversion
+	if exc != nil &&
+		exc.Webhook != nil &&
+		exc.Webhook.ClientConfig != nil {
+		req.Webhook.ClientConfig.CABundle = exc.Webhook.ClientConfig.CABundle
 	}
 }

--- a/lib/resourcemerge/apiext_test.go
+++ b/lib/resourcemerge/apiext_test.go
@@ -1,0 +1,191 @@
+package resourcemerge
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestEnsureCustomResourceDefinitionV1(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing apiextv1.CustomResourceDefinition
+		required apiextv1.CustomResourceDefinition
+
+		expectedModified bool
+		expected         apiextv1.CustomResourceDefinition
+	}{
+		{
+			name: "respect injected caBundle when the annotation `...inject-cabundle=true` is set",
+			existing: apiextv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: []byte("CA bundle added by the ca operator"),
+							},
+						},
+					},
+				},
+			},
+			required: apiextv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: nil,
+							},
+						},
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: apiextv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: []byte("CA bundle added by the ca operator"),
+							},
+						},
+					},
+				}},
+		},
+		{
+			name: "respect injected caBundle when the annotation `...inject-cabundle=true` is set by the user",
+			existing: apiextv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: []byte("CA bundle added by the ca operator"),
+							},
+						},
+					},
+				},
+			},
+			required: apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: nil,
+							},
+						},
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: apiextv1.CustomResourceDefinition{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: []byte("CA bundle added by the ca operator"),
+							},
+						},
+					},
+				}},
+		},
+		{
+			name: "remove injected caBundle when the annotation `...inject-cabundle=true` is not set",
+			existing: apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: []byte("CA bundle added by the user"),
+							},
+						},
+					},
+				},
+			},
+			required: apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: nil,
+							},
+						},
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Conversion: &apiextv1.CustomResourceConversion{
+						Strategy: apiextv1.WebhookConverter,
+						Webhook: &apiextv1.WebhookConversion{
+							ClientConfig: &apiextv1.WebhookClientConfig{
+								CABundle: nil,
+							},
+						},
+					},
+				}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defaultCustomResourceDefinitionV1(&test.existing, test.existing)
+			defaultCustomResourceDefinitionV1(&test.expected, test.expected)
+			modified := pointer.Bool(false)
+			EnsureCustomResourceDefinitionV1(modified, &test.existing, test.required)
+			if *modified != test.expectedModified {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
+			}
+
+			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
+			}
+		})
+	}
+}
+
+// Ensures the structure contains any defaults not explicitly set by the test
+func defaultCustomResourceDefinitionV1(in *apiextv1.CustomResourceDefinition, from apiextv1.CustomResourceDefinition) {
+	modified := pointer.Bool(false)
+	EnsureCustomResourceDefinitionV1(modified, in, from)
+}

--- a/lib/resourcemerge/helper.go
+++ b/lib/resourcemerge/helper.go
@@ -1,0 +1,5 @@
+package resourcemerge
+
+// injectCABundleAnnotation is the annotation used to indicate into which resources
+// the service-ca controller should inject the CA bundle.
+const injectCABundleAnnotation = "service.beta.openshift.io/inject-cabundle"


### PR DESCRIPTION
This pull request will fix CVO's behavior of removing the `caBundle` field of CRDs when reconciling manifests.

This pull request references the bug OCPBUGS-702 [1].

---

*   lib/resourcemerge: Fix removing `caBundle` field of CRDs when `...inject-cabundle=true`

Currently, the users can omit the `caBundle` field in the CRDs and set the `service.beta.openshift.io/inject-cabundle=true` annotation so that the given `caBundle` field is managed by the `service-ca` controller (this functionality is not limited only to CRDs) [2].

However, the CVO is not aware of this feature. CVO, when reconciling such CRD, sees an empty `caBundle` field in the given release manifest, and CVO then removes any value in the existing applied CRD so it matches the release manifest semantically.

This commit makes the CVO look into the existing resource and check for the `service.beta.openshift.io/inject-cabundle=true` annotation. If it's set then the `service-ca` controller is responsible for the field, and CVO will ignore any differences between the existing `caBundle` field and the `caBundle` field in the given release manifest of the CRD.

This bug also caused the CVO to hotloop on CRDs as mentioned in the bug [3].

---

*   lib/resourceapply/apiext.go: Improve diff logging for CRDs

This pull request also improves the logging of handling the CRDs. Previously, the logged `diff` wasn't helpful and it didn't show the reason why the update of the resource happened. Now, CVO logs the different fields that caused the update. This change is similar to the change in the commit [4].

---

[1] https://issues.redhat.com/browse/OCPBUGS-702
[2] https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2089097
[4] https://github.com/openshift/cluster-version-operator/commit/c58385eea897b5af790e4dd36103e978e7e4c597