### PR TITLE
[release-4.11] OCPBUGS-5882: Set upgradeability check throttling period to 2m

### DIFF
--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -29,16 +29,16 @@ import (
 const (
 	adminAckGateFmt             string = "^ack-[4-5][.]([0-9]{1,})-[^-]"
 	upgradeableAdminAckRequired        = configv1.ClusterStatusConditionType("UpgradeableAdminAckRequired")
+	checkThrottlePeriod                = 2 * time.Minute
 )
 
 var adminAckGateRegexp = regexp.MustCompile(adminAckGateFmt)
 
 // syncUpgradeable. The status is only checked if it has been more than
-// the minimumUpdateCheckInterval since the last check.
+// the checkThrottlePeriod since the last check.
 func (optr *Operator) syncUpgradeable() error {
-	// updates are only checked at most once per minimumUpdateCheckInterval or if the generation changes
 	u := optr.getUpgradeable()
-	if u != nil && u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
+	if u != nil && u.RecentlyChanged(checkThrottlePeriod) {
 		klog.V(2).Infof("Upgradeable conditions were recently checked, will try later.")
 		return nil
 	}


### PR DESCRIPTION
Previously, the throttling reused the `minimumUpdateCheckInterval` value
which is derived from the full CVO minimum sync period. This value is
set between 2m and 4m at CVO startup. This period is unecessarily long
and bad for UX, things happen with a delay and our own testcase expects
upgradeability to be propagated in 3 minutes at worst.

Hardcode the throttling to 2m (lower bound of previous behavior) to
prevent flapping on flurries but allow changes to propagate
deterministically faster. We will still get a bit of non-determinisim
from sync periods and requeueing, so this change should not cause any
periodic API-hammering.

This is a partial backport of https://github.com/openshift/cluster-version-operator/pull/882. The `release-4.11` branch does not contain the fast-mode-with-failing-precondition code from https://github.com/openshift/cluster-version-operator/pull/808 so the refactoring commit from https://github.com/openshift/cluster-version-operator/pull/882 is not applicable nor needed.
