### PR TITLE
syncStatus: Reduce verbosity when syncing nothing of interest

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -167,7 +167,12 @@ const ImplicitlyEnabledCapabilities configv1.ClusterStatusConditionType = "Impli
 // syncStatus calculates the new status of the ClusterVersion based on the current sync state and any
 // validation errors found. We allow the caller to pass the original object to avoid DeepCopying twice.
 func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1.ClusterVersion, status *SyncWorkerStatus, validationErrs field.ErrorList) error {
-	klog.V(2).Infof("Synchronizing status errs=%#v status=%#v", validationErrs, status)
+	// Be more verbose when we are syncing something interesting
+	verbosityLevel := klog.Level(4)
+	if len(validationErrs) != 0 || status.Failure != nil {
+		verbosityLevel = klog.Level(2)
+	}
+	klog.V(verbosityLevel).Infof("Synchronizing status errs=%#v status=%#v", validationErrs, status)
 
 	cvUpdated := false
 	// update the config with the latest available updates


### PR DESCRIPTION
Status is synchronized every 15 seconds, and each call is currently logged with a lot of metadata, including full `status`. The metadata include words `error` and `Failure` which usually have zero values, but the words get noticed by filters and people eyeballing the logs:

```
I0405 09:24:26.084143       1 status.go:170] Synchronizing status errs=field.ErrorList(nil) status=&cvo.SyncWorkerStatus{Generation:55, Failure:error(nil), Done:830, Total:830, Completed:107, Reconciling:true, Initial:false, VersionHash:"yroEV7BhWJo=", Architecture:"amd64", LastProgress:time.Date(2023, time.April, 5, 9, 21, 50, 486422587, time.Local), Actual:v1.Release{Version:"4.12.10", Image:"quay.io/openshift-release-dev/ocp-release@sha256:db976910d909373b1136261a5479ed18ec08c93971285ff760ce75c6217d3943", URL:"https://access.redhat.com/errata/RHBA-2023:1508", Channels:[]string(nil)}, Verified:false, loadPayloadStatus:cvo.LoadPayloadStatus{Step:"PayloadLoaded", Message:"Payload loaded version=\"4.12.10\" image=\"quay.io/openshift-release-dev/ocp-release@sha256:db976910d909373b1136261a5479ed18ec08c93971285ff760ce75c6217d3943\" architecture=\"amd64\"", AcceptedRisks:"", Failure:error(nil), Update:v1.Update{Version:"4.12.10", Image:"quay.io/openshift-release-dev/ocp-release@sha256:db976910d909373b1136261a5479ed18ec08c93971285ff760ce75c6217d3943", Force:false}, Verified:false, Local:true, LastTransitionTime:time.Time{wall:0xc102c34e44dd634f, ext:2230452990, loc:(*time.Location)(0x2f4afa0)}}, CapabilitiesStatus:cvo.CapabilityStatus{Status:v1.ClusterVersionCapabilitiesStatus{EnabledCapabilities:[]v1.ClusterVersionCapability{"CSISnapshot", "Console", "Insights", "Storage", "baremetal", "marketplace", "openshift-samples"}, KnownCapabilities:[]v1.ClusterVersionCapability{"CSISnapshot", "Console", "Insights", "Storage", "baremetal", "marketplace", "openshift-samples"}}, ImplicitlyEnabledCaps:[]v1.ClusterVersionCapability(nil)}}
```

Because most of the time this event is not interesting, we can only log it if we happen to sync something interesting, like a failure, an only log every event on higher verbosity.
