### PR TITLE
pkg/cvo/status: Failing is not more serious than Degraded

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -27,8 +27,7 @@ import (
 
 const (
 	// ClusterStatusFailing is set on the ClusterVersion status when a cluster
-	// cannot reach the desired state. It is considered more serious than Degraded
-	// and indicates the cluster is not healthy.
+	// cannot reach the desired state. It indicates the cluster is not healthy.
 	ClusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
 
 	// MaxHistory is the maximum size of ClusterVersion history. Once exceeded


### PR DESCRIPTION
The outgoing text goes way back to the local Failing type in 7f5b7f42dd (#191).  But ClusterVersion doesn't include Degraded, and ClusterOperator don't set Failing, so we don't need a relative-seriousness ranking.  In practice, a Degraded=True ClusterOperator is one of several issues that could lead to a Failing=True ClusterVersion, and when that's the only issue going on, they clearly have the same severity.  When an Available=False ClusterOperator feeds a Failing=True ClusterVersion, that would be worse than a Degraded=True Available=True ClusterOperator.  And there may also be issues like the CVO failing to reconcile a peripheral change like an alert rule where ClusterVersion is Failing=True despite the issue being less severe than many Degraded=True ClusterOperator situations.