### PR TITLE
OCPBUGS-5469: pkg/cvo/availableupdates: Prioritize conditional risks for largest target version

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -301,6 +301,12 @@ func (u *availableUpdates) evaluateConditionalUpdates(ctx context.Context) {
 		return
 	}
 
+	sort.Slice(u.ConditionalUpdates, func(i, j int) bool {
+		vi := semver.MustParse(u.ConditionalUpdates[i].Release.Version)
+		vj := semver.MustParse(u.ConditionalUpdates[j].Release.Version)
+		return vi.GTE(vj)
+	})
+
 	for i, conditionalUpdate := range u.ConditionalUpdates {
 		if errorCondition := evaluateConditionalUpdate(ctx, &conditionalUpdate); errorCondition != nil {
 			meta.SetStatusCondition(&conditionalUpdate.Conditions, *errorCondition)


### PR DESCRIPTION
When changing channels it's possible that multiple new conditional update risks will need to be evaluated.  For instance, a cluster running 4.10.34 in a 4.10 channel might only have to evaluate `OpenStackNodeCreationFails`.  But when the channel is changed to a 4.11 channel multiple new risks require evaluation and the evaluation of new risks was throttled at one every 10 minutes.  This means if there are three new risks it may take up to 20 minutes after the channel has changed for the full set of conditional updates to be computed.

With this commit, I'm sorting the conditional updates in version-descending order, which is the order we've used in the ClusterVersion status since c9dd4792f3ef (#663).  This prioritizes the longest-hop risks.  For example, 4.10.34 currently has the following updates:

* 4.10.(z!=38): no risks
* 4.10.38: `OpenStackNodeCreationFails`
* 4.11.(z<10): `ARM64SecCompError524`, `AWSOldBootImagesLackAfterburn`, `MachineConfigRenderingChurn`, `OVNNetworkPolicyLongName`
* 4.11.(10<=z<26): `ARM64SecCompError524`, `AWSOldBootImagesLackAfterburn`, `MachineConfigRenderingChurn`
* 4.11.26: `ARM64SecCompError524`, `AWSOldBootImagesLackAfterburn`
* 4.11.(27<=z<...): `AWSOldBootImagesLackAfterburn`

By focusing on the largest target (say 4.11.30), we'd evaluate `AWSOldBootImagesLackAfterburn` first.  If it did not match the current cluster, 4.11.27 and later would be quickly recommended.  It would take another 10m before the self-throttling allowed us to evaluate `ARM64SecCompError524`, and once we had, that would unblock 4.11.26. Ten minutes after that, we'd evaluate `MachineConfigRenderingChurn`, and unblock 4.11.(10<=z<26).  And so on.  But folks on 4.10.34 today are much more likely to be interested in 4.11.30 and other tip releases than they are to care about 4.11.10 and other relatively old releases.