### PR TITLE
OCPBUGS-5011: Backport `seccompProfile` reconciliation behavior

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -487,6 +487,7 @@ func ensureSecurityContext(modified *bool, existing *corev1.SecurityContext, req
 	setBoolPtr(modified, &existing.RunAsNonRoot, required.RunAsNonRoot)
 	setBoolPtr(modified, &existing.ReadOnlyRootFilesystem, required.ReadOnlyRootFilesystem)
 	setBoolPtr(modified, &existing.AllowPrivilegeEscalation, required.AllowPrivilegeEscalation)
+	ensureSeccompProfilePtr(modified, &existing.SeccompProfile, required.SeccompProfile)
 }
 
 func ensureCapabilitiesPtr(modified *bool, existing **corev1.Capabilities, required *corev1.Capabilities) {
@@ -533,6 +534,30 @@ func ensureCapabilities(modified *bool, existing *corev1.Capabilities, required 
 			existing.Drop = append(existing.Drop, required)
 		}
 	}
+}
+
+func ensureSeccompProfilePtr(modified *bool, existing **corev1.SeccompProfile, required *corev1.SeccompProfile) {
+	if *existing == nil && required == nil {
+		return
+	}
+
+	// Check if we can simply set to required. This can be done if existing is not set or it is set
+	// but required is not set.
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	ensureSeccompProfile(modified, *existing, *required)
+}
+
+func ensureSeccompProfile(modified *bool, existing *corev1.SeccompProfile, required corev1.SeccompProfile) {
+	if equality.Semantic.DeepEqual(existing, required) {
+		return
+	}
+
+	*modified = true
+	*existing = required
 }
 
 func setStringSlice(modified *bool, existing *[]string, required []string) {
@@ -637,6 +662,7 @@ func ensurePodSecurityContext(modified *bool, existing *corev1.PodSecurityContex
 	setInt64Ptr(modified, &existing.RunAsUser, required.RunAsUser)
 	setInt64Ptr(modified, &existing.RunAsGroup, required.RunAsGroup)
 	setBoolPtr(modified, &existing.RunAsNonRoot, required.RunAsNonRoot)
+	ensureSeccompProfilePtr(modified, &existing.SeccompProfile, required.SeccompProfile)
 
 	// any SupplementalGroups we specify, we require.
 	for _, required := range required.SupplementalGroups {

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -45,7 +45,7 @@ func TestEnsurePodSpec(t *testing.T) {
 					{Name: "test"}}},
 		},
 		{
-			name: "PodSecurityContext empty",
+			name: "PodSecurityContext empty input wont overwrite existing",
 			existing: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
 					RunAsUser:      pointer.Int64Ptr(int64(1234)),
@@ -56,9 +56,13 @@ func TestEnsurePodSpec(t *testing.T) {
 			input: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{}},
 
-			expectedModified: true,
 			expected: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{}},
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+					RunAsUser:      pointer.Int64Ptr(int64(1234)),
+					RunAsGroup:     pointer.Int64Ptr(int64(1234)),
+					FSGroup:        pointer.Int64Ptr(int64(1234)),
+					SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
+				}},
 		},
 		{
 			name: "PodSecurityContext changes",
@@ -74,6 +78,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			expectedModified: true,
 			expected: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+					RunAsUser:      pointer.Int64Ptr(int64(1234)),
 					RunAsGroup:     pointer.Int64Ptr(int64(5)),
 					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
 		},
@@ -93,7 +98,7 @@ func TestEnsurePodSpec(t *testing.T) {
 			expected:         corev1.PodSpec{},
 		},
 		{
-			name: "container SecurityContext empty",
+			name: "container SecurityContext empty wont overwrite existing",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
@@ -106,10 +111,14 @@ func TestEnsurePodSpec(t *testing.T) {
 				Containers: []corev1.Container{
 					{SecurityContext: &corev1.SecurityContext{}}}},
 
-			expectedModified: true,
 			expected: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{SecurityContext: &corev1.SecurityContext{}}}},
+					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+						RunAsUser: pointer.Int64Ptr(int64(1234)),
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"bar"}},
+						SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
+					}}}},
 		},
 		{
 			name: "remove regular and init containers from existing",

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -47,10 +47,10 @@ func TestEnsurePodSpec(t *testing.T) {
 		{
 			name: "PodSecurityContext empty",
 			existing: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
-					RunAsUser:      int64Ptr(int64(1234)),
-					RunAsGroup:     int64Ptr(int64(1234)),
-					FSGroup:        int64Ptr(int64(1234)),
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+					RunAsUser:      pointer.Int64Ptr(int64(1234)),
+					RunAsGroup:     pointer.Int64Ptr(int64(1234)),
+					FSGroup:        pointer.Int64Ptr(int64(1234)),
 					SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
 				}},
 			input: corev1.PodSpec{
@@ -63,26 +63,26 @@ func TestEnsurePodSpec(t *testing.T) {
 		{
 			name: "PodSecurityContext changes",
 			existing: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(true),
-					RunAsUser:  int64Ptr(int64(1234)),
-					RunAsGroup: int64Ptr(int64(1234))}},
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(true),
+					RunAsUser:  pointer.Int64Ptr(int64(1234)),
+					RunAsGroup: pointer.Int64Ptr(int64(1234))}},
 			input: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
-					RunAsGroup:     int64Ptr(int64(5)),
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+					RunAsGroup:     pointer.Int64Ptr(int64(5)),
 					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
 
 			expectedModified: true,
 			expected: corev1.PodSpec{
-				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
-					RunAsGroup:     int64Ptr(int64(5)),
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+					RunAsGroup:     pointer.Int64Ptr(int64(5)),
 					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
 		},
 		{
 			name: "container SecurityContext none",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: boolPtr(false),
-						RunAsUser: int64Ptr(int64(1234)),
+					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+						RunAsUser: pointer.Int64Ptr(int64(1234)),
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{"bar"}},
 						SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
@@ -96,8 +96,8 @@ func TestEnsurePodSpec(t *testing.T) {
 			name: "container SecurityContext empty",
 			existing: corev1.PodSpec{
 				Containers: []corev1.Container{
-					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: boolPtr(false),
-						RunAsUser: int64Ptr(int64(1234)),
+					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: pointer.BoolPtr(false),
+						RunAsUser: pointer.Int64Ptr(int64(1234)),
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{"bar"}},
 						SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -45,6 +45,73 @@ func TestEnsurePodSpec(t *testing.T) {
 					{Name: "test"}}},
 		},
 		{
+			name: "PodSecurityContext empty",
+			existing: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
+					RunAsUser:      int64Ptr(int64(1234)),
+					RunAsGroup:     int64Ptr(int64(1234)),
+					FSGroup:        int64Ptr(int64(1234)),
+					SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
+				}},
+			input: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{}},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{}},
+		},
+		{
+			name: "PodSecurityContext changes",
+			existing: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(true),
+					RunAsUser:  int64Ptr(int64(1234)),
+					RunAsGroup: int64Ptr(int64(1234))}},
+			input: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
+					RunAsGroup:     int64Ptr(int64(5)),
+					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),
+					RunAsGroup:     int64Ptr(int64(5)),
+					SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault}}},
+		},
+		{
+			name: "container SecurityContext none",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: boolPtr(false),
+						RunAsUser: int64Ptr(int64(1234)),
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"bar"}},
+						SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
+					}}}},
+			input: corev1.PodSpec{},
+
+			expectedModified: true,
+			expected:         corev1.PodSpec{},
+		},
+		{
+			name: "container SecurityContext empty",
+			existing: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{SecurityContext: &corev1.SecurityContext{RunAsNonRoot: boolPtr(false),
+						RunAsUser: int64Ptr(int64(1234)),
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"bar"}},
+						SELinuxOptions: &corev1.SELinuxOptions{User: "foo"},
+					}}}},
+			input: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{SecurityContext: &corev1.SecurityContext{}}}},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{SecurityContext: &corev1.SecurityContext{}}}},
+		},
+		{
 			name: "remove regular and init containers from existing",
 			existing: corev1.PodSpec{
 				InitContainers: []corev1.Container{


### PR DESCRIPTION
> ⚠️ **this PR is mutually exclusive with https://github.com/openshift/cluster-version-operator/pull/940** ⚠️

---

From OCPBUGS-5011:

> After upgrading the cluster from 4.10 to 4.11, openshift-apiserver fails to match the new Pod Security Admission criteria.

Apiserver folks pinned this on CVO reconciliation behavior:

> - the openshift-apiserver-operator deployment/pod on 4.10 doesn't contain any definition of `seccompProfile` in the security context (it does on 4.11)
> - the Cluster Version Operator actually skips `seccompProfile` reconciliation when upgrading to 4.11
> - therefore the resulting deployment/pod after the upgrade will be missing `seccompProfile`, and this will cause the pod to fire PS violation alerts

This behavior in CVO was introduced in https://github.com/openshift/cluster-version-operator/pull/830 in 4.12 which was not backported to 4.11. Cherry-picking aae14d2a0467dbea6c92ed5a30b77f853cd74bb4 does not apply cleanly on release-4.11 without changes from https://github.com/openshift/cluster-version-operator/pull/804 (another 4.12 PR that changes `SecurityContext` reconciliation), so this PR adds necessary adjustments, including changing the behavior expected in the backported tests so it matches the CVO behavior after backporting only https://github.com/openshift/cluster-version-operator/pull/830 behavior without the https://github.com/openshift/cluster-version-operator/pull/804 one. The alternative is to backport both, proposed in https://github.com/openshift/cluster-version-operator/pull/940.

This PR resolves the problem identified by apiserver, but it does not *fully* resolve OCPBUGS-5011 for these two reasons:
- Even with the fixed CVO, there is a period during the update where we already run the 4.11 kube-apiserver (which brings the alert reporting the PSA violations) while we still have the 4.10 openshift-apiserver-operator `ReplicaSet` (which violates the PSA, it is only fixed in 4.11). So even with fixed CVO, we will still trip the alert during the upgrade.
- Because OCPBUGS-5011 was around for a long time, it became a honeypot for any report where the PodSecurityViolation alert fired, even ones unrelated to openshift-apiserver. The CVO change does not fix all culprits that trip this alert. I have not investigated the culprits unrelated to openshift-apiserver. It is possible that some of them are caused by the same gotcha like above, but it is also possible that they are separate problems.

So even if we merge this, the observable behavior of "we trip an alert during the update" will not disappear, disappointing all people who linked a "my update tripped the alert" report to OCPBUGS-5011.
