### PR TITLE
pkg/payload: code cleanups

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -160,7 +159,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 	var manifests []manifest.Manifest
 	var errs []error
 	for _, task := range tasks {
-		files, err := ioutil.ReadDir(task.idir)
+		files, err := os.ReadDir(task.idir)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +180,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 				continue
 			}
 
-			raw, err := ioutil.ReadFile(p)
+			raw, err := os.ReadFile(p)
 			if err != nil {
 				errs = append(errs, err)
 				continue
@@ -361,7 +360,7 @@ func getPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []
 func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return release, "", err
 	}
@@ -424,7 +423,7 @@ func loadReleaseFromMetadata(releaseDir string) (configv1.Release, string, error
 
 func loadImageReferences(releaseDir string) (*imagev1.ImageStream, error) {
 	irf := filepath.Join(releaseDir, imageReferencesFile)
-	imageRefData, err := ioutil.ReadFile(irf)
+	imageRefData, err := os.ReadFile(irf)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -3,10 +3,8 @@ package payload
 import (
 	"errors"
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"testing"
 
@@ -136,9 +134,8 @@ func TestLoadUpdate(t *testing.T) {
 			}
 			// Manifest holds an unexported type of 'resourceID' with a field name of 'id'
 			// DeepEqual fails, so here we use cmp.Diff to ignore just that field to avoid false positives
-			stringDiff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(manifest.Manifest{}, "id"))
-			if !reflect.DeepEqual(got, tt.want) && stringDiff != "" {
-				t.Errorf("loadUpdatePayload() = %s", stringDiff)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(manifest.Manifest{}, "id")); diff != "" {
+				t.Errorf("loadUpdatePayload() = %s", diff)
 			}
 		})
 	}
@@ -211,9 +208,8 @@ func TestLoadUpdateArchitecture(t *testing.T) {
 			}
 			// Manifest holds an unexported type of 'resourceID' with a field name of 'id'
 			// DeepEqual fails, so here we use cmp.Diff to ignore just that field to avoid false positives
-			stringDiff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(manifest.Manifest{}, "id"))
-			if !reflect.DeepEqual(got, tt.want) && stringDiff != "" {
-				t.Errorf("loadUpdatePayload() = %s", stringDiff)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(manifest.Manifest{}, "id")); diff != "" {
+				t.Errorf("loadUpdatePayload() = %s", diff)
 			}
 		})
 	}
@@ -430,7 +426,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 }
 
 func readManifestFiles(path string) ([]manifest.Manifest, error) {
-	readFiles, err := ioutil.ReadDir(path)
+	readFiles, err := os.ReadDir(path)
 
 	// no dir for nil tests
 	if errors.Is(err, os.ErrNotExist) {
@@ -451,7 +447,7 @@ func readManifestFiles(path string) ([]manifest.Manifest, error) {
 }
 
 func mustRead(path string) []byte {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -3,7 +3,6 @@ package payload
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -64,7 +63,7 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, skipFiles s
 	if err := os.MkdirAll(odir, 0666); err != nil {
 		return err
 	}
-	files, err := ioutil.ReadDir(idir)
+	files, err := os.ReadDir(idir)
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, skipFiles s
 		}
 
 		ipath := filepath.Join(idir, file.Name())
-		iraw, err := ioutil.ReadFile(ipath)
+		iraw, err := os.ReadFile(ipath)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -91,7 +90,7 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, skipFiles s
 		}
 
 		opath := filepath.Join(odir, file.Name())
-		if err := ioutil.WriteFile(opath, rraw, 0666); err != nil {
+		if err := os.WriteFile(opath, rraw, 0666); err != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -15,7 +15,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	manifest "github.com/openshift/library-go/pkg/manifest"
+	"github.com/openshift/library-go/pkg/manifest"
 )
 
 var (

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/diff"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/library-go/pkg/manifest"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func Test_TaskGraph_Split(t *testing.T) {
@@ -227,7 +226,7 @@ func TestByNumberAndComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ByNumberAndComponent(tt.tasks); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, got))
+				t.Fatalf("%s", cmp.Diff(tt.want, got))
 			}
 		})
 	}
@@ -339,7 +338,7 @@ func TestShiftOrder(t *testing.T) {
 				return test.tasks
 			}
 			if out := ShiftOrder(fn, test.step, test.stride)(nil); !reflect.DeepEqual(test.want, out) {
-				t.Errorf("%s", diff.ObjectReflectDiff(test.want, out))
+				t.Errorf("%s", cmp.Diff(test.want, out))
 			}
 		})
 	}
@@ -476,7 +475,7 @@ func TestFlattenByNumberAndComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := FlattenByNumberAndComponent(tt.tasks); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, got))
+				t.Fatalf("%s", cmp.Diff(tt.want, got))
 			}
 		})
 	}
@@ -921,7 +920,7 @@ func TestRunGraph(t *testing.T) {
 			})
 			if tt.order != nil {
 				if !reflect.DeepEqual(tt.order, order.items) {
-					t.Fatal(diff.ObjectReflectDiff(tt.order, order.items))
+					t.Fatal(cmp.Diff(tt.order, order.items))
 				}
 			}
 			if tt.invariants != nil {
@@ -931,7 +930,7 @@ func TestRunGraph(t *testing.T) {
 				sort.Strings(tt.want)
 				sort.Strings(order.items)
 				if !reflect.DeepEqual(tt.want, order.items) {
-					t.Fatal(diff.ObjectReflectDiff(tt.want, order.items))
+					t.Fatal(cmp.Diff(tt.want, order.items))
 				}
 			}
 

--- a/pkg/payload/task_test.go
+++ b/pkg/payload/task_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/library-go/pkg/manifest"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestTaskString(t *testing.T) {
@@ -162,7 +162,7 @@ func TestTaskString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.task.String(); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("%s", diff.ObjectReflectDiff(tt.want, got))
+				t.Fatalf("%s", cmp.Diff(tt.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
- remove redundant `DeepEqual` checks (followup to a nit in https://github.com/openshift/cluster-version-operator/pull/860)
- update deprecated `ioutil.*` calls
- replace `ObjectReflectDiff` with `cmp.Diff`