### PR TITLE
logging: consistently use RFC3339 in log messages

### DIFF
--- a/lib/resourcedelete/helper.go
+++ b/lib/resourcedelete/helper.go
@@ -104,14 +104,14 @@ func GetDeleteProgress(resource Resource, getError error) (bool, error) {
 	if deletionTimes, ok := getDeleteTimes(resource); ok {
 		if !deletionTimes.Verified.IsZero() {
 			if getError == nil || !apierrors.IsNotFound(getError) {
-				klog.Warningf("%s has reappeared after having been deleted at %s.", resource, deletionTimes.Verified)
+				klog.Warningf("%s has reappeared after having been deleted at %s.", resource, deletionTimes.Verified.Format(time.RFC3339))
 			}
 		} else {
 			if apierrors.IsNotFound(getError) {
 				SetDeleteVerified(resource)
 			} else {
 				if deletionTimes.Expected != nil {
-					klog.V(2).Infof("Delete of %s is expected by %s.", resource, deletionTimes.Expected.String())
+					klog.V(2).Infof("Delete of %s is expected by %s.", resource, deletionTimes.Expected.Format(time.RFC3339))
 				} else {
 					klog.V(2).Infof("Delete of %s has already been requested.", resource)
 				}

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -153,7 +153,7 @@ func (ctrl *Controller) handleErr(err error, key interface{}) {
 
 func (ctrl *Controller) sync(ctx context.Context, key string) error {
 	startTime := time.Now()
-	klog.V(2).Infof("Started syncing auto-updates %q (%v)", key, startTime)
+	klog.V(2).Infof("Started syncing auto-updates %q", key)
 	defer func() {
 		klog.V(2).Infof("Finished syncing auto-updates %q (%v)", key, time.Since(startTime))
 	}()

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -49,14 +49,13 @@ func (optr *Operator) syncAvailableUpdates(ctx context.Context, config *configv1
 	if u == nil {
 		klog.V(2).Info("First attempt to retrieve available updates")
 	} else if !u.RecentlyChanged(optr.minimumUpdateCheckInterval) {
-		klog.V(2).Infof("Retrieving available updates again, because more than %s has elapsed since %s", optr.minimumUpdateCheckInterval, u.LastAttempt)
+		klog.V(2).Infof("Retrieving available updates again, because more than %s has elapsed since %s", optr.minimumUpdateCheckInterval, u.LastAttempt.Format(time.RFC3339))
 	} else if channel != u.Channel {
 		klog.V(2).Infof("Retrieving available updates again, because the channel has changed from %q to %q", u.Channel, channel)
 	} else if desiredArch != u.Architecture {
-		klog.V(2).Infof("Retrieving available updates again, because the architecture has changed from %q to %q",
-			u.Architecture, desiredArch)
+		klog.V(2).Infof("Retrieving available updates again, because the architecture has changed from %q to %q", u.Architecture, desiredArch)
 	} else if upstream == u.Upstream || (upstream == optr.defaultUpstreamServer && u.Upstream == "") {
-		klog.V(2).Infof("Available updates were recently retrieved, with less than %s elapsed since %s, will try later.", optr.minimumUpdateCheckInterval, u.LastAttempt)
+		klog.V(2).Infof("Available updates were recently retrieved, with less than %s elapsed since %s, will try later.", optr.minimumUpdateCheckInterval, u.LastAttempt.Format(time.RFC3339))
 		return nil
 	} else {
 		klog.V(2).Infof("Retrieving available updates again, because the upstream has changed from %q to %q", u.Upstream, config.Spec.Upstream)

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -567,7 +567,7 @@ func handleErr(ctx context.Context, queue workqueue.RateLimitingInterface, err e
 // It returns an error if it could not update the cluster version object.
 func (optr *Operator) sync(ctx context.Context, key string) error {
 	startTime := time.Now()
-	klog.V(2).Infof("Started syncing cluster version %q, spec changes, status, and payload (%v)", key, startTime)
+	klog.V(2).Infof("Started syncing cluster version %q, spec changes, status, and payload", key)
 	defer func() {
 		klog.V(2).Infof("Finished syncing cluster version %q (%v)", key, time.Since(startTime))
 	}()
@@ -636,7 +636,7 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 // sync available updates. It only modifies cluster version.
 func (optr *Operator) availableUpdatesSync(ctx context.Context, key string) error {
 	startTime := time.Now()
-	klog.V(2).Infof("Started syncing available updates %q (%v)", key, startTime)
+	klog.V(2).Infof("Started syncing available updates %q", key)
 	defer func() {
 		klog.V(2).Infof("Finished syncing available updates %q (%v)", key, time.Since(startTime))
 	}()
@@ -655,7 +655,7 @@ func (optr *Operator) availableUpdatesSync(ctx context.Context, key string) erro
 // sync upgradeableCondition. It only modifies cluster version.
 func (optr *Operator) upgradeableSync(ctx context.Context, key string) error {
 	startTime := time.Now()
-	klog.V(2).Infof("Started syncing upgradeable %q (%v)", key, startTime)
+	klog.V(2).Infof("Started syncing upgradeable %q", key)
 	defer func() {
 		klog.V(2).Infof("Finished syncing upgradeable %q (%v)", key, time.Since(startTime))
 	}()

--- a/pkg/payload/precondition/clusterversion/upgradeable.go
+++ b/pkg/payload/precondition/clusterversion/upgradeable.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
@@ -69,7 +70,7 @@ func (pf *Upgradeable) Run(ctx context.Context, releaseContext precondition.Rele
 		return nil
 	}
 	if up.Status != configv1.ConditionFalse {
-		klog.V(2).Infof("Precondition %s passed: Upgradeable %s since %v: %s: %s", pf.Name(), up.Status, up.LastTransitionTime, up.Reason, up.Message)
+		klog.V(2).Infof("Precondition %s passed: Upgradeable %s since %s: %s: %s", pf.Name(), up.Status, up.LastTransitionTime.Format(time.RFC3339), up.Reason, up.Message)
 		return nil
 	}
 


### PR DESCRIPTION
Replaces the default serialization format `2023-01-18 18:31:06.806926942 +0100 CET m=+18.871775150` with `2023-01-18T16:31:37Z` in log messages.

I do not believe the nanoseconds, monotonic clock reading and timezone have value in log messages. RFC3339 makes logs more concise and better readable.


