### PR TITLE
pkg/cvo/metrics: Doc from_version semantics for cluster_version{type="completed"}

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -80,8 +80,9 @@ cluster version object and the current version. The type
 new version but has not reached the completed state and
 is the time the update was started. The type 'initial' is
 set to the oldest entry in the history. The from_version label
-will be set to the last completed version, the initial
-version for 'cluster', or empty for 'initial'.
+will be set to the last completed version for most types, the
+initial version for 'cluster', empty for 'initial', and the
+penultimate completed version for 'completed'.
 .`,
 		}, []string{"type", "version", "image", "from_version"}),
 		availableUpdates: prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Since bd8d7cf7f4 (#204), the `from_version` value has been the penultimate `Completed` history entry.  So a cluster with a history like:

1. Version D, Partial
2. Version C, Completed
3. Version B, Partial
4. Version A, Completed

will have `version="C"` and `from_version="A"`.