### PR TITLE
OCPBUGS-18567: lib/resourcemerge/apps: Cover paused and other spec properties in EnsureDeployment

### DIFF
--- a/lib/resourcemerge/apps.go
+++ b/lib/resourcemerge/apps.go
@@ -26,6 +26,22 @@ func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required apps
 		*modified = true
 		existing.Spec.Selector = required.Spec.Selector
 	}
+	if existing.Spec.Paused != required.Spec.Paused {
+		*modified = true
+		existing.Spec.Paused = required.Spec.Paused
+	}
+	if existing.Spec.MinReadySeconds != required.Spec.MinReadySeconds {
+		*modified = true
+		existing.Spec.MinReadySeconds = required.Spec.MinReadySeconds
+	}
+	if required.Spec.RevisionHistoryLimit != nil && !equality.Semantic.DeepEqual(existing.Spec.RevisionHistoryLimit, required.Spec.RevisionHistoryLimit) {
+		*modified = true
+		existing.Spec.RevisionHistoryLimit = required.Spec.RevisionHistoryLimit
+	}
+	if required.Spec.ProgressDeadlineSeconds != nil && !equality.Semantic.DeepEqual(existing.Spec.ProgressDeadlineSeconds, required.Spec.ProgressDeadlineSeconds) {
+		*modified = true
+		existing.Spec.ProgressDeadlineSeconds = required.Spec.ProgressDeadlineSeconds
+	}
 
 	ensureStrategyDefault(&required)
 	if !equality.Semantic.DeepEqual(existing.Spec.Strategy, required.Spec.Strategy) {


### PR DESCRIPTION
With this change, we now reconcile all of these:

```console
$ git --no-pager grep -A42 'type DeploymentSpec struct' vendor/k8s.io/api/apps/v1 | grep json
vendor/k8s.io/api/apps/v1/types.go-     Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
vendor/k8s.io/api/apps/v1/types.go-     Selector *metav1.LabelSelector `json:"selector" protobuf:"bytes,2,opt,name=selector"`
vendor/k8s.io/api/apps/v1/types.go-     Template v1.PodTemplateSpec `json:"template" protobuf:"bytes,3,opt,name=template"`
vendor/k8s.io/api/apps/v1/types.go-     Strategy DeploymentStrategy `json:"strategy,omitempty" patchStrategy:"retainKeys" protobuf:"bytes,4,opt,name=strategy"`
vendor/k8s.io/api/apps/v1/types.go-     MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,5,opt,name=minReadySeconds"`
vendor/k8s.io/api/apps/v1/types.go-     RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,6,opt,name=revisionHistoryLimit"`
vendor/k8s.io/api/apps/v1/types.go-     Paused bool `json:"paused,omitempty" protobuf:"varint,7,opt,name=paused"`
vendor/k8s.io/api/apps/v1/types.go-     ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty" protobuf:"varint,9,opt,name=progressDeadlineSeconds"`
```

For `revisionHistoryLimit` and `progressDeadlineSeconds`, if the required manifest doesn't have an opinion and the existing in-cluster object does, I'm allowing the in-cluster value to persist.  That avoids having to teach the cluster-version operator about the current Kubernetes default values, and the chances that we need to stomp out a change from another actor like a confused administrator seems low.

Stomping `paused` to match the required manifest (which will almost certainly leave this property in its default `false`, otherwise updates would not work) will avoid [OCPBUGS-18567][1].  Still not clear to me why an admin would have wanted to [pause a an operator deployment][2], but automatically unpausing the deployment gives one less thing that might surprise folks during updates, and we'll log ourselves patching paused back to false if that stomping happens while we're in reconcile-mode.

[1]: https://issues.redhat.com/browse/OCPBUGS-18567
[2]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#pausing-and-resuming-a-deployment