### PR TITLE
pkg/cvo/sync_worker: Fix "The sync worker already has a pending notification" formatting

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -237,7 +237,7 @@ func (w *SyncWorker) NotifyAboutManagedResourceActivity(obj interface{}, message
 	case w.notify <- message:
 		klog.V(2).Infof("Notify the sync worker: %s", message)
 	default:
-		klog.V(2).Info("The sync worker already has a pending notification, so do not notify about:no need to inform about: %s", message)
+		klog.V(2).Infof("The sync worker already has a pending notification, so no need to inform about: %s", message)
 	}
 }
 


### PR DESCRIPTION
Cleaning up a log line I'd fumbled in 9222fa9a66 (#818).  Changes:

* Remove redundant `so do not notify about`, because `no need to inform about` covers that with more clarity (we're not informing, and even if we did, it would be useless, because there's already a pending notification in place).
* Use `Infof` to get the `%s` formatted in, avoiding:

        ...no need to inform about: %sCluster operator...

   `