### PR TITLE
OCPBUGS-13308: Simplify user-facing messages on risk evaluation throttling

### DIFF
--- a/pkg/clusterconditions/cache/cache_test.go
+++ b/pkg/clusterconditions/cache/cache_test.go
@@ -116,7 +116,6 @@ func TestCache(t *testing.T) {
 }
 
 func Test_calculateMostStale(t *testing.T) {
-	ctx := context.Background()
 	now := time.Now()
 	for _, testCase := range []struct {
 		name              string
@@ -189,7 +188,7 @@ func Test_calculateMostStale(t *testing.T) {
 				MinForCondition: 30 * time.Minute,
 				MatchResults:    testCase.cache,
 			}
-			key, condition, err := c.calculateMostStale(ctx, now)
+			key, condition, err := c.calculateMostStale(now)
 
 			if key != testCase.expectedKey {
 				t.Errorf("got key %q but expected %q", key, testCase.expectedKey)

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -335,6 +335,13 @@ func (u *availableUpdates) removeUpdate(image string) {
 	}
 }
 
+func unknownExposureMessage(risk configv1.ConditionalUpdateRisk, err error) string {
+	template := `Could not evaluate exposure to update risk %s (%v)
+  %s description: %s
+  %s URL: %s`
+	return fmt.Sprintf(template, risk.Name, err, risk.Name, risk.Message, risk.Name, risk.URL)
+}
+
 func evaluateConditionalUpdate(ctx context.Context, conditionalUpdate *configv1.ConditionalUpdate, conditionRegistry clusterconditions.ConditionRegistry) *metav1.Condition {
 	recommended := &metav1.Condition{
 		Type: "Recommended",
@@ -350,7 +357,7 @@ func evaluateConditionalUpdate(ctx context.Context, conditionalUpdate *configv1.
 			} else {
 				recommended.Reason = "MultipleReasons"
 			}
-			messages = append(messages, fmt.Sprintf("Exposure to %s is unknown due to an evaluation failure: %v\n%s %s", risk.Name, err, risk.Message, risk.URL))
+			messages = append(messages, unknownExposureMessage(risk, err))
 		} else if match {
 			recommended.Status = metav1.ConditionFalse
 			if recommended.Reason == "" {


### PR DESCRIPTION
There are opportunities to improve this area overall but we probably do not want to do that in the scope of OCPBUGS-13308
