### PR TITLE
OCPBUGS-24535: pkg/payload/precondition/clusterversion/rollback: Allow previous version within z-stream

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -947,7 +947,7 @@ func hasReachedLevel(cv *configv1.ClusterVersion, desired configv1.Update) bool 
 
 func (optr *Operator) defaultPreconditionChecks() precondition.List {
 	return []precondition.Precondition{
-		preconditioncv.NewRollback(optr.currentVersion),
+		preconditioncv.NewRollback(optr.cvLister),
 		preconditioncv.NewUpgradeable(optr.cvLister),
 		preconditioncv.NewRecommendedUpdate(optr.cvLister),
 	}

--- a/pkg/payload/precondition/clusterversion/rollback.go
+++ b/pkg/payload/precondition/clusterversion/rollback.go
@@ -5,41 +5,56 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
-	configv1 "github.com/openshift/api/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog/v2"
 
 	precondition "github.com/openshift/cluster-version-operator/pkg/payload/precondition"
 )
 
-// currentRelease is a callback for returning the version that is currently being reconciled.
-type currentRelease func() configv1.Release
-
 // Rollback blocks rollbacks from the version that is currently being reconciled.
 type Rollback struct {
-	currentRelease
+	key    string
+	lister configv1listers.ClusterVersionLister
 }
 
 // NewRollback returns a new Rollback precondition check.
-func NewRollback(fn currentRelease) *Rollback {
+func NewRollback(lister configv1listers.ClusterVersionLister) *Rollback {
 	return &Rollback{
-		currentRelease: fn,
+		key:    "version",
+		lister: lister,
 	}
 }
 
 // Name returns Name for the precondition.
-func (pf *Rollback) Name() string { return "ClusterVersionRollback" }
+func (p *Rollback) Name() string { return "ClusterVersionRollback" }
 
 // Run runs the Rollback precondition, blocking rollbacks from the
 // version that is currently being reconciled.  It returns a
 // PreconditionError when possible.
 func (p *Rollback) Run(ctx context.Context, releaseContext precondition.ReleaseContext) error {
-	currentRelease := p.currentRelease()
-	currentVersion, err := semver.Parse(currentRelease.Version)
+	cv, err := p.lister.Get(p.key)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return nil
+	}
 	if err != nil {
 		return &precondition.Error{
 			Nested:  err,
-			Reason:  "InvalidCurrentVersion",
+			Reason:  "UnknownError",
 			Message: err.Error(),
 			Name:    p.Name(),
+		}
+	}
+
+	currentVersion, err := semver.Parse(cv.Status.Desired.Version)
+	if err != nil {
+		return &precondition.Error{
+			Nested:             err,
+			Reason:             "InvalidCurrentVersion",
+			Message:            err.Error(),
+			Name:               p.Name(),
+			NonBlockingWarning: true, // do not block on issues that require an update to fix
 		}
 	}
 
@@ -54,9 +69,42 @@ func (p *Rollback) Run(ctx context.Context, releaseContext precondition.ReleaseC
 	}
 
 	if targetVersion.LT(currentVersion) {
+		var previousVersion *semver.Version
+		var previousImage string
+		for _, entry := range cv.Status.History {
+			if entry.Version != currentVersion.String() || entry.Image != cv.Status.Desired.Image {
+				version, err := semver.Parse(entry.Version)
+				if err != nil {
+					klog.Errorf("Precondition %q previous version %q invalid SemVer: %v", p.Name(), entry.Version, err)
+				} else {
+					previousVersion = &version
+					previousImage = entry.Image
+				}
+				break
+			}
+		}
+
+		if previousVersion != nil {
+			if !targetVersion.EQ(*previousVersion) {
+				return &precondition.Error{
+					Reason:  "LowDesiredVersion",
+					Message: fmt.Sprintf("%s is less than the current target %s, and the only supported rollback is to the cluster's previous version %s (%s)", targetVersion, currentVersion, *previousVersion, previousImage),
+					Name:    p.Name(),
+				}
+			}
+			if previousVersion.Major == currentVersion.Major && previousVersion.Minor == currentVersion.Minor {
+				klog.V(2).Infof("Precondition %q allows rollbacks from %s to the previous version %s within a z-stream", p.Name(), currentVersion, targetVersion)
+				return nil
+			}
+			return &precondition.Error{
+				Reason:  "LowDesiredVersion",
+				Message: fmt.Sprintf("%s is less than the current target %s and matches the cluster's previous version, but rollbacks that change major or minor versions are not recommended", targetVersion, currentVersion),
+				Name:    p.Name(),
+			}
+		}
 		return &precondition.Error{
 			Reason:  "LowDesiredVersion",
-			Message: fmt.Sprintf("%s is less than the current target %s, but rollbacks and downgrades are not recommended", targetVersion, currentVersion),
+			Message: fmt.Sprintf("%s is less than the current target %s, and the cluster has no previous Semantic Version", targetVersion, currentVersion),
 			Name:    p.Name(),
 		}
 	}

--- a/pkg/payload/precondition/clusterversion/rollback_test.go
+++ b/pkg/payload/precondition/clusterversion/rollback_test.go
@@ -13,40 +13,186 @@ func TestRollbackRun(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		currVersion    string
-		desiredVersion string
+		clusterVersion configv1.ClusterVersion
 		expected       string
 	}{
 		{
-			name:           "update",
-			currVersion:    "1.0.0",
-			desiredVersion: "1.0.1",
-			expected:       "",
+			name: "update",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.1",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "",
 		},
 		{
-			name:           "no change",
-			currVersion:    "1.0.0",
-			desiredVersion: "1.0.0",
-			expected:       "",
+			name: "no change",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "",
 		},
 		{
-			name:           "rollback",
-			currVersion:    "1.0.1",
-			desiredVersion: "1.0.0",
-			expected:       "1.0.0 is less than the current target 1.0.1, but rollbacks and downgrades are not recommended",
+			name: "rollback no history",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.1",
+					},
+				},
+			},
+			expected: "1.0.0 is less than the current target 1.0.1, and the cluster has no previous Semantic Version",
+		},
+		{
+			name: "rollback to previous in the same minor version",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.1",
+					},
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.1",
+						},
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "rollback to previous completed with intermediate partial",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.2",
+						Image:   "example.com/image:1.0.2",
+					},
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.PartialUpdate,
+							Version: "1.0.2",
+							Image:   "example.com/image:1.0.2",
+						},
+						{
+							State:   configv1.PartialUpdate,
+							Version: "1.0.1",
+							Image:   "example.com/image:1.0.1",
+						},
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.0",
+							Image:   "example.com/image:1.0.0",
+						},
+					},
+				},
+			},
+			expected: "1.0.0 is less than the current target 1.0.2, and the only supported rollback is to the cluster's previous version 1.0.1 (example.com/image:1.0.1)",
+		},
+		{
+			name: "rollback to previous completed with intermediate image change",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.1",
+						Image:   "example.com/image:multi-arch",
+					},
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.1",
+							Image:   "example.com/image:multi-arch",
+						},
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.1",
+							Image:   "example.com/image:single-arch",
+						},
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			expected: "1.0.0 is less than the current target 1.0.1, and the only supported rollback is to the cluster's previous version 1.0.1 (example.com/image:single-arch)",
+		},
+		{
+			name: "rollback to previous in an earlier minor release",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "2.0.0",
+					},
+					History: []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "2.0.0",
+						},
+						{
+							State:   configv1.CompletedUpdate,
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			expected: "1.0.0 is less than the current target 2.0.0 and matches the cluster's previous version, but rollbacks that change major or minor versions are not recommended",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			instance := NewRollback(func() configv1.Release {
-				return configv1.Release{
-					Version: tc.currVersion,
-				}
-			})
+			tc.clusterVersion.ObjectMeta.Name = "version"
+			cvLister := fakeClusterVersionLister(t, &tc.clusterVersion)
+			instance := NewRollback(cvLister)
 
 			err := instance.Run(ctx, precondition.ReleaseContext{
-				DesiredVersion: tc.desiredVersion,
+				DesiredVersion: tc.clusterVersion.Spec.DesiredUpdate.Version,
 			})
 			switch {
 			case err != nil && len(tc.expected) == 0:


### PR DESCRIPTION
From [OTA-553](https://issues.redhat.com/browse/OTA-553), Lala, Scott, and Subin all agreed that rollbacks to the cluster's previous release should not be blocked, as long as the previous and current version had the same `major.minor` version (i.e. "within a z-stream", using `x.y.z` naming for `major.minor.patch`). We agreed to ignore whether the previous history entry is `Completed` or `Partial`, expecting that most users who are interested in rolling back will make that decision at the first sign of trouble, and not after attempting a few roll-forward retargets.