### PR TITLE
Bug 2089138: CVO hotloops on ValidatingWebhookConfiguration

### DIFF
--- a/hack/generate-lib-resources.py
+++ b/hack/generate-lib-resources.py
@@ -283,6 +283,7 @@ if __name__ == '__main__':
         'github.com/openshift/api/image/v1': {'ImageStream'}, # for payload loading
         'github.com/openshift/api/security/v1': {'SecurityContextConstraints'},
         'github.com/operator-framework/api/pkg/operators/v1': {'OperatorGroup'},
+        'k8s.io/api/admissionregistration/v1': {'ValidatingWebhookConfiguration'},
         'k8s.io/api/apps/v1': {'DaemonSet', 'Deployment'},
         'k8s.io/api/batch/v1': {'Job'},
         'k8s.io/api/core/v1': {'ConfigMap', 'Namespace', 'Service', 'ServiceAccount'},
@@ -294,6 +295,7 @@ if __name__ == '__main__':
         'github.com/openshift/api/config/v1': {'package': 'github.com/openshift/client-go/config/clientset/versioned/typed/config/v1', 'type': 'ConfigV1Client'},
         'github.com/openshift/api/image/v1': {'package': 'github.com/openshift/client-go/image/clientset/versioned/typed/image/v1', 'type': 'ImageV1Client'},
         'github.com/operator-framework/api/pkg/operators/v1': {'package': 'github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1', 'type': 'OperatorsV1Client'},
+        'k8s.io/api/admissionregistration/v1': {'package': 'k8s.io/client-go/kubernetes/typed/admissionregistration/v1', 'type': 'AdmissionregistrationV1Client'},
         'k8s.io/api/apps/v1': {'package': 'k8s.io/client-go/kubernetes/typed/apps/v1', 'type': 'AppsV1Client'},
         'k8s.io/api/batch/v1': {'package': 'k8s.io/client-go/kubernetes/typed/batch/v1', 'type': 'BatchV1Client'},
         'k8s.io/api/core/v1': {'package': 'k8s.io/client-go/kubernetes/typed/core/v1', 'type': 'CoreV1Client'},

--- a/hack/generate-lib-resources.py
+++ b/hack/generate-lib-resources.py
@@ -282,6 +282,7 @@ if __name__ == '__main__':
     types = {
         'github.com/openshift/api/image/v1': {'ImageStream'}, # for payload loading
         'github.com/openshift/api/security/v1': {'SecurityContextConstraints'},
+        'github.com/operator-framework/api/pkg/operators/v1': {'OperatorGroup'},
         'k8s.io/api/apps/v1': {'DaemonSet', 'Deployment'},
         'k8s.io/api/batch/v1': {'Job'},
         'k8s.io/api/core/v1': {'ConfigMap', 'Namespace', 'Service', 'ServiceAccount'},
@@ -292,6 +293,7 @@ if __name__ == '__main__':
         'github.com/openshift/api/security/v1': {'package': 'github.com/openshift/client-go/security/clientset/versioned/typed/security/v1', 'type': 'SecurityV1Client'},
         'github.com/openshift/api/config/v1': {'package': 'github.com/openshift/client-go/config/clientset/versioned/typed/config/v1', 'type': 'ConfigV1Client'},
         'github.com/openshift/api/image/v1': {'package': 'github.com/openshift/client-go/image/clientset/versioned/typed/image/v1', 'type': 'ImageV1Client'},
+        'github.com/operator-framework/api/pkg/operators/v1': {'package': 'github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/typed/operators/v1', 'type': 'OperatorsV1Client'},
         'k8s.io/api/apps/v1': {'package': 'k8s.io/client-go/kubernetes/typed/apps/v1', 'type': 'AppsV1Client'},
         'k8s.io/api/batch/v1': {'package': 'k8s.io/client-go/kubernetes/typed/batch/v1', 'type': 'BatchV1Client'},
         'k8s.io/api/core/v1': {'package': 'k8s.io/client-go/kubernetes/typed/core/v1', 'type': 'CoreV1Client'},

--- a/lib/resourceapply/admissionregistration.go
+++ b/lib/resourceapply/admissionregistration.go
@@ -1,0 +1,48 @@
+package resourceapply
+
+import (
+	"context"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+)
+
+func ApplyValidatingWebhookConfigurationv1(ctx context.Context, client admissionregclientv1.ValidatingWebhookConfigurationsGetter, required *admissionregv1.ValidatingWebhookConfiguration, reconciling bool) (*admissionregv1.ValidatingWebhookConfiguration, bool, error) {
+	existing, err := client.ValidatingWebhookConfigurations().Get(ctx, required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(2).Infof("ValidatingWebhookConfiguration %s/%s not found, creating", required.Namespace, required.Name)
+		actual, err := client.ValidatingWebhookConfigurations().Create(ctx, required, metav1.CreateOptions{})
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	// if we only create this resource, we have no need to continue further
+	if IsCreateOnly(required) {
+		return nil, false, nil
+	}
+
+	var original admissionregv1.ValidatingWebhookConfiguration
+	existing.DeepCopyInto(&original)
+	modified := pointer.Bool(false)
+	resourcemerge.EnsureValidatingWebhookConfiguration(modified, existing, *required)
+	if !*modified {
+		return existing, false, nil
+	}
+	if reconciling {
+		if diff := cmp.Diff(&original, existing); diff != "" {
+			klog.V(2).Infof("Updating ValidatingWebhookConfiguration %s/%s due to diff: %v", required.Namespace, required.Name, diff)
+		} else {
+			klog.V(2).Infof("Updating ValidatingWebhookConfiguration %s/%s with empty diff: possible hotloop after wrong comparison", required.Namespace, required.Name)
+		}
+	}
+
+	actual, err := client.ValidatingWebhookConfigurations().Update(ctx, existing, metav1.UpdateOptions{})
+	return actual, true, err
+}

--- a/lib/resourcedelete/admissionregistration.go
+++ b/lib/resourcedelete/admissionregistration.go
@@ -1,0 +1,41 @@
+package resourcedelete
+
+import (
+	"context"
+	"fmt"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+)
+
+// DeleteValidatingWebhookConfigurationv1 checks the given resource for a valid delete
+// annotation. If found it checks the status of a previously issued delete request.
+// If delete has not been requested and in UpdatingMode it will issue a delete request.
+func DeleteValidatingWebhookConfigurationv1(ctx context.Context,
+	client admissionregclientv1.ValidatingWebhookConfigurationsGetter,
+	required *admissionregv1.ValidatingWebhookConfiguration,
+	updateMode bool) (bool, error) {
+
+	if delAnnoFound, err := ValidDeleteAnnotation(required.Annotations); !delAnnoFound || err != nil {
+		return delAnnoFound, err
+	}
+	existing, err := client.ValidatingWebhookConfigurations().Get(ctx, required.Name, metav1.GetOptions{})
+	resource := Resource{
+		Kind:      "validatingwebhookconfiguration",
+		Namespace: required.Namespace,
+		Name:      required.Name,
+	}
+	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
+		// Only request deletion when in update mode.
+		if !deleteRequested && updateMode {
+			if err := client.ValidatingWebhookConfigurations().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
+				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+			}
+			SetDeleteRequested(existing, resource)
+		}
+	} else {
+		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+	}
+	return true, nil
+}

--- a/lib/resourcemerge/admissionregistration.go
+++ b/lib/resourcemerge/admissionregistration.go
@@ -1,0 +1,56 @@
+package resourcemerge
+
+import (
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// EnsureValidatingWebhookConfiguration ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureValidatingWebhookConfiguration(modified *bool, existing *admissionregv1.ValidatingWebhookConfiguration, required admissionregv1.ValidatingWebhookConfiguration) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	ensureValidatingWebhookConfigurationDefaults(&required)
+	if !equality.Semantic.DeepEqual(existing.Webhooks, required.Webhooks) {
+		*modified = true
+		existing.Webhooks = required.Webhooks
+	}
+}
+
+func ensureValidatingWebhookConfigurationDefaults(required *admissionregv1.ValidatingWebhookConfiguration) {
+	for i := range required.Webhooks {
+		ensureValidatingWebhookDefaults(&required.Webhooks[i])
+	}
+}
+
+func ensureValidatingWebhookDefaults(required *admissionregv1.ValidatingWebhook) {
+	if required.FailurePolicy == nil {
+		policy := admissionregv1.Fail
+		required.FailurePolicy = &policy
+	}
+	if required.MatchPolicy == nil {
+		policy := admissionregv1.Equivalent
+		required.MatchPolicy = &policy
+	}
+	if required.NamespaceSelector == nil {
+		required.NamespaceSelector = &metav1.LabelSelector{}
+	}
+	if required.ObjectSelector == nil {
+		required.ObjectSelector = &metav1.LabelSelector{}
+	}
+	if required.TimeoutSeconds == nil {
+		required.TimeoutSeconds = pointer.Int32(10)
+	}
+	for i := range required.Rules {
+		ensureRuleWithOperationsDefaults(&required.Rules[i])
+	}
+}
+
+func ensureRuleWithOperationsDefaults(required *admissionregv1.RuleWithOperations) {
+	if required.Scope == nil {
+		scope := admissionregv1.AllScopes
+		required.Scope = &scope
+	}
+}
+

--- a/lib/resourcemerge/admissionregistration_test.go
+++ b/lib/resourcemerge/admissionregistration_test.go
@@ -1,0 +1,460 @@
+package resourcemerge
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestEnsureValidatingWebhookConfiguration(t *testing.T) {
+	defaulting := struct {
+		failurePolicy     admissionregv1.FailurePolicyType
+		matchPolicy       admissionregv1.MatchPolicyType
+		namespaceSelector *metav1.LabelSelector
+		objectSelector    *metav1.LabelSelector
+		timeoutSeconds    *int32
+	}{
+		failurePolicy:     admissionregv1.Fail,
+		matchPolicy:       admissionregv1.Equivalent,
+		namespaceSelector: &metav1.LabelSelector{},
+		objectSelector:    &metav1.LabelSelector{},
+		timeoutSeconds:    pointer.Int32(10),
+	}
+	nonDefaulting := struct {
+		failurePolicy     admissionregv1.FailurePolicyType
+		matchPolicy       admissionregv1.MatchPolicyType
+		namespaceSelector *metav1.LabelSelector
+		objectSelector    *metav1.LabelSelector
+		timeoutSeconds    *int32
+	}{
+		failurePolicy: admissionregv1.Ignore,
+		matchPolicy:   admissionregv1.Exact,
+		namespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "foo",
+			},
+		},
+		objectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "foo",
+			},
+		},
+		timeoutSeconds: pointer.Int32(42),
+	}
+
+	tests := []struct {
+		name     string
+		existing admissionregv1.ValidatingWebhookConfiguration
+		required admissionregv1.ValidatingWebhookConfiguration
+
+		expectedModified bool
+		expected         admissionregv1.ValidatingWebhookConfiguration
+	}{
+		{
+			name: "same failure policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &nonDefaulting.failurePolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &nonDefaulting.failurePolicy,
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &nonDefaulting.failurePolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "different failure policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &defaulting.failurePolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &nonDefaulting.failurePolicy,
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &nonDefaulting.failurePolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "implicit failure policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &defaulting.failurePolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						FailurePolicy: &defaulting.failurePolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "same match policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &nonDefaulting.matchPolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &nonDefaulting.matchPolicy,
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &nonDefaulting.matchPolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "different match policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &defaulting.matchPolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &nonDefaulting.matchPolicy,
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &nonDefaulting.matchPolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "implicit match policy",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &defaulting.matchPolicy,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						MatchPolicy: &defaulting.matchPolicy,
+					},
+				},
+			},
+		},
+		{
+			name: "same namespace selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.namespaceSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.namespaceSelector,
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.namespaceSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "different namespace selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.namespaceSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.namespaceSelector,
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.namespaceSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "implicit namespace selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.namespaceSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.namespaceSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "same object selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.objectSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.objectSelector,
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.objectSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "different object selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.objectSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.objectSelector,
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: nonDefaulting.objectSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "implicit object selector",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.objectSelector,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						NamespaceSelector: defaulting.objectSelector,
+					},
+				},
+			},
+		},
+		{
+			name: "same timeout seconds",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: nonDefaulting.timeoutSeconds,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: nonDefaulting.timeoutSeconds,
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: nonDefaulting.timeoutSeconds,
+					},
+				},
+			},
+		},
+		{
+			name: "different timeout seconds",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: defaulting.timeoutSeconds,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: nonDefaulting.timeoutSeconds,
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: nonDefaulting.timeoutSeconds,
+					},
+				},
+			},
+		},
+		{
+			name: "implicit timeout seconds",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: defaulting.timeoutSeconds,
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						TimeoutSeconds: defaulting.timeoutSeconds,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defaultValidatingWebhookConfiguration(&test.existing, test.existing)
+			defaultValidatingWebhookConfiguration(&test.expected, test.expected)
+			modified := pointer.Bool(false)
+			EnsureValidatingWebhookConfiguration(modified, &test.existing, test.required)
+			if *modified != test.expectedModified {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
+			}
+
+			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
+				t.Errorf("unexpected: %s", cmp.Diff(test.expected, test.existing))
+			}
+		})
+	}
+}
+
+// Ensures the structure contains any defaults not explicitly set by the test
+func defaultValidatingWebhookConfiguration(in *admissionregv1.ValidatingWebhookConfiguration, from admissionregv1.ValidatingWebhookConfiguration) {
+	modified := pointer.Bool(false)
+	EnsureValidatingWebhookConfiguration(modified, in, from)
+}

--- a/lib/resourcemerge/admissionregistration_test.go
+++ b/lib/resourcemerge/admissionregistration_test.go
@@ -434,6 +434,189 @@ func TestEnsureValidatingWebhookConfiguration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "respect injected caBundle when the annotation `...inject-cabundle=true` is set",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "respect injected caBundle when the annotation `...inject-cabundle=true` is set by the user",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "remove injected caBundle when the annotation `...inject-cabundle=true` is not set",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the user"),
+						},
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+				},
+			},
+
+			expectedModified: true,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "respect injected caBundles in all webhooks when the annotation `...inject-cabundle=true` is set",
+			existing: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+			required: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: nil,
+						},
+					},
+				},
+			},
+
+			expectedModified: false,
+			expected: admissionregv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						injectCABundleAnnotation: "true",
+					},
+				},
+				Webhooks: []admissionregv1.ValidatingWebhook{
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+					{
+						ClientConfig: admissionregv1.WebhookClientConfig{
+							CABundle: []byte("CA bundle injected by the ca operator"),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/lib/resourceread/resourceread.go
+++ b/lib/resourceread/resourceread.go
@@ -38,13 +38,13 @@ func init() {
 	if err := imagev1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
+	if err := operatorsv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
 	if err := rbacv1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 	if err := securityv1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-	if err := operatorsv1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 	decoder = codecs.UniversalDecoder(
@@ -53,9 +53,9 @@ func init() {
 		batchv1.SchemeGroupVersion,
 		corev1.SchemeGroupVersion,
 		imagev1.SchemeGroupVersion,
+		operatorsv1.SchemeGroupVersion,
 		rbacv1.SchemeGroupVersion,
 		securityv1.SchemeGroupVersion,
-		operatorsv1.SchemeGroupVersion,
 	)
 }
 

--- a/lib/resourceread/resourceread.go
+++ b/lib/resourceread/resourceread.go
@@ -7,6 +7,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,9 @@ var (
 )
 
 func init() {
+	if err := admissionregistrationv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
 	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
@@ -48,6 +52,7 @@ func init() {
 		panic(err)
 	}
 	decoder = codecs.UniversalDecoder(
+		admissionregistrationv1.SchemeGroupVersion,
 		apiextensionsv1.SchemeGroupVersion,
 		appsv1.SchemeGroupVersion,
 		batchv1.SchemeGroupVersion,


### PR DESCRIPTION
This pull request will fix hotlooping on `ValidatingWebhookConfiguration`.

The hotlooping was caused by missing CVO-side defaulting of the `ValidatingWebhookConfiguration` resources and by missing CVO awareness of the `service-ca` operator who is responsible for injecting the CA bundle into resources annotated by `service.beta.openshift.io/inject-cabundle=true` [1].

This pull request adds the defaulting and ensures that the CVO ignores the respective `CABundle` fields inside the webhooks when the annotation is set.

This pull request references bug 2089138 [2].

[1] https://docs.openshift.com/container-platform/4.12/security/certificates/service-serving-certificate.html
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2089138