### PR TITLE
OCPBUGS-9050: Alert on failing conditional update risk evaluation

### DIFF
--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -127,3 +127,12 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: CannotEvaluateConditionalUpdates
+      annotations:
+        summary: Cluster Version Operator cannot evaluate conditional update matches for {{ "{{ $value | humanizeDuration }}" }}.
+        description: Failure to evaluate conditional update matches means that Cluster Version Operator cannot decide whether an update path is recommended or not.
+      expr: |
+        (cluster_version_conditional_updates_recommended_conditions_seconds{recommended="unknown"}) >= 3000
+      for: 10m
+      labels:
+        severity: warning

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -132,7 +132,6 @@ spec:
         summary: Cluster Version Operator cannot evaluate conditional update matches for {{ "{{ $value | humanizeDuration }}" }}.
         description: Failure to evaluate conditional update matches means that Cluster Version Operator cannot decide whether an update path is recommended or not.
       expr: |
-        (cluster_version_conditional_updates_recommended_conditions_seconds{recommended="unknown"}) >= 3000
-      for: 10m
+        max by (version, condition, status, reason) (cluster_version_conditional_update_condition_seconds{condition="Recommended", status="Unknown"} >= 3600)
       labels:
         severity: warning

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -132,6 +132,11 @@ spec:
         summary: Cluster Version Operator cannot evaluate conditional update matches for {{ "{{ $value | humanizeDuration }}" }}.
         description: Failure to evaluate conditional update matches means that Cluster Version Operator cannot decide whether an update path is recommended or not.
       expr: |
-        max by (version, condition, status, reason) (cluster_version_conditional_update_condition_seconds{condition="Recommended", status="Unknown"} >= 3600)
+        max by (version, condition, status, reason)
+        (
+          (
+            time()-cluster_version_conditional_update_condition_seconds{condition="Recommended", status="Unknown"}
+          ) >= 3600
+        )
       labels:
         severity: warning

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -428,7 +428,7 @@ func unknownExposureMessage(risk configv1.ConditionalUpdateRisk, err error) stri
 
 func evaluateConditionalUpdate(ctx context.Context, conditionalUpdate *configv1.ConditionalUpdate, conditionRegistry clusterconditions.ConditionRegistry) *metav1.Condition {
 	recommended := &metav1.Condition{
-		Type: "Recommended",
+		Type: ConditionalUpdateConditionTypeRecommended,
 	}
 	messages := []string{}
 	for _, risk := range conditionalUpdate.Risks {

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -121,7 +121,7 @@ penultimate completed version for 'completed'.
 		}, []string{"name"}),
 		clusterVersionConditionalUpdateConditionSeconds: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cluster_version_conditional_update_condition_seconds",
-			Help: "Reports when condition on conditional updates were last updated",
+			Help: "Reports the duration (in seconds) since the Recommended condition status on a conditional update changed to its current state.",
 		}, []string{"version", "condition", "status", "reason"}),
 	}
 }

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -58,7 +58,7 @@ func Test_operatorMetrics_Collect(t *testing.T) {
 				}
 				// optr.releaseCreated is epoch+2s, LastTransitionTime is epoch+3s
 				// we mock the evaluation time to be one minute after optr.releaseCreated => expect 59s
-				expectMetric(t, metrics[2], 59, map[string]string{"reason": "RiskDoesNotApply", "recommended": "true", "version": "4.5.6"})
+				expectMetric(t, metrics[2], 59, map[string]string{"condition": "Recommended", "reason": "RiskDoesNotApply", "status": "True", "version": "4.5.6"})
 			},
 		},
 		{
@@ -820,7 +820,7 @@ func TestCollectUnknownConditionalUpdates(t *testing.T) {
 			evaluate: anchorTime.Add(time.Minute),
 			expected: []valueWithLabels{{
 				value:  60,
-				labels: map[string]string{"version": "4.13.1", "recommended": "false", "reason": "RiskApplies"},
+				labels: map[string]string{"version": "4.13.1", "condition": "Recommended", "status": "False", "reason": "RiskApplies"},
 			}},
 		},
 		{
@@ -841,7 +841,7 @@ func TestCollectUnknownConditionalUpdates(t *testing.T) {
 			evaluate: anchorTime.Add(time.Minute),
 			expected: []valueWithLabels{{
 				value:  60,
-				labels: map[string]string{"version": "4.13.1", "recommended": "true", "reason": "RiskDoesNotApply"},
+				labels: map[string]string{"version": "4.13.1", "condition": "Recommended", "status": "True", "reason": "RiskDoesNotApply"},
 			}},
 		},
 		{
@@ -862,7 +862,7 @@ func TestCollectUnknownConditionalUpdates(t *testing.T) {
 			evaluate: anchorTime.Add(time.Minute),
 			expected: []valueWithLabels{{
 				value:  60,
-				labels: map[string]string{"version": "4.13.1", "recommended": "unknown", "reason": "EvaluationFailed"},
+				labels: map[string]string{"version": "4.13.1", "condition": "Recommended", "status": "Unknown", "reason": "EvaluationFailed"},
 			}},
 		},
 		{
@@ -906,15 +906,15 @@ func TestCollectUnknownConditionalUpdates(t *testing.T) {
 			expected: []valueWithLabels{
 				{
 					value:  5 * 60,
-					labels: map[string]string{"version": "4.13.1", "recommended": "false", "reason": "RiskApplies"},
+					labels: map[string]string{"version": "4.13.1", "condition": "Recommended", "status": "False", "reason": "RiskApplies"},
 				},
 				{
 					value:  4 * 60,
-					labels: map[string]string{"version": "4.13.2", "recommended": "true", "reason": "RiskDoesNotApply"},
+					labels: map[string]string{"version": "4.13.2", "condition": "Recommended", "status": "True", "reason": "RiskDoesNotApply"},
 				},
 				{
 					value:  3 * 60,
-					labels: map[string]string{"version": "4.13.3", "recommended": "unknown", "reason": "EvaluationFailed"},
+					labels: map[string]string{"version": "4.13.3", "condition": "Recommended", "status": "Unknown", "reason": "EvaluationFailed"},
 				},
 			},
 		},

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -31,6 +31,10 @@ const (
 	// and indicates the cluster is not healthy.
 	ClusterStatusFailing = configv1.ClusterStatusConditionType("Failing")
 
+	// ConditionalUpdateConditionTypeRecommended is a type of the condition present on a conditional update
+	// that indicates whether the conditional update is recommended or not
+	ConditionalUpdateConditionTypeRecommended = "Recommended"
+
 	// MaxHistory is the maximum size of ClusterVersion history. Once exceeded
 	// ClusterVersion history will be pruned. It is declared here and passed
 	// into the pruner function to allow easier testing.

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -14,6 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -40,6 +41,10 @@ const (
 	// into the pruner function to allow easier testing.
 	MaxHistory = 100
 )
+
+func findRecommendedCondition(conditions []metav1.Condition) *metav1.Condition {
+	return meta.FindStatusCondition(conditions, ConditionalUpdateConditionTypeRecommended)
+}
 
 func mergeEqualVersions(current *configv1.UpdateHistory, desired configv1.Release) bool {
 	if len(desired.Image) > 0 && desired.Image == current.Image {


### PR DESCRIPTION
Add a new `cluster_version_conditional_updates_recommended_conditions_seconds` which, for each conditional update known to CVO, reports how long (in seconds) is the `Recommended` condition on that update in the current state (this is the time since the conditions' `lastTransitionTime`). The metric is labelled with version, reason and status. Note that `lastTransitionTime` was not correctly maintained by CVO until fixed in #964.

Using this metric, we create an alert that fires when there is an update that is in an `Unknown` status for more than 50 minutes and this state is maintained for 10 minutes.

The metric was created slightly more generic than the alert would have needed. Technically the CVO could compute the "bad" state right away and just flap a 0/1 metric, but I believe the metrics are more useful when slightly generic.