### PR TITLE
WIP: Test: Explicitly request fsGroup and UID for CVO pod

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -38,6 +38,15 @@ spec:
           requests:
             cpu: 20m
             memory: 50Mi
+        securityContext:
+          capabilities:
+            drop:
+            - KILL
+            - MKNOD
+            - SETGID
+            - SETUID
+          runAsNonRoot: true
+          runAsUser: 11411
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - mountPath: /etc/ssl/certs
@@ -73,6 +82,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"
+      securityContext:
+        fsGroup: 11411
       terminationGracePeriodSeconds: 130
       tolerations:
       - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
Explicitly request fsGroup and UID for CVO pod

Note: I don't know if this is due to clusterbot, but when the pod comes up initially with this PR, it is ... privileged, until it's deleted. But then it'll come up with node-exporter:
~~~
[akaris@linux scc-assignments]$ oc get pods -n openshift-cluster-version -o custom-columns=NAMESPACE:.metadata.namespace,POD_NAME:.metadata.name,SERVICE_ACCOUNT:.spec.serviceAccount,SCC_PROFILE:".metadata.annotations.openshift\.io/scc"
NAMESPACE                   POD_NAME                                    SERVICE_ACCOUNT   SCC_PROFILE
openshift-cluster-version   cluster-version-operator-7f5fc64568-sjpph   default           privileged
[akaris@linux scc-assignments]$ oc get pods -n openshift-cluster-version
NAME                                        READY   STATUS    RESTARTS   AGE
cluster-version-operator-7f5fc64568-sjpph   1/1     Running   0          104m
[akaris@linux scc-assignments]$ oc get pods -n openshift-cluster-version  -o yaml cluster-version-operator-7f5fc64568-sjpph | oc -n openshift-cluster-version policy scc-review -f -
RESOURCE                                        SERVICE ACCOUNT   ALLOWED BY      
Pod/cluster-version-operator-7f5fc64568-sjpph   default           node-exporter   
Pod/cluster-version-operator-7f5fc64568-sjpph   default           privileged      
[akaris@linux scc-assignments]$ oc delete pod -n openshift-cluster-version cluster-version-operator-7f5fc64568-sjpph
pod "cluster-version-operator-7f5fc64568-sjpph" deleted
[akaris@linux scc-assignments]$ oc get pods -n openshift-cluster-version -o custom-columns=NAMESPACE:.metadata.namespace,POD_NAME:.metadata.name,SERVICE_ACCOUNT:.spec.serviceAccount,SCC_PROFILE:".metadata.annotations.openshift\.io/scc"
NAMESPACE                   POD_NAME                                    SERVICE_ACCOUNT   SCC_PROFILE
openshift-cluster-version   cluster-version-operator-7f5fc64568-m5kdj   default           node-exporter
~~~

Hence, I have no idea if this makes sense as a fix or not, but the securityContext is correctly set even when the custom SCC (see https://issues.redhat.com/browse/OCPBUGS-12724) is matched:
~~~
[akaris@linux yamls]$ oc get pods -n openshift-cluster-version -o custom-columns=NAMESPACE:.metadata.namespace,POD_NAME:.metadata.name,SERVICE_ACCOUNT:.spec.serviceAccount,SCC_PROFILE:".metadata.annotations.openshift\.io/scc"
NAMESPACE                   POD_NAME                                    SERVICE_ACCOUNT   SCC_PROFILE
openshift-cluster-version   cluster-version-operator-7f5fc64568-j4sbn   default           custom-pod-security-policy
(reverse-i-search)`-a': git commit -^Cmend
[akaris@linux yamls]$ oc get pod -n openshift-cluster-version   cluster-version-operator-7f5fc64568-m5kdj -o yaml | grep securityContext -A8
Error from server (NotFound): pods "cluster-version-operator-7f5fc64568-m5kdj" not found
[akaris@linux yamls]$ oc get pod -n openshift-cluster-version   cluster-version-operator-7f5fc64568-j4sbn -o yaml | grep securityContext -A8
    securityContext:
      capabilities:
        drop:
        - KILL
        - MKNOD
        - SETGID
        - SETUID
      runAsNonRoot: true
      runAsUser: 11411
--
  securityContext:
    fsGroup: 11411
    seLinuxOptions:
      level: s0:c6,c0
  serviceAccount: default
  serviceAccountName: default
  terminationGracePeriodSeconds: 130
  tolerations:
  - effect: NoSchedule
~~~