### PR TITLE
OCPBUGS-20321: pkg/cvo/sync_worker: Always enable the DeploymentConfig capability

### DIFF
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -402,6 +402,12 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork,
 		if w.payload != nil {
 			implicitlyEnabledCaps = payload.GetImplicitlyEnabledCapabilities(payloadUpdate.Manifests, w.payload.Manifests,
 				work.Capabilities)
+			if strings.HasPrefix(payloadUpdate.Release.Version, "4.14.") {
+				deploymentConfig := configv1.ClusterVersionCapability("DeploymentConfig")
+				if _, ok := work.Capabilities.EnabledCapabilities[deploymentConfig]; !ok && !capability.Contains(implicitlyEnabledCaps, deploymentConfig) {
+					implicitlyEnabledCaps = append(implicitlyEnabledCaps, deploymentConfig)
+				}
+			}
 		}
 		w.payload = payloadUpdate
 		msg = fmt.Sprintf("Payload loaded version=%q image=%q architecture=%q", desired.Version, desired.Image,


### PR DESCRIPTION
The capability is new in 4.14, via openshift/api@d557f9784b (openshift/api#1462) and ba3aeb9ab9 (#950).  But as pointed out in [OCPBUGS-20321](https://issues.redhat.com/browse/OCPBUGS-20321), 4.14 releases do not declare any manifests as linked to the new capability:

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.14.0-rc.5-x86_64
Extracted release payload from digest sha256:042899f17f33259ed9f2cfc179930af283733455720f72ea3483fd1905f9b301 created at 2023-10-10T18:00:08Z
$ grep -ohr 'capability.openshift.io/name:.*' manifests | sort | uniq
capability.openshift.io/name: baremetal
capability.openshift.io/name: Console
capability.openshift.io/name: CSISnapshot
capability.openshift.io/name: ImageRegistry
capability.openshift.io/name: Insights
capability.openshift.io/name: MachineAPI
capability.openshift.io/name: marketplace
capability.openshift.io/name: NodeTuning
capability.openshift.io/name: openshift-samples
capability.openshift.io/name: Storage
```

That means our existing logic to compare reconciled-manifest requirements for detecting the need to implicitly enable capabilities breaks down.  In this commit, I'm teaching the outgoing 4.13 CVO that all 4.13 clusters have the `DeploymentConfig` capability enabled (even if it is not declared by a ClusterVersion capability in 4.13), so that capability needs to persist into 4.14 releases, to avoid surprising admins by dropping functionality.

Folks who do want to drop `DeploymentConfig` functionality will need to perform fresh installs with 4.14 or later, because [capabilities cannot be uninstalled][2].

[2]: https://github.com/openshift/enhancements/blob/d2edd51b600c5490eaa3650aac3b45a0bff5b3d5/enhancements/installer/component-selection.md#capabilities-cannot-be-uninstalled