### PR TITLE
lib/validation: Drop "a previous version" from desiredUpdate validation

### DIFF
--- a/lib/validation/validation.go
+++ b/lib/validation/validation.go
@@ -41,7 +41,7 @@ func ValidateClusterVersion(config *configv1.ClusterVersion) field.ErrorList {
 			switch countPayloadsForVersion(config, u.Version) {
 			case 0:
 				errs = append(errs, field.Invalid(field.NewPath("spec", "desiredUpdate", "version"), u.Version,
-					"when image is empty the update must be a previous version or an available update"))
+					"when image is empty the update must be an available update"))
 			case 1:
 			default:
 				errs = append(errs, field.Invalid(field.NewPath("spec", "desiredUpdate", "version"), u.Version,

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -1865,7 +1865,7 @@ func TestOperator_sync(t *testing.T) {
 						},
 						ObservedGeneration: 2,
 						Conditions: []configv1.ClusterOperatorStatusCondition{
-							{Type: ClusterVersionInvalid, Status: configv1.ConditionTrue, Reason: "InvalidClusterVersion", Message: "The cluster version is invalid: spec.desiredUpdate.version: Invalid value: \"4.0.4\": when image is empty the update must be a previous version or an available update"},
+							{Type: ClusterVersionInvalid, Status: configv1.ConditionTrue, Reason: "InvalidClusterVersion", Message: "The cluster version is invalid: spec.desiredUpdate.version: Invalid value: \"4.0.4\": when image is empty the update must be an available update"},
 							{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
 							{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 4.0.1"},
 							{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},


### PR DESCRIPTION
Narrowly catching up with c80bd024a8 (#684, [4.10][1]), which removed that option from the implementation.  Having the validation code living so far from the implementation code makes us more vulnerable to this kind of divergence, but I'll leave larger refactorings to follow-up work.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1878925