### PR TITLE
OCPBUGS-7714: Refactor & improve SyncWorker lock code

### DIFF
--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -192,7 +192,7 @@ func Test_SyncWorker_apply(t *testing.T) {
 			}
 			worker.payload = up
 
-			err := worker.apply(ctx, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			err := worker.apply(ctx, &SyncWork{}, 1, worker.Status())
 			if !test.wantErr && err != nil {
 				t.Fatal(err)
 			}
@@ -411,7 +411,7 @@ func Test_SyncWorker_apply_generic(t *testing.T) {
 			}
 			worker.payload = up
 			ctx := context.Background()
-			err := worker.apply(ctx, &SyncWork{}, 1, &statusWrapper{w: worker, previousStatus: worker.Status()})
+			err := worker.apply(ctx, &SyncWork{}, 1, worker.Status())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -890,19 +890,22 @@ func (w *SyncWorker) apply(ctx context.Context, work *SyncWork, maxWorkers int, 
 	total := len(payloadUpdate.Manifests)
 	cr := &consistentReporter{
 		status: SyncWorkerStatus{
-			Generation:   work.Generation,
-			Initial:      work.State.Initializing(),
-			Reconciling:  work.State.Reconciling(),
-			VersionHash:  payloadUpdate.ManifestHash,
-			Architecture: w.status.Architecture,
-			Actual:       payloadUpdate.Release,
-			Verified:     payloadUpdate.VerifiedImage,
+			Generation:  work.Generation,
+			Initial:     work.State.Initializing(),
+			Reconciling: work.State.Reconciling(),
+			VersionHash: payloadUpdate.ManifestHash,
+			Actual:      payloadUpdate.Release,
+			Verified:    payloadUpdate.VerifiedImage,
 		},
 		completed: work.Completed,
 		version:   payloadUpdate.Release.Version,
 		total:     total,
 		reporter:  reporter,
 	}
+
+	w.lock.Lock()
+	cr.status.Architecture = w.status.Architecture
+	w.lock.Unlock()
 
 	var tasks []*payload.Task
 	backoff := w.backoff


### PR DESCRIPTION
Code refactors and cleanups that were previously part of https://github.com/openshift/cluster-version-operator/pull/1005, extracted to a separate PR because the actual OCPBUGS-7714 is possibly sensitive and we may want to review, discuss and investigate it (in the future) without the interference of the refactors.

Recommended to review per-commit.

- sync_worker.go: Refactor `calculateNext` and pull up lock
- sync_worker.go: add comments about lock assumptions
- sync_worker.go: lock access to w.status
- sync_worker.go: get rid of `StatusReporter` interface
- sync_worker.go: simplify `apply()` signature
- sync_worker.go: simplify `syncPayload` signature
