### PR TITLE
OCPBUGS-12182: Update dnsPolicy to allow consistent resolution of the internal LB

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,9 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
-
-	_ "github.com/openshift/cluster-version-operator/pkg/clusterconditions/always"
-	_ "github.com/openshift/cluster-version-operator/pkg/clusterconditions/promql"
 )
 
 var (

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -66,7 +66,9 @@ spec:
                 fieldPath: spec.nodeName
           - name: CLUSTER_PROFILE
             value: {{ .ClusterProfile }}
-      dnsPolicy: ClusterFirstWithHostNet
+      # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
+      # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
+      dnsPolicy: Default
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -10,11 +10,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/standard"
+
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
-	_ "github.com/openshift/cluster-version-operator/pkg/clusterconditions/always"
-	_ "github.com/openshift/cluster-version-operator/pkg/clusterconditions/promql"
 	_ "k8s.io/klog/v2" // integration tests set glog flags.
 )
 
@@ -604,7 +604,7 @@ func TestGetUpdates(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(handler))
 			defer ts.Close()
 
-			c := NewClient(clientID, nil)
+			c := NewClient(clientID, nil, standard.NewConditionRegistry(nil))
 
 			uri, err := url.Parse(ts.URL)
 			if err != nil {

--- a/pkg/clusterconditions/always/always.go
+++ b/pkg/clusterconditions/always/always.go
@@ -13,8 +13,6 @@ import (
 // Always implements a cluster condition that always matches.
 type Always struct{}
 
-var always = &Always{}
-
 // Valid returns an error if the condition contains any properties
 // besides 'type'.
 func (a *Always) Valid(ctx context.Context, condition *configv1.ClusterCondition) error {

--- a/pkg/clusterconditions/always/always.go
+++ b/pkg/clusterconditions/always/always.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
 )
 
 // Always implements a cluster condition that always matches.
@@ -29,8 +28,4 @@ func (a *Always) Valid(ctx context.Context, condition *configv1.ClusterCondition
 // Match always returns true.
 func (a *Always) Match(ctx context.Context, condition *configv1.ClusterCondition) (bool, error) {
 	return true, nil
-}
-
-func init() {
-	clusterconditions.Register("Always", always)
 }

--- a/pkg/clusterconditions/clusterconditions.go
+++ b/pkg/clusterconditions/clusterconditions.go
@@ -25,28 +25,51 @@ type Condition interface {
 	Match(ctx context.Context, condition *configv1.ClusterCondition) (bool, error)
 }
 
-// Registry is a registry of implemented condition types.
-var Registry map[string]Condition
+type ConditionRegistry interface {
+	// Register registers a condition type, and panics on any name collisions.
+	Register(conditionType string, condition Condition)
+
+	// PruneInvalid returns a new slice with recognized, valid conditions.
+	// The error complains about any unrecognized or invalid conditions.
+	PruneInvalid(ctx context.Context, matchingRules []configv1.ClusterCondition) ([]configv1.ClusterCondition, error)
+
+	// Match returns whether the cluster matches the given rules (true),
+	// does not match (false), or the rules fail to evaluate (error).
+	Match(ctx context.Context, matchingRules []configv1.ClusterCondition) (bool, error)
+}
+
+type conditionRegistry struct {
+	// registry is a registry of implemented condition types.
+	registry map[string]Condition
+}
+
+func NewConditionRegistry() ConditionRegistry {
+	ret := &conditionRegistry{
+		registry: map[string]Condition{},
+	}
+
+	return ret
+}
 
 // Register registers a condition type, and panics on any name collisions.
-func Register(conditionType string, condition Condition) {
-	if Registry == nil {
-		Registry = make(map[string]Condition, 1)
+func (r *conditionRegistry) Register(conditionType string, condition Condition) {
+	if r.registry == nil {
+		r.registry = make(map[string]Condition, 1)
 	}
-	if existing, ok := Registry[conditionType]; ok && condition != existing {
+	if existing, ok := r.registry[conditionType]; ok && condition != existing {
 		panic(fmt.Sprintf("cluster condition %q already registered", conditionType))
 	}
-	Registry[conditionType] = condition
+	r.registry[conditionType] = condition
 }
 
 // PruneInvalid returns a new slice with recognized, valid conditions.
 // The error complains about any unrecognized or invalid conditions.
-func PruneInvalid(ctx context.Context, matchingRules []configv1.ClusterCondition) ([]configv1.ClusterCondition, error) {
+func (r *conditionRegistry) PruneInvalid(ctx context.Context, matchingRules []configv1.ClusterCondition) ([]configv1.ClusterCondition, error) {
 	var valid []configv1.ClusterCondition
 	var errs []error
 
 	for _, config := range matchingRules {
-		condition, ok := Registry[config.Type]
+		condition, ok := r.registry[config.Type]
 		if !ok {
 			errs = append(errs, fmt.Errorf("Skipping unrecognized cluster condition type %q", config.Type))
 			continue
@@ -63,11 +86,11 @@ func PruneInvalid(ctx context.Context, matchingRules []configv1.ClusterCondition
 
 // Match returns whether the cluster matches the given rules (true),
 // does not match (false), or the rules fail to evaluate (error).
-func Match(ctx context.Context, matchingRules []configv1.ClusterCondition) (bool, error) {
+func (r *conditionRegistry) Match(ctx context.Context, matchingRules []configv1.ClusterCondition) (bool, error) {
 	var errs []error
 
 	for _, config := range matchingRules {
-		condition, ok := Registry[config.Type]
+		condition, ok := r.registry[config.Type]
 		if !ok {
 			klog.V(2).Infof("Skipping unrecognized cluster condition type %q", config.Type)
 			continue

--- a/pkg/clusterconditions/promql/promql.go
+++ b/pkg/clusterconditions/promql/promql.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -14,6 +15,8 @@ import (
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/cache"
@@ -21,8 +24,7 @@ import (
 
 // PromQL implements a cluster condition that matches based on PromQL.
 type PromQL struct {
-	// Address holds the Prometheus query URI.
-	Address string
+	kubeClient kubernetes.Interface
 
 	// HTTPClientConfig holds the client configuration for connecting to the Prometheus service.
 	HTTPClientConfig config.HTTPClientConfig
@@ -31,16 +33,18 @@ type PromQL struct {
 	QueryTimeout time.Duration
 }
 
-func NewPromQL() *cache.Cache {
+func NewPromQL(kubeClient kubernetes.Interface) *cache.Cache {
 	return &cache.Cache{
 		Condition: &PromQL{
+			kubeClient: kubeClient,
 			HTTPClientConfig: config.HTTPClientConfig{
 				Authorization: &config.Authorization{
 					Type:            "Bearer",
 					CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 				},
 				TLSConfig: config.TLSConfig{
-					CAFile:     "/etc/tls/service-ca/service-ca.crt",
+					CAFile: "/etc/tls/service-ca/service-ca.crt",
+					// ServerName is used to verify the name of the service we will connect to using IP.
 					ServerName: "thanos-querier.openshift-monitoring.svc.cluster.local",
 				},
 			},
@@ -50,6 +54,19 @@ func NewPromQL() *cache.Cache {
 		MinForCondition:   time.Hour,
 		Expiration:        24 * time.Hour,
 	}
+}
+
+// Address determines the address of the thanos-querier to avoid requiring service DNS resolution.
+// We do this so that our host-network pod can use the node's resolv.conf to resolve the internal load balancer name
+// on the pod before DNS pods are available and before the service network is available.  The side effect is that
+// the CVO cannot resolve service DNS names.
+func (p *PromQL) Address(ctx context.Context) (string, error) {
+	svc, err := p.kubeClient.CoreV1().Services("openshift-monitoring").Get(ctx, "thanos-querier", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("https://%s", net.JoinHostPort(svc.Spec.ClusterIP, "9091")), nil
 }
 
 // Valid returns an error if the condition contains any properties
@@ -70,7 +87,13 @@ func (p *PromQL) Valid(ctx context.Context, condition *configv1.ClusterCondition
 // false when the PromQL evaluates to 0, and an error if the PromQL
 // returns no time series or returns a value besides 0 or 1.
 func (p *PromQL) Match(ctx context.Context, condition *configv1.ClusterCondition) (bool, error) {
-	clientConfig := api.Config{Address: p.Address}
+	// Lookup the address every attempt in case the service IP changes.  This can happen when the thanos service is
+	// deleted and recreated.
+	address, err := p.Address(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failure determine thanos IP: %w", err)
+	}
+	clientConfig := api.Config{Address: address}
 
 	if roundTripper, err := config.NewRoundTripperFromConfig(p.HTTPClientConfig, "cluster-conditions"); err == nil {
 		clientConfig.RoundTripper = roundTripper

--- a/pkg/clusterconditions/standard/standard.go
+++ b/pkg/clusterconditions/standard/standard.go
@@ -1,0 +1,16 @@
+package standard
+
+import (
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/always"
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/promql"
+	"k8s.io/client-go/kubernetes"
+)
+
+func NewConditionRegistry(kubeClient kubernetes.Interface) clusterconditions.ConditionRegistry {
+	conditionRegistry := clusterconditions.NewConditionRegistry()
+	conditionRegistry.Register("Always", &always.Always{})
+	conditionRegistry.Register("PromQL", promql.NewPromQL())
+
+	return conditionRegistry
+}

--- a/pkg/clusterconditions/standard/standard.go
+++ b/pkg/clusterconditions/standard/standard.go
@@ -10,7 +10,7 @@ import (
 func NewConditionRegistry(kubeClient kubernetes.Interface) clusterconditions.ConditionRegistry {
 	conditionRegistry := clusterconditions.NewConditionRegistry()
 	conditionRegistry.Register("Always", &always.Always{})
-	conditionRegistry.Register("PromQL", promql.NewPromQL())
+	conditionRegistry.Register("PromQL", promql.NewPromQL(kubeClient))
 
 	return conditionRegistry
 }

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -8,6 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/standard"
+
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,6 +133,9 @@ type Operator struct {
 	// synchronization
 	upgradeableCheckIntervals upgradeableCheckIntervals
 
+	// conditionRegistry is used to evaluate whether a particular condition is risky or not.
+	conditionRegistry clusterconditions.ConditionRegistry
+
 	// verifier, if provided, will be used to check an update before it is executed.
 	// Any error will prevent an update payload from being accessed.
 	verifier verify.Interface
@@ -204,6 +211,7 @@ func New(
 		exclude:            exclude,
 		requiredFeatureSet: requiredFeatureSet,
 		clusterProfile:     clusterProfile,
+		conditionRegistry:  standard.NewConditionRegistry(kubeClient),
 	}
 
 	cvInformer.Informer().AddEventHandler(optr.clusterVersionEventHandler())

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -8,10 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/standard"
-
-	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +33,8 @@ import (
 	"github.com/openshift/cluster-version-operator/lib/capability"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
 	"github.com/openshift/cluster-version-operator/lib/validation"
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
+	"github.com/openshift/cluster-version-operator/pkg/clusterconditions/standard"
 	cvointernal "github.com/openshift/cluster-version-operator/pkg/cvo/internal"
 	"github.com/openshift/cluster-version-operator/pkg/cvo/internal/dynamicclient"
 	"github.com/openshift/cluster-version-operator/pkg/internal"


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/cluster-version-operator/pull/923

The 8af3ba94774cba60e91cd5d231eee9bd8f37d40c commit did not apply cleanly and I had to manually adjust for missing https://github.com/openshift/cluster-version-operator/pull/839 and https://github.com/openshift/cluster-version-operator/pull/860, but the changes were not that invasive, so I do not consider the resulting change to be too risky compared to https://github.com/openshift/cluster-version-operator/pull/923