### PR TITLE
Dockerfile: bump to 1.19 and use public UBI pullspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
-FROM registry.ci.openshift.org/ocp/ubi:8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml /manifests/


### PR DESCRIPTION
This Dockerfile is not used in CI [1] nor in product builds [2], so it may as
well be external contributor friendly and do not contain private CI
registry pullspecs.

We should use 1.20 but that image does not exist yet [3]. I do not see
any reason why to keep using UBI8 in this Dockerfile, so I bumped it to
UBI9.

[1] https://github.com/openshift/release/blob/7d59d083a7aa5f2aec28e807681a4b4e9ccdd088/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-master.yaml#L17-L25
[2] https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.14/images/cluster-version-operator.yml#L3
[3] https://github.com/openshift/release/pull/40567
