### PR TITLE
TEST: Prolong upgradeable check throttle period to 15m

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -180,7 +180,7 @@ func New(
 		},
 
 		statusInterval:             15 * time.Second,
-		minimumUpdateCheckInterval: minimumInterval,
+		minimumUpdateCheckInterval: 15 * time.Minute,
 		payloadDir:                 overridePayloadDir,
 		defaultUpstreamServer:      "https://api.openshift.com/api/upgrades_info/v1/graph",
 

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -180,7 +180,7 @@ func New(
 		},
 
 		statusInterval:             15 * time.Second,
-		minimumUpdateCheckInterval: 15 * time.Minute,
+		minimumUpdateCheckInterval: minimumInterval,
 		payloadDir:                 overridePayloadDir,
 		defaultUpstreamServer:      "https://api.openshift.com/api/upgrades_info/v1/graph",
 

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -38,7 +38,7 @@ var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 func (optr *Operator) syncUpgradeable() error {
 	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
 	u := optr.getUpgradeable()
-	if u != nil && u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
+	if u != nil && u.RecentlyChanged(time.Minute) {
 		klog.V(2).Infof("Upgradeable conditions were recently checked, will try later.")
 		return nil
 	}


### PR DESCRIPTION
Only do this to see that the upgradeability feature test in E2E suite is sensitive to this. I am expecting the following test to fail in the upgrade-into-change CI job, and also the `azure-sdn-upgrade-4.11-minor` payload job that I can run with `/payload`


```
[bz-Cluster Version Operator] Verify presence of admin ack gate blocks upgrade until acknowledged
```