### PR TITLE
OCPBUGS-25862: CO health: only track current in-progress upgrade start

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -44,13 +44,20 @@ func InitCOUpdateStartTimes() {
 	clusterOperatorUpdateStartTimes.lock.Unlock()
 }
 
-// COUpdateStartTimesEnsureName adds name to clusterOperatorUpdateStartTimes map and sets to
+// COUpdateStartTimesEnsure adds name to clusterOperatorUpdateStartTimes map and sets to
 // current time if name does not already exist in map.
-func COUpdateStartTimesEnsureName(name string) {
+func COUpdateStartTimesEnsure(name string) {
 	clusterOperatorUpdateStartTimes.lock.Lock()
 	if _, ok := clusterOperatorUpdateStartTimes.m[name]; !ok {
 		clusterOperatorUpdateStartTimes.m[name] = time.Now()
 	}
+	clusterOperatorUpdateStartTimes.lock.Unlock()
+}
+
+// COUpdateStartTimesRemove removes name from clusterOperatorUpdateStartTimes
+func COUpdateStartTimesRemove(name string) {
+	clusterOperatorUpdateStartTimes.lock.Lock()
+	delete(clusterOperatorUpdateStartTimes.m, name)
 	clusterOperatorUpdateStartTimes.lock.Unlock()
 }
 


### PR DESCRIPTION
Keeping the original upgrade start time may cause CVO spuriously warn about waiting on a CO for over 40 minutes, in a scenario like this:

1. CVO upgrades etcd / KAS very early in the upgrade, noting the time when it started to do that
2. These two COs upgrade successfully and upgrade proceeds
3. Eventually cluster starts rebooting masters and etcd/KAS go degraded
4. CVO compares current time against the noted time, discovers its more than 40 minutes and starts warning about it.
