### PR TITLE
OCPBUGS-20711: pkg/cvo/metrics: Disable HTTP/2

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -126,7 +126,8 @@ func createHttpServer() *http.Server {
 	handler := http.NewServeMux()
 	handler.Handle("/metrics", promhttp.Handler())
 	server := &http.Server{
-		Handler: handler,
+		Handler:      handler,
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){}, // disable HTTP/2
 	}
 	return server
 }


### PR DESCRIPTION
HTTP/2 is a good fit for some use-cases, but is unneccessary complication for our metrics server, which is only expected to have a single client in the local cluster's Prometheus scraper polling every 30 seconds or so.  Disabling HTTP/2 simplifies the server stack, and prevents exposure to CVE-2023-39325 and CVE-2023-44487, which [may not have been fully mitigated by recent Go-side fixes][1].  This also protects us against any future HTTP/2 vulnerabilities.

From [Go docs][2]:

> Starting with Go 1.6, the http package has transparent support for the HTTP/2 protocol when using HTTPS. Programs that must disable HTTP/2 can do so by setting `Transport.TLSNextProto` (for clients) or `Server.TLSNextProto` (for servers) to a non-nil, empty map.

[1]: https://github.com/golang/go/issues/63417#issuecomment-1758858612
[2]: https://pkg.go.dev/net/http#hdr-HTTP_2