### PR TITLE
OTA-1159: [3/3] Propagate reconciliation errors via ReconciliationIssues condition

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -681,7 +681,7 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 	// handle the case of a misconfigured CVO by doing nothing
 	if len(desired.Image) == 0 {
 		return optr.syncStatus(ctx, original, config, &SyncWorkerStatus{
-			Failure: &payload.UpdateError{
+			FailureSummary: &payload.UpdateError{
 				Reason:  "NoDesiredImage",
 				Message: "No configured operator version, unable to update cluster",
 			},

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -194,7 +194,7 @@ func TestOperator_sync(t *testing.T) {
 			syncStatus: &SyncWorkerStatus{
 				Reconciling: false,
 				Actual:      configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-				Failure: &payload.UpdateError{
+				FailureSummary: &payload.UpdateError{
 					Reason:  "UpdatePayloadIntegrity",
 					Message: "unable to apply object",
 				},
@@ -275,7 +275,7 @@ func TestOperator_sync(t *testing.T) {
 					Returns: &SyncWorkerStatus{
 						Reconciling: true,
 						Actual:      configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-						Failure: &payload.UpdateError{
+						FailureSummary: &payload.UpdateError{
 							Reason:  "UpdatePayloadIntegrity",
 							Message: "unable to apply object",
 						},
@@ -352,7 +352,7 @@ func TestOperator_sync(t *testing.T) {
 						Reconciling: true,
 						Completed:   2,
 						Actual:      configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-						Failure: &payload.UpdateError{
+						FailureSummary: &payload.UpdateError{
 							Reason:  "UpdatePayloadIntegrity",
 							Message: "unable to apply object",
 						},
@@ -426,9 +426,9 @@ func TestOperator_sync(t *testing.T) {
 				name:      "default",
 				configSync: &fakeSyncRecorder{
 					Returns: &SyncWorkerStatus{
-						Actual:      configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
-						Failure:     fmt.Errorf("injected error"),
-						VersionHash: "foo",
+						Actual:         configv1.Release{Version: "0.0.1-abc", Image: "image/image:v4.0.1"},
+						FailureSummary: fmt.Errorf("injected error"),
+						VersionHash:    "foo",
 					},
 				},
 				client: fake.NewSimpleClientset(
@@ -491,8 +491,8 @@ func TestOperator_sync(t *testing.T) {
 		{
 			name: "invalid image reports image error",
 			syncStatus: &SyncWorkerStatus{
-				Failure: os.ErrNotExist,
-				Actual:  configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
+				FailureSummary: os.ErrNotExist,
+				Actual:         configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
 			optr: &Operator{
 				release: configv1.Release{
@@ -546,10 +546,10 @@ func TestOperator_sync(t *testing.T) {
 		{
 			name: "invalid image while progressing preserves progressing order and partial history",
 			syncStatus: &SyncWorkerStatus{
-				Done:    600,
-				Total:   1000,
-				Failure: os.ErrNotExist,
-				Actual:  configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
+				Done:           600,
+				Total:          1000,
+				FailureSummary: os.ErrNotExist,
+				Actual:         configv1.Release{Image: "image/image:v4.0.1", Version: "4.0.1"},
 			},
 			optr: &Operator{
 				release: configv1.Release{

--- a/pkg/cvo/reconciliation_issues.go
+++ b/pkg/cvo/reconciliation_issues.go
@@ -1,13 +1,76 @@
 package cvo
 
-import v1 "github.com/openshift/api/config/v1"
+import (
+	"encoding/json"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-version-operator/pkg/payload"
+)
 
 const (
-	reconciliationIssuesConditionType v1.ClusterStatusConditionType = "ReconciliationIssues"
+	reconciliationIssuesConditionType configv1.ClusterStatusConditionType = "ReconciliationIssues"
 
 	noReconciliationIssuesReason  string = "NoIssues"
 	noReconciliationIssuesMessage string = "No issues found during reconciliation"
 
-	reconciliationIssuesFoundReason  string = "IssuesFound"
-	reconciliationIssuesFoundMessage string = "Issues found during reconciliation"
+	reconciliationIssuesFoundReason string = "IssuesFound"
 )
+
+type ReconciliationIssueUpdateError struct {
+	NestedMessage string `json:"nestedMessage,omitempty"`
+	Effect        string `json:"effect,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	PluralReason  string `json:"pluralReason,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Names         string `json:"names,omitempty"`
+
+	ManifestFilename string `json:"manifestFilename,omitempty"`
+	ResourceGroup    string `json:"manifestGroup,omitempty"`
+	ResourceVersion  string `json:"resourceVersion,omitempty"`
+	ResourceKind     string `json:"resourceKind,omitempty"`
+	ResourceSummary  string `json:"resourceSummary,omitempty"`
+}
+
+type ReconciliationIssueString struct {
+	Message string `json:"message"`
+}
+
+type ReconciliationIssue struct {
+	UpdateError *ReconciliationIssueUpdateError `json:"updateError,omitempty"`
+	SimpleError *ReconciliationIssueString      `json:"simpleError,omitempty"`
+}
+
+func reconciliationIssuesFromErrors(errs []error) string {
+	var reconciliationIssues []ReconciliationIssue
+	for _, err := range errs {
+		if updateError, ok := err.(*payload.UpdateError); ok {
+			reconciliationIssues = append(reconciliationIssues, ReconciliationIssue{
+				UpdateError: &ReconciliationIssueUpdateError{
+					NestedMessage:    updateError.Nested.Error(),
+					Effect:           string(updateError.UpdateEffect),
+					Reason:           updateError.Reason,
+					PluralReason:     updateError.PluralReason,
+					Message:          updateError.Message,
+					Name:             updateError.Name,
+					Names:            strings.Join(updateError.Names, ", "),
+					ManifestFilename: updateError.Task.Manifest.OriginalFilename,
+					ResourceGroup:    updateError.Task.Manifest.GVK.Group,
+					ResourceVersion:  updateError.Task.Manifest.GVK.Version,
+					ResourceKind:     updateError.Task.Manifest.GVK.Kind,
+				},
+			})
+		} else {
+			reconciliationIssues = append(reconciliationIssues, ReconciliationIssue{
+				SimpleError: &ReconciliationIssueString{
+					Message: err.Error(),
+				},
+			})
+		}
+	}
+	if raw, err := json.Marshal(reconciliationIssues); err == nil {
+		return string(raw)
+	}
+	return ""
+}

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -392,7 +392,11 @@ func updateClusterVersionStatus(cvStatus *configv1.ClusterVersionStatus, status 
 		if status.FailureSummary != nil {
 			riCondition.Status = configv1.ConditionTrue
 			riCondition.Reason = reconciliationIssuesFoundReason
-			riCondition.Message = fmt.Sprintf("%s: %s", reconciliationIssuesFoundMessage, status.FailureSummary.Error())
+			if len(status.Failures) == 0 { // this should not happen with non-nil FailureSummary but lets be defensive
+				riCondition.Message = reconciliationIssuesFromErrors([]error{status.FailureSummary})
+			} else {
+				riCondition.Message = reconciliationIssuesFromErrors(status.Failures)
+			}
 		}
 		resourcemerge.SetOperatorStatusCondition(&cvStatus.Conditions, riCondition)
 	} else if oldRiCondition != nil {

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -270,7 +270,7 @@ func TestUpdateClusterVersionStatus_UnknownVersionAndReconciliationIssues(t *tes
 			if tc.oldCondition != nil {
 				cvStatus.Conditions = append(cvStatus.Conditions, *tc.oldCondition)
 			}
-			updateClusterVersionStatus(&cvStatus, &SyncWorkerStatus{Failure: tc.failure}, release, getAvailableUpdates, gates, noErrors)
+			updateClusterVersionStatus(&cvStatus, &SyncWorkerStatus{FailureSummary: tc.failure}, release, getAvailableUpdates, gates, noErrors)
 			condition := resourcemerge.FindOperatorStatusCondition(cvStatus.Conditions, reconciliationIssuesConditionType)
 			if diff := cmp.Diff(tc.expectedRiCondition, condition, ignoreLastTransitionTime); diff != "" {
 				t.Errorf("unexpected condition\n:%s", diff)
@@ -306,7 +306,7 @@ func TestUpdateClusterVersionStatus_ReconciliationIssues(t *testing.T) {
 		{
 			name: "ReconciliationIssues present and unhappy when gate is enabled and failures happened",
 			syncWorkerStatus: SyncWorkerStatus{
-				Failure: fmt.Errorf("Something happened"),
+				FailureSummary: fmt.Errorf("Something happened"),
 			},
 			enabled: true,
 			expectedCondition: &configv1.ClusterOperatorStatusCondition{
@@ -319,7 +319,7 @@ func TestUpdateClusterVersionStatus_ReconciliationIssues(t *testing.T) {
 		{
 			name: "ReconciliationIssues not present when gate is enabled and failures happened",
 			syncWorkerStatus: SyncWorkerStatus{
-				Failure: fmt.Errorf("Something happened"),
+				FailureSummary: fmt.Errorf("Something happened"),
 			},
 			enabled:           false,
 			expectedCondition: nil,

--- a/pkg/cvo/sync_worker_test.go
+++ b/pkg/cvo/sync_worker_test.go
@@ -30,34 +30,34 @@ func Test_statusWrapper_ReportProgress(t *testing.T) {
 	}{
 		{
 			name:     "skip updates that clear an error and are at an earlier fraction",
-			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			previous: SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
 			next:     SyncWorkerStatus{Actual: configv1.Release{Image: "testing"}},
 			want:     false,
 		},
 		{
-			previous:     SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			previous:     SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
 			next:         SyncWorkerStatus{Actual: configv1.Release{Image: "testing2"}},
 			want:         true,
 			wantProgress: true,
 		},
 		{
-			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}},
+			previous: SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}},
 			next:     SyncWorkerStatus{Actual: configv1.Release{Image: "testing"}},
 			want:     true,
 		},
 		{
-			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
-			next:     SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}},
+			previous: SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			next:     SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}},
 			want:     true,
 		},
 		{
-			previous: SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
-			next:     SyncWorkerStatus{Failure: fmt.Errorf("b"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			previous: SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			next:     SyncWorkerStatus{FailureSummary: fmt.Errorf("b"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
 			want:     true,
 		},
 		{
-			previous:     SyncWorkerStatus{Failure: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
-			next:         SyncWorkerStatus{Failure: fmt.Errorf("b"), Actual: configv1.Release{Image: "testing"}, Done: 20, Total: 100},
+			previous:     SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Actual: configv1.Release{Image: "testing"}, Done: 10, Total: 100},
+			next:         SyncWorkerStatus{FailureSummary: fmt.Errorf("b"), Actual: configv1.Release{Image: "testing"}, Done: 20, Total: 100},
 			want:         true,
 			wantProgress: true,
 		},
@@ -169,21 +169,21 @@ func Test_runThrottledStatusNotifier(t *testing.T) {
 		t.Fatalf("should have not throttled")
 	}
 
-	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
+	in <- SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
 	select {
 	case <-out:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("should have not throttled")
 	}
 
-	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
+	in <- SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
 	select {
 	case <-out:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("should have not throttled")
 	}
 
-	in <- SyncWorkerStatus{Failure: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
+	in <- SyncWorkerStatus{FailureSummary: fmt.Errorf("a"), Reconciling: true, Actual: configv1.Release{Image: "test"}}
 	select {
 	case <-out:
 		t.Fatalf("should have throttled")


### PR DESCRIPTION
SyncWorkerStatus: Add Failures field with all failures

Previously, the errors that happened during reconciliation were flattened by `summarizeTaskGraphErrors` method call in `consistentReporter.Errors()` before they were sent to status reconciliation method `syncStatus`, which propagates this flattened error to the ClusterVersion status field.

Rename the `Failure` field to `FailureSummary`, it still caries the flattened error. Add a new `Failures` field to carry the full slice of the original errors.

The error processing is overall a bit weird because the errors get flattened first at the resource reconciling loop side, and then the status reporting loop side uses the flattened error to somehow reconstruct what actually happened, but cleaning up that code would be a much larger effort, so this commit simply makes original errors to be passed to status reporting loop. It is not easy to do all error processing at a single side; it would make sense to do that on status reporting level, but the initial flattening uses some task graph / resource reconciliation data that are not available on the status reporting side.

---

status sync: propagate reconciliation errors via RRI condition

Fulfilling [OTA-1159](https://issues.redhat.com//browse/OTA-1159), this change adds a JSON-serialized form of all reconciliation errors encountered during a single reconciliation loop run to the `Message` field of the `ReconciliationIssues`-type condition, present only when `ReconciliationIssuesCondition` feature gate is enabled (=in tech preview).