### PR TITLE
OCPBUGS-9070: Fix hotlooping on Cronjob resources

### DIFF
--- a/hack/generate-lib-resources.py
+++ b/hack/generate-lib-resources.py
@@ -285,7 +285,7 @@ if __name__ == '__main__':
         'github.com/operator-framework/api/pkg/operators/v1': {'OperatorGroup'},
         'k8s.io/api/admissionregistration/v1': {'ValidatingWebhookConfiguration'},
         'k8s.io/api/apps/v1': {'DaemonSet', 'Deployment'},
-        'k8s.io/api/batch/v1': {'Job'},
+        'k8s.io/api/batch/v1': {'CronJob', 'Job'},
         'k8s.io/api/core/v1': {'ConfigMap', 'Namespace', 'Service', 'ServiceAccount'},
         'k8s.io/api/rbac/v1': {'ClusterRole', 'ClusterRoleBinding', 'Role', 'RoleBinding'},
         'k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1': {'CustomResourceDefinition'},

--- a/lib/resourceapply/batch.go
+++ b/lib/resourceapply/batch.go
@@ -47,3 +47,38 @@ func ApplyJobv1(ctx context.Context, client batchclientv1.JobsGetter, required *
 	actual, err := client.Jobs(required.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
 	return actual, true, err
 }
+
+// ApplyCronJobv1 applies the required CronJob to the cluster.
+func ApplyCronJobv1(ctx context.Context, client batchclientv1.CronJobsGetter, required *batchv1.CronJob, reconciling bool) (*batchv1.CronJob, bool, error) {
+	existing, err := client.CronJobs(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(2).Infof("CronJob %s/%s not found, creating", required.Namespace, required.Name)
+		actual, err := client.CronJobs(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	// if we only create this resource, we have no need to continue further
+	if IsCreateOnly(required) {
+		return nil, false, nil
+	}
+
+	var original batchv1.CronJob
+	existing.DeepCopyInto(&original)
+	modified := pointer.BoolPtr(false)
+	resourcemerge.EnsureCronJob(modified, existing, *required)
+	if !*modified {
+		return existing, false, nil
+	}
+	if reconciling {
+		if diff := cmp.Diff(&original, existing); diff != "" {
+			klog.V(2).Infof("Updating CronJob %s/%s due to diff: %v", required.Namespace, required.Name, diff)
+		} else {
+			klog.V(2).Infof("Updating CronJob %s/%s with empty diff: possible hotloop after wrong comparison", required.Namespace, required.Name)
+		}
+	}
+
+	actual, err := client.CronJobs(required.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return actual, true, err
+}

--- a/lib/resourceapply/batch.go
+++ b/lib/resourceapply/batch.go
@@ -29,14 +29,19 @@ func ApplyJobv1(ctx context.Context, client batchclientv1.JobsGetter, required *
 		return nil, false, nil
 	}
 
+	var original batchv1.Job
+	existing.DeepCopyInto(&original)
 	modified := pointer.BoolPtr(false)
 	resourcemerge.EnsureJob(modified, existing, *required)
 	if !*modified {
 		return existing, false, nil
 	}
-
 	if reconciling {
-		klog.V(2).Infof("Updating Job %s/%s due to diff: %v", required.Namespace, required.Name, cmp.Diff(existing, required))
+		if diff := cmp.Diff(&original, existing); diff != "" {
+			klog.V(2).Infof("Updating Job %s/%s due to diff: %v", required.Namespace, required.Name, diff)
+		} else {
+			klog.V(2).Infof("Updating Job %s/%s with empty diff: possible hotloop after wrong comparison", required.Namespace, required.Name)
+		}
 	}
 
 	actual, err := client.Jobs(required.Namespace).Update(ctx, existing, metav1.UpdateOptions{})

--- a/lib/resourcebuilder/resourcebuilder.go
+++ b/lib/resourcebuilder/resourcebuilder.go
@@ -169,6 +169,18 @@ func (b *builder) Do(ctx context.Context) error {
 				return b.checkDeploymentHealth(ctx, actual)
 			}
 		}
+	case *batchv1.CronJob:
+		if b.modifier != nil {
+			b.modifier(typedObject)
+		}
+		if deleteReq, err := resourcedelete.DeleteCronJobv1(ctx, b.batchClientv1, typedObject,
+			updatingMode); err != nil {
+			return err
+		} else if !deleteReq {
+			if _, _, err := resourceapply.ApplyCronJobv1(ctx, b.batchClientv1, typedObject, reconcilingMode); err != nil {
+				return err
+			}
+		}
 	case *batchv1.Job:
 		if b.modifier != nil {
 			b.modifier(typedObject)
@@ -306,6 +318,7 @@ func init() {
 	rm.RegisterGVK(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), newBuilder)
 	rm.RegisterGVK(appsv1.SchemeGroupVersion.WithKind("DaemonSet"), newBuilder)
 	rm.RegisterGVK(appsv1.SchemeGroupVersion.WithKind("Deployment"), newBuilder)
+	rm.RegisterGVK(batchv1.SchemeGroupVersion.WithKind("CronJob"), newBuilder)
 	rm.RegisterGVK(batchv1.SchemeGroupVersion.WithKind("Job"), newBuilder)
 	rm.RegisterGVK(corev1.SchemeGroupVersion.WithKind("ConfigMap"), newBuilder)
 	rm.RegisterGVK(corev1.SchemeGroupVersion.WithKind("Namespace"), newBuilder)

--- a/lib/resourcedelete/batch.go
+++ b/lib/resourcedelete/batch.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DeleteJobv1 checks the given resource for a valid delete annotation. If found
-// it checks the status of a previousily issued delete request. If delete has not been
+// it checks the status of a previously issued delete request. If delete has not been
 // requested and in UpdatingMode it will issue a delete request.
 func DeleteJobv1(ctx context.Context, client batchclientv1.JobsGetter, required *batchv1.Job,
 	updateMode bool) (bool, error) {
@@ -24,16 +24,15 @@ func DeleteJobv1(ctx context.Context, client batchclientv1.JobsGetter, required 
 		Namespace: required.Namespace,
 		Name:      required.Name,
 	}
-	if deleteRequested, err := GetDeleteProgress(resource, err); err == nil {
-		// Only request deletion when in update mode.
-		if !deleteRequested && updateMode {
-			if err := client.Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
-			}
-			SetDeleteRequested(existing, resource)
-		}
-	} else {
+	deleteRequested, err := GetDeleteProgress(resource, err)
+	if err != nil {
 		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+	}
+	if !deleteRequested && updateMode {
+		if err := client.Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
+			return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+		}
+		SetDeleteRequested(existing, resource)
 	}
 	return true, nil
 }

--- a/lib/resourcemerge/batch.go
+++ b/lib/resourcemerge/batch.go
@@ -2,6 +2,8 @@ package resourcemerge
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/pointer"
 )
 
 // EnsureJob ensures that the existing matches the required.
@@ -15,10 +17,34 @@ func ensureJobSpec(modified *bool, existing *batchv1.JobSpec, required batchv1.J
 	if required.Selector != nil {
 		panic("spec.selector is not supported in Job manifests")
 	}
+	ensureJobSpecDefault(&required)
 	setInt32Ptr(modified, &existing.Parallelism, required.Parallelism)
 	setInt32Ptr(modified, &existing.Completions, required.Completions)
 	setInt64Ptr(modified, &existing.ActiveDeadlineSeconds, required.ActiveDeadlineSeconds)
 	setInt32Ptr(modified, &existing.BackoffLimit, required.BackoffLimit)
 	setBoolPtr(modified, &existing.ManualSelector, required.ManualSelector)
+	setInt32Ptr(modified, &existing.TTLSecondsAfterFinished, required.TTLSecondsAfterFinished)
+	setBoolPtr(modified, &existing.Suspend, required.Suspend)
 	ensurePodTemplateSpec(modified, &existing.Template, required.Template)
+	if !equality.Semantic.DeepEqual(existing.CompletionMode, required.CompletionMode) {
+		*modified = true
+		existing.CompletionMode = required.CompletionMode
+	}
+	if !equality.Semantic.DeepEqual(existing.PodFailurePolicy, required.PodFailurePolicy) {
+		*modified = true
+		existing.PodFailurePolicy = required.PodFailurePolicy
+	}
+}
+
+func ensureJobSpecDefault(required *batchv1.JobSpec) {
+	if required.BackoffLimit == nil {
+		required.BackoffLimit = pointer.Int32(6)
+	}
+	if required.CompletionMode == nil {
+		completionMode := batchv1.NonIndexedCompletion
+		required.CompletionMode = &completionMode
+	}
+	if required.Suspend == nil {
+		required.Suspend = pointer.Bool(false)
+	}
 }

--- a/lib/resourcemerge/batch.go
+++ b/lib/resourcemerge/batch.go
@@ -7,16 +7,18 @@ import (
 // EnsureJob ensures that the existing matches the required.
 // modified is set to true when existing had to be updated with required.
 func EnsureJob(modified *bool, existing *batchv1.Job, required batchv1.Job) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	ensureJobSpec(modified, &existing.Spec, required.Spec)
+}
 
-	if required.Spec.Selector != nil {
+func ensureJobSpec(modified *bool, existing *batchv1.JobSpec, required batchv1.JobSpec) {
+	if required.Selector != nil {
 		panic("spec.selector is not supported in Job manifests")
 	}
-	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
-	setInt32Ptr(modified, &existing.Spec.Parallelism, required.Spec.Parallelism)
-	setInt32Ptr(modified, &existing.Spec.Completions, required.Spec.Completions)
-	setInt64Ptr(modified, &existing.Spec.ActiveDeadlineSeconds, required.Spec.ActiveDeadlineSeconds)
-	setInt32Ptr(modified, &existing.Spec.BackoffLimit, required.Spec.BackoffLimit)
-	setBoolPtr(modified, &existing.Spec.ManualSelector, required.Spec.ManualSelector)
-
-	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+	setInt32Ptr(modified, &existing.Parallelism, required.Parallelism)
+	setInt32Ptr(modified, &existing.Completions, required.Completions)
+	setInt64Ptr(modified, &existing.ActiveDeadlineSeconds, required.ActiveDeadlineSeconds)
+	setInt32Ptr(modified, &existing.BackoffLimit, required.BackoffLimit)
+	setBoolPtr(modified, &existing.ManualSelector, required.ManualSelector)
+	ensurePodTemplateSpec(modified, &existing.Template, required.Template)
 }

--- a/lib/resourcemerge/batch.go
+++ b/lib/resourcemerge/batch.go
@@ -48,3 +48,51 @@ func ensureJobSpecDefault(required *batchv1.JobSpec) {
 		required.Suspend = pointer.Bool(false)
 	}
 }
+
+// EnsureCronJob ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureCronJob(modified *bool, existing *batchv1.CronJob, required batchv1.CronJob) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	ensureCronJobSpec(modified, &existing.Spec, required.Spec)
+}
+
+func ensureCronJobSpec(modified *bool, existing *batchv1.CronJobSpec, required batchv1.CronJobSpec) {
+	ensureCronJobSpecDefault(&required)
+	setInt64Ptr(modified, &existing.StartingDeadlineSeconds, required.StartingDeadlineSeconds)
+	setBoolPtr(modified, &existing.Suspend, required.Suspend)
+	setInt32Ptr(modified, &existing.SuccessfulJobsHistoryLimit, required.SuccessfulJobsHistoryLimit)
+	setInt32Ptr(modified, &existing.FailedJobsHistoryLimit, required.FailedJobsHistoryLimit)
+	if existing.Schedule != required.Schedule {
+		*modified = true
+		existing.Schedule = required.Schedule
+	}
+	if !equality.Semantic.DeepEqual(existing.TimeZone, required.TimeZone) {
+		*modified = true
+		existing.TimeZone = required.TimeZone
+	}
+	if existing.ConcurrencyPolicy != required.ConcurrencyPolicy {
+		*modified = true
+		existing.ConcurrencyPolicy = required.ConcurrencyPolicy
+	}
+	ensureJobTemplateSpec(modified, &existing.JobTemplate, required.JobTemplate)
+}
+
+func ensureCronJobSpecDefault(required *batchv1.CronJobSpec) {
+	if required.ConcurrencyPolicy == "" {
+		required.ConcurrencyPolicy = batchv1.AllowConcurrent
+	}
+	if required.FailedJobsHistoryLimit == nil {
+		required.FailedJobsHistoryLimit = pointer.Int32(1)
+	}
+	if required.SuccessfulJobsHistoryLimit == nil {
+		required.SuccessfulJobsHistoryLimit = pointer.Int32(3)
+	}
+	if required.Suspend == nil {
+		required.Suspend = pointer.Bool(false)
+	}
+}
+
+func ensureJobTemplateSpec(modified *bool, existing *batchv1.JobTemplateSpec, required batchv1.JobTemplateSpec) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	ensureJobSpec(modified, &existing.Spec, required.Spec)
+}

--- a/lib/resourcemerge/batch_test.go
+++ b/lib/resourcemerge/batch_test.go
@@ -2,63 +2,408 @@ package resourcemerge
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
-func TestEnsureJob(t *testing.T) {
-	labelSelector := metav1.LabelSelector{}
+func TestEnsureJob_JobStatus(t *testing.T) {
 	tests := []struct {
 		name     string
-		existing batchv1.Job
-		required batchv1.Job
-
-		expectedModified bool
-		expectedPanic    bool
-		expected         batchv1.Job
+		existing batchv1.JobStatus
+		required batchv1.JobStatus
 	}{
 		{
-			name: "different backofflimit count",
-			existing: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(2)}},
-			required: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(3)}},
+			name: "cvo should ignore same status field",
+			existing: batchv1.JobStatus{
+				StartTime: &metav1.Time{Time: time.Unix(0, 0)},
+				Active:    3,
+				Succeeded: 4,
+				Failed:    2,
+				Ready:     pointer.Int32(1),
+			},
+			required: batchv1.JobStatus{
+				StartTime: &metav1.Time{Time: time.Unix(0, 0)},
+				Active:    3,
+				Succeeded: 4,
+				Failed:    2,
+				Ready:     pointer.Int32(1),
+			},
+		},
+		{
+			name: "cvo should ignore different status field",
+			existing: batchv1.JobStatus{
+				StartTime: &metav1.Time{Time: time.Unix(0, 0)},
+				Active:    3,
+				Succeeded: 4,
+				Failed:    2,
+				Ready:     pointer.Int32(1),
+			},
+			required: batchv1.JobStatus{},
+		},
+	}
 
+	var expected batchv1.Job
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			existing := batchv1.Job{Status: test.existing}
+			required := batchv1.Job{Status: test.required}
+			defaultJob(&existing, existing)
+			existing.DeepCopyInto(&expected)
+			modified := pointer.Bool(false)
+			EnsureJob(modified, &existing, required)
+			if *modified != false {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, false)
+			}
+			if !equality.Semantic.DeepEqual(existing, expected) {
+				t.Errorf("unexpected: %s", cmp.Diff(expected, existing))
+			}
+		})
+	}
+}
+
+func TestEnsureJob_JobSpec(t *testing.T) {
+	NonIndexedCompletion := batchv1.NonIndexedCompletion
+	IndexedCompletion := batchv1.IndexedCompletion
+	tests := []struct {
+		name     string
+		existing batchv1.JobSpec
+		required batchv1.JobSpec
+
+		expectedModified bool
+	}{
+		{
+			name: "same parallelism",
+			existing: batchv1.JobSpec{
+				Parallelism: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				Parallelism: pointer.Int32(10),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different parallelism",
+			existing: batchv1.JobSpec{
+				Parallelism: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				Parallelism: pointer.Int32(5),
+			},
 			expectedModified: true,
-			expected: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(3)}},
+		},
+		{
+			name: "same completions",
+			existing: batchv1.JobSpec{
+				Completions: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				Completions: pointer.Int32(10),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different completions",
+			existing: batchv1.JobSpec{
+				Completions: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				Completions: pointer.Int32(5),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "same active deadline seconds",
+			existing: batchv1.JobSpec{
+				ActiveDeadlineSeconds: pointer.Int64(10),
+			},
+			required: batchv1.JobSpec{
+				ActiveDeadlineSeconds: pointer.Int64(10),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different active deadline seconds",
+			existing: batchv1.JobSpec{
+				ActiveDeadlineSeconds: pointer.Int64(10),
+			},
+			required: batchv1.JobSpec{
+				ActiveDeadlineSeconds: pointer.Int64(5),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "same pod failure policy",
+			existing: batchv1.JobSpec{
+				PodFailurePolicy: &batchv1.PodFailurePolicy{
+					Rules: []batchv1.PodFailurePolicyRule{
+						{
+							Action: batchv1.PodFailurePolicyActionIgnore,
+							OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
+								{
+									Type:   v1.PodReady,
+									Status: metav1.StatusSuccess,
+								},
+							},
+						},
+					},
+				},
+			},
+			required: batchv1.JobSpec{
+				PodFailurePolicy: &batchv1.PodFailurePolicy{
+					Rules: []batchv1.PodFailurePolicyRule{
+						{
+							Action: batchv1.PodFailurePolicyActionIgnore,
+							OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
+								{
+									Type:   v1.PodReady,
+									Status: metav1.StatusSuccess,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different pod failure policy",
+			existing: batchv1.JobSpec{
+				PodFailurePolicy: &batchv1.PodFailurePolicy{
+					Rules: []batchv1.PodFailurePolicyRule{
+						{
+							Action: batchv1.PodFailurePolicyActionIgnore,
+							OnPodConditions: []batchv1.PodFailurePolicyOnPodConditionsPattern{
+								{
+									Type:   v1.PodReady,
+									Status: metav1.StatusSuccess,
+								},
+							},
+						},
+					},
+				},
+			},
+			required:         batchv1.JobSpec{},
+			expectedModified: true,
 		},
 		{
 			name: "same backofflimit count",
-			existing: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(2)}},
-			required: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(2)}},
-
+			existing: batchv1.JobSpec{
+				BackoffLimit: pointer.Int32(2),
+			},
+			required: batchv1.JobSpec{
+				BackoffLimit: pointer.Int32(2),
+			},
 			expectedModified: false,
-			expected: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					BackoffLimit: pointer.Int32(2)}},
 		},
 		{
-			name: "required-Selector not nil",
-			existing: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Selector:       &labelSelector,
-					ManualSelector: pointer.Bool(false)}},
-			required: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Selector:       &labelSelector,
-					ManualSelector: pointer.Bool(true)}},
+			name: "different backofflimit count",
+			existing: batchv1.JobSpec{
+				BackoffLimit: pointer.Int32(2),
+			},
+			required: batchv1.JobSpec{
+				BackoffLimit: pointer.Int32(3),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "implicit backofflimit count",
+			existing: batchv1.JobSpec{
+				BackoffLimit: pointer.Int32(6),
+			},
+			required:         batchv1.JobSpec{},
+			expectedModified: false,
+		},
+		{
+			name: "same manual selector",
+			existing: batchv1.JobSpec{
+				ManualSelector: pointer.Bool(true),
+			},
+			required: batchv1.JobSpec{
+				ManualSelector: pointer.Bool(true),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different manual selector",
+			existing: batchv1.JobSpec{
+				ManualSelector: pointer.Bool(true),
+			},
+			required: batchv1.JobSpec{
+				ManualSelector: pointer.Bool(false),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "same template",
+			existing: batchv1.JobSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "app",
+								Image: "app:latest",
+							},
+						},
+					},
+				},
+			},
+			required: batchv1.JobSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "app",
+								Image: "app:latest",
+							},
+						},
+					},
+				},
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different template",
+			existing: batchv1.JobSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "app",
+								Image: "app:latest",
+							},
+						},
+					},
+				},
+			},
+			required:         batchv1.JobSpec{},
+			expectedModified: true,
+		},
+		{
+			name: "same TTL seconds after finished",
+			existing: batchv1.JobSpec{
+				TTLSecondsAfterFinished: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				TTLSecondsAfterFinished: pointer.Int32(10),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different TTL seconds after finished",
+			existing: batchv1.JobSpec{
+				TTLSecondsAfterFinished: pointer.Int32(10),
+			},
+			required: batchv1.JobSpec{
+				TTLSecondsAfterFinished: pointer.Int32(5),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "same completion mode",
+			existing: batchv1.JobSpec{
+				CompletionMode: &IndexedCompletion,
+			},
+			required: batchv1.JobSpec{
+				CompletionMode: &IndexedCompletion,
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different completion mode",
+			existing: batchv1.JobSpec{
+				CompletionMode: &IndexedCompletion,
+			},
+			required: batchv1.JobSpec{
+				CompletionMode: &NonIndexedCompletion,
+			},
+			expectedModified: true,
+		},
+		{
+			name: "implicit completion mode",
+			existing: batchv1.JobSpec{
+				CompletionMode: &NonIndexedCompletion,
+			},
+			required:         batchv1.JobSpec{},
+			expectedModified: false,
+		},
+		{
+			name: "same suspend",
+			existing: batchv1.JobSpec{
+				Suspend: pointer.Bool(true),
+			},
+			required: batchv1.JobSpec{
+				Suspend: pointer.Bool(true),
+			},
+			expectedModified: false,
+		},
+		{
+			name: "different suspend",
+			existing: batchv1.JobSpec{
+				Suspend: pointer.Bool(true),
+			},
+			required: batchv1.JobSpec{
+				Suspend: pointer.Bool(false),
+			},
+			expectedModified: true,
+		},
+		{
+			name: "implicit suspend",
+			existing: batchv1.JobSpec{
+				Suspend: pointer.Bool(false),
+			},
+			required:         batchv1.JobSpec{},
+			expectedModified: false,
+		},
+	}
+	for _, test := range tests {
+		var expected batchv1.Job
+		t.Run(test.name, func(t *testing.T) {
+			existing := batchv1.Job{Spec: test.existing}
+			required := batchv1.Job{Spec: test.required}
+			if test.expectedModified == false {
+				existing.DeepCopyInto(&expected)
+			} else {
+				required.DeepCopyInto(&expected)
+			}
+			defaultJob(&existing, existing)
+			defaultJob(&expected, expected)
+			modified := pointer.Bool(false)
+			EnsureJob(modified, &existing, required)
+			if *modified != test.expectedModified {
+				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
+			}
+			if !equality.Semantic.DeepEqual(existing, expected) {
+				t.Errorf("unexpected: %s", cmp.Diff(existing, expected))
+			}
+		})
+	}
+}
 
+func TestEnsureJob_JobSpec_Selector(t *testing.T) {
+	labelSelector := metav1.LabelSelector{}
+	tests := []struct {
+		name     string
+		existing batchv1.JobSpec
+		required batchv1.JobSpec
+
+		expectedPanic bool
+	}{
+		{
+			name: "required-Selector not nil",
+			existing: batchv1.JobSpec{
+				Selector:       &labelSelector,
+				ManualSelector: pointer.Bool(false),
+			},
+			required: batchv1.JobSpec{
+				Selector:       &labelSelector,
+				ManualSelector: pointer.Bool(true),
+			},
 			expectedPanic: true,
 		},
 	}
@@ -77,17 +422,11 @@ func TestEnsureJob(t *testing.T) {
 					}
 				}
 			}()
-			defaultJob(&test.existing, test.existing)
-			defaultJob(&test.expected, test.expected)
+			existing := batchv1.Job{Spec: test.existing}
+			required := batchv1.Job{Spec: test.required}
+			defaultJob(&existing, existing)
 			modified := pointer.Bool(false)
-			EnsureJob(modified, &test.existing, test.required)
-			if *modified != test.expectedModified {
-				t.Errorf("mismatch modified got: %v want: %v", *modified, test.expectedModified)
-			}
-
-			if !equality.Semantic.DeepEqual(test.existing, test.expected) {
-				t.Errorf("mismatch Job got: %v want: %v", test.existing, test.expected)
-			}
+			EnsureJob(modified, &existing, required)
 		})
 	}
 }


### PR DESCRIPTION
Currently the CVO hotloops on `CronJob` resources.

The issue was caused by the missing defaulting of these resources.

To fix this issue I have added the handling for `CronJob` resources so they are not reconciled as `generic` resources. This has then allowed me to introduce the defaulting.

To fix this issue I have also updated the applying for `Job` resources because its logic can be then reused as part of the fix for the hotlooping on `Cronjob` resources.  While updating the applying for `Job` I have added missing defaulting,  and I have added reconciling of fields that were added later in the development, and the CVO was not reconciling them.

This pull request references https://issues.redhat.com/browse/OCPBUGS-9070