### PR TITLE
OTA-1159: [1/x] Refactor syncStatus for testability

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -811,18 +811,18 @@ func versionStringFromRelease(release configv1.Release) string {
 // are used as fallbacks for any properties not defined in the release
 // image itself.
 func (optr *Operator) currentVersion() configv1.Release {
-	return optr.mergeReleaseMetadata(optr.release)
+	return mergeReleaseMetadata(optr.release, optr.getAvailableUpdates)
 }
 
 // mergeReleaseMetadata returns a deep copy of the input release.
 // Values from any matching availableUpdates release are used as
 // fallbacks for any properties not defined in the input release.
-func (optr *Operator) mergeReleaseMetadata(release configv1.Release) configv1.Release {
+func mergeReleaseMetadata(release configv1.Release, getAvailableUpdates func() *availableUpdates) configv1.Release {
 	merged := *release.DeepCopy()
 
 	if merged.Version == "" || len(merged.URL) == 0 || merged.Channels == nil {
 		// only fill in missing values from availableUpdates, to avoid clobbering data from payload.LoadUpdate.
-		availableUpdates := optr.getAvailableUpdates()
+		availableUpdates := getAvailableUpdates()
 		if availableUpdates != nil {
 			var update *configv1.Release
 			if equalDigest(merged.Image, availableUpdates.Current.Image) {

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -4343,7 +4343,7 @@ func TestOperator_mergeReleaseMetadata(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			optr := Operator{availableUpdates: testCase.availableUpdates}
-			actual := optr.mergeReleaseMetadata(testCase.input)
+			actual := mergeReleaseMetadata(testCase.input, optr.getAvailableUpdates)
 			if !reflect.DeepEqual(actual, testCase.expected) {
 				t.Fatalf("unexpected: %s", diff.ObjectReflectDiff(testCase.expected, actual))
 			}

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -208,7 +208,10 @@ func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1
 	return err
 }
 
-func updateClusterVersionStatus(cvStatus *configv1.ClusterVersionStatus, status *SyncWorkerStatus, release configv1.Release, getAvailableUpdates func() *availableUpdates, validationErrs field.ErrorList) {
+// updateClusterVersionStatus updates the passed cvStatus with the latest status information
+func updateClusterVersionStatus(cvStatus *configv1.ClusterVersionStatus, status *SyncWorkerStatus,
+	release configv1.Release, getAvailableUpdates func() *availableUpdates, validationErrs field.ErrorList) {
+
 	cvStatus.ObservedGeneration = status.Generation
 	if len(status.VersionHash) > 0 {
 		cvStatus.VersionHash = status.VersionHash


### PR DESCRIPTION
updateClusterVersionStatus: add godoc and linewrap signature

---

status: work with `ClusterVersionStatus` instead of `ClusterVersion`
    
Status-computing methods can only read and modify `ClusterVersionStatus`
instead of `ClusterVersion`, resulting in simpler code and lower chance
of making a mistake.

---

status: uncouple `updateClusterVersionStatus` with `Operator`
    
`Operator` is a pretty beefy object with access to half of the universe, but `updateClusterVersionStatus` only uses its member very little. It reads its `release` member and calls its `getAvailableUpdates` method.
    
We can uncouple the long method by passing these two members as parameters. It is slightly awkward for the `getAvailableUpdates` method but I think the benefits outweight this.

---

status: extract status update logic to method
    
I would like to unit-test this logic but `syncStatus` does API operation so such tests would need a fake. Computing new status is enough logic to constitute a method, so we can extract it so that we can test it without a mock server.
    
Extracted with an IDE refactor helper.