### PR TITLE
Build CVO from UBI8 instead of obsolete `origin-v4.0:base`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
-FROM registry.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/ocp/ubi:8
 COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/


### PR DESCRIPTION
I think the bare `Dockerfile` only supports developer usecases (https://github.com/openshift/cluster-version-operator/pull/871), we build the product with `Dockerfile.rhel`. We should use the modern base images even for this scenario.

I have considered using upstream registry.access.redhat.com pullspec (https://catalog.redhat.com/software/containers/ubi8/5c647760bed8bd28d0e38f9f?container-tabs=gti) which should also allow unauthenticated access, but we use registry.ci.openshift.org in the first `FROM` anyway, and UBI images are periodically mirrored to registry.ci.openshift.org so we get the same stuff.