### PR TITLE
install/0000_00_cluster-version-operator_04_testing: Reproduce OCPBUGS-27822

### DIFF
--- a/install/0000_00_cluster-version-operator_04_testing.yaml
+++ b/install/0000_00_cluster-version-operator_04_testing.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: etcd
+  namespace: openshift-etcd
+spec: {}
+status:
+  versions:
+  - name: operator
+    version: 0.0.1-snapshot

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -504,6 +504,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 
 	// output cluster operator version and condition info
 	operators, _ := m.optr.coLister.List(labels.Everything())
+	now := time.Now()
 	for _, op := range operators {
 		var version string
 		for _, v := range op.Status.Versions {
@@ -525,6 +526,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 		}
 		g := m.clusterOperatorUp.WithLabelValues(op.Name, version, reason)
 		g.Set(isUp)
+		klog.V(2).Infof("HACK: round %s set cluster_operator_up for %q", now, op.Name)
 		ch <- g
 		for _, condition := range op.Status.Conditions {
 			if condition.Status != configv1.ConditionFalse && condition.Status != configv1.ConditionTrue {


### PR DESCRIPTION
Effectively reverting openshift/platform-operators#100 to reproduce the ClusterOperator-patching behavior that seems to trigger client-cache corruption in OCPBUGS-27822.

/hold