### PR TITLE
Code cleanups for golangci-lint failures

### DIFF
--- a/hack/test-prerequisites.go
+++ b/hack/test-prerequisites.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -32,7 +32,7 @@ func main() {
 	} {
 		var name string
 		err := wait.PollImmediate(time.Second, 30*time.Second, func() (bool, error) {
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				log.Fatalf("Unable to read %s: %v", path, err)
 			}

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -113,6 +113,9 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, desiredArch, curre
 		if c.transport.TLSClientConfig.ClientCAs == nil {
 			klog.V(2).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
 		} else {
+			//nolint:staticcheck // SA1019: TLSClientConfig.RootCAs.Subjects() is deprecated because
+			// "if s was returned by SystemCertPool, Subjects will not include the system roots"
+			// but that should not apply for us, we construct it ourselves in Operator.getTLSConfig()
 			klog.V(2).Infof("Using a root CA pool with %n root CA subjects to request updates from %s", len(c.transport.TLSClientConfig.RootCAs.Subjects()), uri)
 		}
 	}
@@ -141,7 +144,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, desiredArch, curre
 	}
 
 	// Parse the graph.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return current, nil, nil, &Error{Reason: "ResponseFailed", Message: err.Error(), cause: err}
 	}

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -627,11 +626,11 @@ func certsChanged(origCertChecksum []byte, origKeyChecksum []byte, certFile, key
 
 func makeTLSConfig(servingCertFile, servingKeyFile string) (*tls.Config, error) {
 	// Load the initial certificate contents.
-	certBytes, err := ioutil.ReadFile(servingCertFile)
+	certBytes, err := os.ReadFile(servingCertFile)
 	if err != nil {
 		return nil, err
 	}
-	keyBytes, err := ioutil.ReadFile(servingKeyFile)
+	keyBytes, err := os.ReadFile(servingKeyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -164,7 +163,7 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 		}
 	}()
 
-	dir, err := ioutil.TempDir("", "cvo-test")
+	dir, err := os.MkdirTemp("", "cvo-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +295,7 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 		}
 	}()
 
-	dir, err := ioutil.TempDir("", "cvo-test")
+	dir, err := os.MkdirTemp("", "cvo-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +464,7 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 		}
 	}()
 
-	dir, err := ioutil.TempDir("", "cvo-test")
+	dir, err := os.MkdirTemp("", "cvo-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -489,13 +488,13 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 	if err := os.Mkdir(releaseManifestsDir, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(releaseManifestsDir, "release-metadata"), []byte(`{
+	if err := os.WriteFile(filepath.Join(releaseManifestsDir, "release-metadata"), []byte(`{
   "kind": "cincinnati-metadata-v0",
   "version": "0.0.1"
 }`), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(releaseManifestsDir, "image-references"), []byte(`kind: ImageStream
+	if err := os.WriteFile(filepath.Join(releaseManifestsDir, "image-references"), []byte(`kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   name: 0.0.1
@@ -806,7 +805,7 @@ func createContent(baseDir string, content map[string]interface{}, replacements 
 					return key
 				})
 			}
-			if err := ioutil.WriteFile(filepath.Join(baseDir, k), []byte(t), 0640); err != nil {
+			if err := os.WriteFile(filepath.Join(baseDir, k), []byte(t), 0640); err != nil {
 				return err
 			}
 		case map[string]interface{}:


### PR DESCRIPTION
Saw this failing in https://github.com/openshift/cluster-version-operator/pull/929 , not exactly sure what mechanism makes these appear  on their own :monocle_face: 

Also bumping the linter in https://github.com/openshift/release/pull/40480 because why not.