### PR TITLE
OCPBUGS-18454: Avoid using risk names as condition reasons when invalid

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -389,7 +389,7 @@ func (u *availableUpdates) evaluateConditionalUpdates(ctx context.Context) {
 		return vi.GTE(vj)
 	})
 	for i, conditionalUpdate := range u.ConditionalUpdates {
-		if errorCondition := evaluateConditionalUpdate(ctx, &conditionalUpdate, u.ConditionRegistry); errorCondition != nil {
+		if errorCondition := evaluateConditionalUpdate(ctx, conditionalUpdate.Risks, u.ConditionRegistry); errorCondition != nil {
 			meta.SetStatusCondition(&conditionalUpdate.Conditions, *errorCondition)
 			u.removeUpdate(conditionalUpdate.Release.Image)
 		} else {
@@ -432,12 +432,12 @@ func unknownExposureMessage(risk configv1.ConditionalUpdateRisk, err error) stri
 	return fmt.Sprintf(template, risk.Name, err, risk.Name, risk.Message, risk.Name, risk.URL)
 }
 
-func evaluateConditionalUpdate(ctx context.Context, conditionalUpdate *configv1.ConditionalUpdate, conditionRegistry clusterconditions.ConditionRegistry) *metav1.Condition {
+func evaluateConditionalUpdate(ctx context.Context, risks []configv1.ConditionalUpdateRisk, conditionRegistry clusterconditions.ConditionRegistry) *metav1.Condition {
 	recommended := &metav1.Condition{
 		Type: ConditionalUpdateConditionTypeRecommended,
 	}
 	messages := []string{}
-	for _, risk := range conditionalUpdate.Risks {
+	for _, risk := range risks {
 		if match, err := conditionRegistry.Match(ctx, risk.MatchingRules); err != nil {
 			if recommended.Status != metav1.ConditionFalse {
 				recommended.Status = metav1.ConditionUnknown

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -274,7 +274,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionTrue,
-				Reason:  recommendedReasonAsExpected,
+				Reason:  recommendedReasonRisksNotExposed,
 				Message: "The update is recommended, because none of the conditional update risks apply to this cluster.",
 			},
 		},
@@ -295,7 +295,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionTrue,
-				Reason:  recommendedReasonAsExpected,
+				Reason:  recommendedReasonRisksNotExposed,
 				Message: "The update is recommended, because none of the conditional update risks apply to this cluster.",
 			},
 		},
@@ -337,7 +337,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionFalse,
-				Reason:  recommendedReasonRiskApplies,
+				Reason:  recommendedReasonExposed,
 				Message: "This is a risk! https://match.es",
 			},
 		},

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -321,6 +321,27 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "matching risk with name that cannot be used as a condition reason",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://match.es",
+					Name:          "RISK-THAT-APPLIES", // Condition reasons are CamelCase names, must not contain dashes
+					Message:       "This is a risk!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil},
+				MatchQueue: []mock.MatchResult{{Match: true, Error: nil}},
+			},
+			expected: metav1.Condition{
+				Type:    "Recommended",
+				Status:  metav1.ConditionFalse,
+				Reason:  recommendedReasonRiskApplies,
+				Message: "This is a risk! https://match.es",
+			},
+		},
+		{
 			name: "two risks that match",
 			risks: []configv1.ConditionalUpdateRisk{
 				{

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -274,7 +274,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionTrue,
-				Reason:  "AsExpected",
+				Reason:  recommendedReasonAsExpected,
 				Message: "The update is recommended, because none of the conditional update risks apply to this cluster.",
 			},
 		},
@@ -295,7 +295,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionTrue,
-				Reason:  "AsExpected",
+				Reason:  recommendedReasonAsExpected,
 				Message: "The update is recommended, because none of the conditional update risks apply to this cluster.",
 			},
 		},
@@ -343,7 +343,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:    "Recommended",
 				Status:  metav1.ConditionFalse,
-				Reason:  "MultipleReasons",
+				Reason:  recommendedReasonMultiple,
 				Message: "This is a risk! https://match.es\n\nThis is a risk too! https://match.es/too",
 			},
 		},
@@ -370,7 +370,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:   "Recommended",
 				Status: metav1.ConditionFalse,
-				Reason: "MultipleReasons",
+				Reason: recommendedReasonMultiple,
 				Message: "This is a risk! https://match.es\n\n" +
 					"Could not evaluate exposure to update risk RiskThatFailsToEvaluate (ERROR)\n" +
 					"  RiskThatFailsToEvaluate description: This is a risk too!\n" +
@@ -394,7 +394,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 			expected: metav1.Condition{
 				Type:   "Recommended",
 				Status: metav1.ConditionUnknown,
-				Reason: "EvaluationFailed",
+				Reason: recommendedReasonEvaluationFailed,
 				Message: "Could not evaluate exposure to update risk RiskThatFailsToEvaluate (ERROR)\n" +
 					"  RiskThatFailsToEvaluate description: This is a risk!\n" +
 					"  RiskThatFailsToEvaluate URL: https://whokno.ws",

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -2,6 +2,7 @@ package cvo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,7 +33,7 @@ func (n notFoundProxyLister) List(labels.Selector) ([]*configv1.Proxy, error) {
 }
 
 func (n notFoundProxyLister) Get(name string) (*configv1.Proxy, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: configv1.GroupName, Resource: "proxy"}, name)
+	return nil, k8serrors.NewNotFound(schema.GroupResource{Group: configv1.GroupName, Resource: "proxy"}, name)
 }
 
 type notFoundConfigMapLister struct{}
@@ -42,7 +43,7 @@ func (n notFoundConfigMapLister) List(labels.Selector) ([]*corev1.ConfigMap, err
 }
 
 func (n notFoundConfigMapLister) Get(name string) (*corev1.ConfigMap, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmap"}, name)
+	return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmap"}, name)
 }
 
 // osusWithSingleConditionalEdge helper returns:
@@ -256,6 +257,150 @@ func TestSyncAvailableUpdates_ConditionalUpdateRecommendedConditions(t *testing.
 			}
 			if !tc.expectTimeChange && timeBefore != timeAfter {
 				t.Errorf("lastTransitionTime was updated but was not expected to: before=%s after=%s", timeBefore, timeAfter)
+			}
+		})
+	}
+}
+
+func TestEvaluateConditionalUpdate(t *testing.T) {
+	testcases := []struct {
+		name       string
+		risks      []configv1.ConditionalUpdateRisk
+		mockPromql clusterconditions.Condition
+		expected   *metav1.Condition
+	}{
+		{
+			name: "no risks",
+		},
+		{
+			// It is weird that "evaluate" only returns Status: False or Status: Unknown but Status: True
+			// is handled at the callsite. I think this should be refactored so the logic is at one place.
+			name: "one risk that does not match",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://doesnotmat.ch",
+					Name:          "ShouldNotApply",
+					Message:       "ShouldNotApply",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil},
+				MatchQueue: []mock.MatchResult{{Match: false, Error: nil}},
+			},
+		},
+		{
+			name: "one risk that matches",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://match.es",
+					Name:          "RiskThatApplies",
+					Message:       "This is a risk!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil},
+				MatchQueue: []mock.MatchResult{{Match: true, Error: nil}},
+			},
+			expected: &metav1.Condition{
+				Type:    "Recommended",
+				Status:  metav1.ConditionFalse,
+				Reason:  "RiskThatApplies",
+				Message: "This is a risk! https://match.es",
+			},
+		},
+		{
+			name: "two risks that match",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://match.es",
+					Name:          "RiskThatApplies",
+					Message:       "This is a risk!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+				{
+					URL:           "https://match.es/too",
+					Name:          "RiskThatAppliesToo",
+					Message:       "This is a risk too!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil, nil},
+				MatchQueue: []mock.MatchResult{{Match: true, Error: nil}, {Match: true, Error: nil}},
+			},
+			expected: &metav1.Condition{
+				Type:    "Recommended",
+				Status:  metav1.ConditionFalse,
+				Reason:  "MultipleReasons",
+				Message: "This is a risk! https://match.es\n\nThis is a risk too! https://match.es/too",
+			},
+		},
+		{
+			name: "first risk matches, second fails to evaluate",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://match.es",
+					Name:          "RiskThatApplies",
+					Message:       "This is a risk!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+				{
+					URL:           "https://whokno.ws",
+					Name:          "RiskThatFailsToEvaluate",
+					Message:       "This is a risk too!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil, nil},
+				MatchQueue: []mock.MatchResult{{Match: true, Error: nil}, {Match: false, Error: errors.New("ERROR")}},
+			},
+			expected: &metav1.Condition{
+				Type:   "Recommended",
+				Status: metav1.ConditionFalse,
+				Reason: "MultipleReasons",
+				Message: "This is a risk! https://match.es\n\n" +
+					"Could not evaluate exposure to update risk RiskThatFailsToEvaluate (ERROR)\n" +
+					"  RiskThatFailsToEvaluate description: This is a risk too!\n" +
+					"  RiskThatFailsToEvaluate URL: https://whokno.ws",
+			},
+		},
+		{
+			name: "one risk that fails to evaluate",
+			risks: []configv1.ConditionalUpdateRisk{
+				{
+					URL:           "https://whokno.ws",
+					Name:          "RiskThatFailsToEvaluate",
+					Message:       "This is a risk!",
+					MatchingRules: []configv1.ClusterCondition{{Type: "PromQL"}},
+				},
+			},
+			mockPromql: &mock.Mock{
+				ValidQueue: []error{nil},
+				MatchQueue: []mock.MatchResult{{Match: false, Error: errors.New("ERROR")}},
+			},
+			expected: &metav1.Condition{
+				Type:   "Recommended",
+				Status: metav1.ConditionUnknown,
+				Reason: "EvaluationFailed",
+				Message: "Could not evaluate exposure to update risk RiskThatFailsToEvaluate (ERROR)\n" +
+					"  RiskThatFailsToEvaluate description: This is a risk!\n" +
+					"  RiskThatFailsToEvaluate URL: https://whokno.ws",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := clusterconditions.NewConditionRegistry()
+			registry.Register("PromQL", tc.mockPromql)
+			update := &configv1.ConditionalUpdate{
+				Risks: tc.risks,
+			}
+			actual := evaluateConditionalUpdate(context.Background(), update, registry)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("actual condition differs from expected:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -395,10 +395,7 @@ func TestEvaluateConditionalUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			registry := clusterconditions.NewConditionRegistry()
 			registry.Register("PromQL", tc.mockPromql)
-			update := &configv1.ConditionalUpdate{
-				Risks: tc.risks,
-			}
-			actual := evaluateConditionalUpdate(context.Background(), update, registry)
+			actual := evaluateConditionalUpdate(context.Background(), tc.risks, registry)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
 				t.Errorf("actual condition differs from expected:\n%s", diff)
 			}


### PR DESCRIPTION
Until / unless we merge https://github.com/openshift/api/pull/1577, conditional risk names may not be valid condition reason strings, so we need to check them and use a generic (new `RiskAppliesToCluster`) reason instead.

I took the opportunity and wrote tests and refactored the code slightly (make it easily testable from a single place and get rid of extensive branching logic that was hard to read). I suggest reviewing individual commits.