### PR TITLE
explain why we cannot currently use the dnsConfig

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -66,7 +66,9 @@ spec:
                 fieldPath: spec.nodeName
           - name: CLUSTER_PROFILE
             value: {{ .ClusterProfile }}
-      dnsPolicy: ClusterFirstWithHostNet
+      # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
+      # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
+      dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -69,6 +69,11 @@ spec:
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default
+      # The dnsConfig below doesn't work because the IP range for the service network is configurable.
+      # There is no easy spot to perform this injection, though the CVO could be made to look up and substitute the value.
+#      dnsConfig:
+#        nameservers:
+#          - 172.30.0.10
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
/hold

Some additional custom substitution logic could be written, but https://github.com/openshift/cluster-version-operator/pull/920 may be more straight forward