### PR TITLE
OCPBUGS-26014: clusterOperatorBuilder: Reconcile metadata on COs

### DIFF
--- a/lib/resourcemerge/os.go
+++ b/lib/resourcemerge/os.go
@@ -3,40 +3,10 @@ package resourcemerge
 import (
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
-
-func EnsureClusterOperatorStatus(modified *bool, existing *configv1.ClusterOperator, required configv1.ClusterOperator) {
-	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
-	ensureClusterOperatorStatus(modified, &existing.Status, required.Status)
-}
-
-func ensureClusterOperatorStatus(modified *bool, existing *configv1.ClusterOperatorStatus, required configv1.ClusterOperatorStatus) {
-	if !equality.Semantic.DeepEqual(existing.Conditions, required.Conditions) {
-		*modified = true
-		existing.Conditions = required.Conditions
-	}
-
-	if !equality.Semantic.DeepEqual(existing.Versions, required.Versions) {
-		*modified = true
-		existing.Versions = required.Versions
-	}
-	if !equality.Semantic.DeepEqual(existing.Extension.Raw, required.Extension.Raw) {
-		*modified = true
-		existing.Extension.Raw = required.Extension.Raw
-	}
-	if !equality.Semantic.DeepEqual(existing.Extension.Object, required.Extension.Object) {
-		*modified = true
-		existing.Extension.Object = required.Extension.Object
-	}
-	if !equality.Semantic.DeepEqual(existing.RelatedObjects, required.RelatedObjects) {
-		*modified = true
-		existing.RelatedObjects = required.RelatedObjects
-	}
-}
 
 func SetOperatorStatusCondition(conditions *[]configv1.ClusterOperatorStatusCondition, newCondition configv1.ClusterOperatorStatusCondition) {
 	if conditions == nil {
@@ -86,10 +56,6 @@ func IsOperatorStatusConditionTrue(conditions []configv1.ClusterOperatorStatusCo
 	return IsOperatorStatusConditionPresentAndEqual(conditions, conditionType, configv1.ConditionTrue)
 }
 
-func IsOperatorStatusConditionFalse(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) bool {
-	return IsOperatorStatusConditionPresentAndEqual(conditions, conditionType, configv1.ConditionFalse)
-}
-
 func IsOperatorStatusConditionPresentAndEqual(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType, status configv1.ConditionStatus) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
@@ -97,18 +63,4 @@ func IsOperatorStatusConditionPresentAndEqual(conditions []configv1.ClusterOpera
 		}
 	}
 	return false
-}
-
-func IsOperatorStatusConditionNotIn(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType, status ...configv1.ConditionStatus) bool {
-	for _, condition := range conditions {
-		if condition.Type == conditionType {
-			for _, s := range status {
-				if s == condition.Status {
-					return false
-				}
-			}
-			return true
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Previously, COs were only precreated so once they existed, they never got any updates from the manifest, like annotations. Our future work relies on CO annotations to recognize platform COs from OLM-created ones but ancient clusters like build02 were created when COs were not annotated at all.
