### PR TITLE
OCPBUGS-4986: pkg/payload/precondition: Do not claim warnings would have blocked

### DIFF
--- a/pkg/payload/precondition/precondition.go
+++ b/pkg/payload/precondition/precondition.go
@@ -81,6 +81,7 @@ func Summarize(errs []error, force bool) (bool, error) {
 			}
 			continue
 		}
+		isWarning = false
 		msgs = append(msgs, e.Error())
 
 	}
@@ -91,7 +92,7 @@ func Summarize(errs []error, force bool) (bool, error) {
 		msg = fmt.Sprintf("Multiple precondition checks failed:\n* %s", strings.Join(msgs, "\n* "))
 	}
 
-	if force {
+	if force && !isWarning {
 		msg = fmt.Sprintf("Forced through blocking failures: %s", msg)
 		isWarning = true
 	}

--- a/pkg/payload/precondition/precondition_test.go
+++ b/pkg/payload/precondition/precondition_test.go
@@ -21,7 +21,7 @@ func TestSummarize(t *testing.T) {
 	}, {
 		name:          "unrecognized error type",
 		errors:        []error{fmt.Errorf("random error")},
-		expectedBlock: false,
+		expectedBlock: true,
 		expectedError: "random error",
 	}, {
 		name:          "forced unrecognized error type",
@@ -29,6 +29,28 @@ func TestSummarize(t *testing.T) {
 		force:         true,
 		expectedBlock: false,
 		expectedError: "Forced through blocking failures: random error",
+	}, {
+		name: "unforced warning",
+		errors: []error{&Error{
+			Nested:             nil,
+			Reason:             "UnknownUpdate",
+			Message:            "update from A to B is probably neither recommended nor supported.",
+			NonBlockingWarning: true,
+			Name:               "ClusterVersionRecommendedUpdate",
+		}},
+		expectedBlock: false,
+		expectedError: `Precondition "ClusterVersionRecommendedUpdate" failed because of "UnknownUpdate": update from A to B is probably neither recommended nor supported.`,
+	}, {
+		name: "forced through warning",
+		errors: []error{&Error{
+			Nested:             nil,
+			Reason:             "UnknownUpdate",
+			Message:            "update from A to B is probably neither recommended nor supported.",
+			NonBlockingWarning: true,
+			Name:               "ClusterVersionRecommendedUpdate",
+		}},
+		force:         true,
+		expectedError: `Precondition "ClusterVersionRecommendedUpdate" failed because of "UnknownUpdate": update from A to B is probably neither recommended nor supported.`,
 	}, {
 		name: "single feature-gate error",
 		errors: []error{&Error{
@@ -42,7 +64,7 @@ func TestSummarize(t *testing.T) {
 	}, {
 		name:          "two unrecognized error types",
 		errors:        []error{fmt.Errorf("random error"), fmt.Errorf("random error 2")},
-		expectedBlock: false,
+		expectedBlock: true,
 		expectedError: `Multiple precondition checks failed:
 * random error
 * random error 2`,


### PR DESCRIPTION
Avoid errors like:

```console
$ oc get -o json clusterversion version | jq -r '.status.history[0].acceptedRisks'
Forced through blocking failures: Precondition "ClusterVersionRecommendedUpdate" failed because of "UnknownUpdate": RetrievedUpdates=True (), so the update from 4.13.0-0.okd-2022-12-11-064650 to 4.13.0-0.okd-2022-12-13-052859 is probably neither recommended nor supported.
```

Instead, tweak the logic from 481bcde393 (#856), and only append the `Forced through blocking failures:` prefix when the forcing was required.