### PR TITLE
[WIP] Add admin-ack for legacy-ingress

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 data:
   ack-4.12-kube-1.26-api-removals-in-4.13: |-
       Kubernetes 1.26 and therefore OpenShift 4.13 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+  ack-4.12-ingress-changes-in-4.13: |-
+    In version 4.13 of OSD/ROSA, we are changing how we manage Ingress Controllers. See  https://access.redhat.com/node/7028653 for more information on how your cluster may be affected, and instructions on how to upgrade.
 metadata:
   name: admin-gates
   namespace: openshift-config-managed


### PR DESCRIPTION
KCS describing changes from 4.12->4.13: https://access.redhat.com/node/7028653
From the KCS:

> In version 4.13 of Red Hat OpenShift Service on AWS (ROSA), we are changing Ingress to give customers more control over their workloads and configuration. Customers will be able to create a fully customizable additional [Ingress Controller](https://docs.openshift.com/container-platform/4.12/networking/ingress-operator.html) alongside the default Ingress provided by the installer.

Epic link:
https://issues.redhat.com/browse/SDE-1768
Ticket link:
https://issues.redhat.com/browse/OSD-17988