### PR TITLE
tests: fix rare nil dereference in `TestCache`

### DIFF
--- a/pkg/clusterconditions/mock/mock.go
+++ b/pkg/clusterconditions/mock/mock.go
@@ -28,7 +28,7 @@ type Call struct {
 	Method string
 
 	// Condition records the condition configuration passed to the method call.
-	Condition configv1.ClusterCondition
+	Condition *configv1.ClusterCondition
 }
 
 // Mock implements a cluster condition with mock responses.
@@ -48,7 +48,7 @@ func (m *Mock) Valid(ctx context.Context, condition *configv1.ClusterCondition) 
 	m.Calls = append(m.Calls, Call{
 		When:      time.Now(),
 		Method:    "Valid",
-		Condition: *condition,
+		Condition: condition.DeepCopy(),
 	})
 
 	if len(m.ValidQueue) == 0 {
@@ -65,7 +65,7 @@ func (m *Mock) Match(ctx context.Context, condition *configv1.ClusterCondition) 
 	m.Calls = append(m.Calls, Call{
 		When:      time.Now(),
 		Method:    "Match",
-		Condition: *condition,
+		Condition: condition.DeepCopy(),
 	})
 
 	if len(m.MatchQueue) == 0 {

--- a/pkg/clusterconditions/mock/mock_test.go
+++ b/pkg/clusterconditions/mock/mock_test.go
@@ -3,7 +3,6 @@ package mock_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
@@ -16,44 +15,57 @@ import (
 
 func TestMock(t *testing.T) {
 	ctx := context.Background()
-	m := &mock.Mock{
-		ValidQueue: []error{nil, errors.New("error a"), errors.New("error b")},
-		MatchQueue: []mock.MatchResult{
-			{
-				Match: true,
-				Error: nil,
-			},
-			{
-				Match: false,
-				Error: errors.New("error c"),
-			},
-			{
-				Match: false,
-				Error: nil,
-			},
+	m := &mock.Mock{}
+
+	validTestCases := []struct {
+		condition     *configv1.ClusterCondition
+		pushErrors    []error
+		expectedError *regexp.Regexp
+	}{
+		{
+			condition:  nil,
+			pushErrors: []error{nil},
+		},
+		{
+			condition:  &configv1.ClusterCondition{Type: "Valid() call 1"},
+			pushErrors: []error{nil},
+		},
+		{
+			condition:     &configv1.ClusterCondition{Type: "Valid() call 2"},
+			pushErrors:    []error{errors.New("error a")},
+			expectedError: regexp.MustCompile("^error a$"),
+		},
+		{
+			condition:     &configv1.ClusterCondition{Type: "Valid() call 3"},
+			pushErrors:    []error{errors.New("error b")},
+			expectedError: regexp.MustCompile("^error b$"),
+		},
+		{
+			condition:     &configv1.ClusterCondition{Type: "Valid() Call with empty queue"},
+			expectedError: regexp.MustCompile("^the mock's ValidQueue stack is empty$"),
 		},
 	}
 
-	for i, expectedError := range []*regexp.Regexp{
-		nil,
-		regexp.MustCompile("^error a$"),
-		regexp.MustCompile("^error b$"),
-		regexp.MustCompile("^the mock's ValidQueue stack is empty$"),
-	} {
-		name := fmt.Sprintf("Valid call %d", i)
-		t.Run(name, func(t *testing.T) {
-			condition := configv1.ClusterCondition{Type: name}
+	for i := range validTestCases {
+		m.ValidQueue = append(m.ValidQueue, validTestCases[i].pushErrors...)
+	}
 
+	for _, testCase := range validTestCases {
+		name := "nil condition"
+		if testCase.condition != nil {
+			name = testCase.condition.Type
+		}
+		t.Run(name, func(t *testing.T) {
 			before := time.Now()
-			err := m.Valid(ctx, &condition)
+			err := m.Valid(ctx, testCase.condition)
 			after := time.Now()
 
-			if err != nil && expectedError == nil {
+			if err != nil && testCase.expectedError == nil {
 				t.Errorf("unexpected error: %v", err)
-			} else if expectedError != nil && err == nil {
-				t.Errorf("unexpected success, expected: %s", expectedError)
-			} else if expectedError != nil && !expectedError.MatchString(err.Error()) {
-				t.Errorf("expected error %s, not: %v", expectedError, err)
+			} else if testCase.expectedError != nil && err == nil {
+				t.Errorf("unexpected success, expected: %s", testCase.expectedError)
+			} else if testCase.expectedError != nil && !testCase.expectedError.MatchString(err.Error()) {
+				t.Errorf("expected error %s, not: %v", testCase.expectedError, err)
 			}
 
 			if len(m.Calls) == 0 {
@@ -68,39 +80,58 @@ func TestMock(t *testing.T) {
 			if logged.Method != "Valid" {
 				t.Errorf("logged method %q but expected Valid", logged.Method)
 			}
-			if !reflect.DeepEqual(logged.Condition, condition) {
-				t.Errorf("logged condition %v but expected %v", logged.Condition, condition)
+			if !reflect.DeepEqual(logged.Condition, testCase.condition) {
+				t.Errorf("logged condition %v but expected %v", logged.Condition, testCase.condition)
 			}
 		})
 	}
 
-	for i, testCase := range []struct {
+	matchTestCases := []struct {
+		condition     *configv1.ClusterCondition
+		pushMatches   []mock.MatchResult
 		expectedMatch bool
 		expectedError *regexp.Regexp
 	}{
 		{
+			condition:     nil,
+			pushMatches:   []mock.MatchResult{{Match: true, Error: nil}},
 			expectedMatch: true,
-			expectedError: nil,
 		},
 		{
+			condition:     &configv1.ClusterCondition{Type: "Match() call 1"},
+			pushMatches:   []mock.MatchResult{{Match: true, Error: nil}},
+			expectedMatch: true,
+		},
+		{
+			condition:     &configv1.ClusterCondition{Type: "Match() call 2"},
+			pushMatches:   []mock.MatchResult{{Match: false, Error: errors.New("error c")}},
 			expectedMatch: false,
 			expectedError: regexp.MustCompile("^error c$"),
 		},
 		{
+			condition:     &configv1.ClusterCondition{Type: "Match() call 3"},
+			pushMatches:   []mock.MatchResult{{Match: false, Error: nil}},
 			expectedMatch: false,
-			expectedError: nil,
 		},
 		{
+			condition:     &configv1.ClusterCondition{Type: "Match() call with empty MatchQueue"},
 			expectedMatch: false,
 			expectedError: regexp.MustCompile("^the mock's MatchQueue stack is empty$"),
 		},
-	} {
-		name := fmt.Sprintf("Match call %d", i)
+	}
+	for i := range matchTestCases {
+		m.MatchQueue = append(m.MatchQueue, matchTestCases[i].pushMatches...)
+	}
+
+	for _, testCase := range matchTestCases {
+		name := "nil condition"
+		if testCase.condition != nil {
+			name = testCase.condition.Type
+		}
 		t.Run(name, func(t *testing.T) {
-			condition := configv1.ClusterCondition{Type: name}
 
 			before := time.Now()
-			match, err := m.Match(ctx, &condition)
+			match, err := m.Match(ctx, testCase.condition)
 			after := time.Now()
 
 			if match != testCase.expectedMatch {
@@ -126,8 +157,8 @@ func TestMock(t *testing.T) {
 			if logged.Method != "Match" {
 				t.Errorf("logged method %q but expected Match", logged.Method)
 			}
-			if !reflect.DeepEqual(logged.Condition, condition) {
-				t.Errorf("logged condition %v but expected %v", logged.Condition, condition)
+			if !reflect.DeepEqual(logged.Condition, testCase.condition) {
+				t.Errorf("logged condition %v but expected %v", logged.Condition, testCase.condition)
 			}
 		})
 	}


### PR DESCRIPTION
Looking at [`Cache.Match()`](https://github.com/openshift/cluster-version-operator/blob/master/pkg/clusterconditions/cache/cache.go#L63-L148) implementation, the `c.Condition.Match()` on [L133](https://github.com/openshift/cluster-version-operator/blob/master/pkg/clusterconditions/cache/cache.go#L133) can be called with `targetCondition=nil` and that seems to be intentional. In tests, `c.Condition` is a mock, which did not expect that pointer to be `nil` and dereferenced it, resulting in an occassional panic in tests like https://github.com/openshift/cluster-version-operator/pull/871#issuecomment-1348927131. The fix stores the full pointer (its deepcopy to avoid sharing that memory) in the mock instead.

I needed to restructure the tests a little to allow adding a nil parameter testcase
