### PR TITLE
OTA-1210: *: Add --update-service command-line option

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -46,5 +46,6 @@ func init() {
 	cmd.PersistentFlags().BoolVar(&opts.PromQLTarget.UseDNS, "use-dns-for-services", opts.PromQLTarget.UseDNS, "Configures the CVO to use DNS for resolution of services in the cluster.")
 	cmd.PersistentFlags().StringVar(&opts.PrometheusURLString, "metrics-url", opts.PrometheusURLString, "The URL used to access the remote PromQL query service.")
 	cmd.PersistentFlags().BoolVar(&opts.InjectClusterIdIntoPromQL, "hypershift", opts.InjectClusterIdIntoPromQL, "This options indicates whether the CVO is running inside a hosted control plane.")
+	cmd.PersistentFlags().StringVar(&opts.UpdateService, "update-service", opts.UpdateService, "The preferred update service.  If set, this option overrides any upstream value configured in ClusterVersion spec.")
 	rootCmd.AddCommand(cmd)
 }

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -116,7 +116,7 @@ func newOperator(url, version string, promqlMock clusterconditions.Condition) (*
 	registry.Register("Always", &always.Always{})
 	registry.Register("PromQL", promqlMock)
 	operator := &Operator{
-		defaultUpstreamServer: url,
+		updateService:         url,
 		architecture:          "amd64",
 		proxyLister:           notFoundProxyLister{},
 		cmConfigManagedLister: notFoundConfigMapLister{},
@@ -149,6 +149,7 @@ func TestSyncAvailableUpdates(t *testing.T) {
 	fakeOsus, mockPromql, expectedConditionalUpdates, version := osusWithSingleConditionalEdge()
 	defer fakeOsus.Close()
 	expectedAvailableUpdates, optr := newOperator(fakeOsus.URL, version, mockPromql)
+	expectedAvailableUpdates.UpdateService = fakeOsus.URL
 	expectedAvailableUpdates.ConditionalUpdates = expectedConditionalUpdates
 	expectedAvailableUpdates.Channel = cvFixture.Spec.Channel
 	expectedAvailableUpdates.Condition = configv1.ClusterOperatorStatusCondition{

--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -454,7 +454,9 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 
 		if len(cv.Spec.Upstream) > 0 || len(cv.Status.AvailableUpdates) > 0 || resourcemerge.IsOperatorStatusConditionTrue(cv.Status.Conditions, configv1.RetrievedUpdates) {
 			upstream := "<default>"
-			if len(cv.Spec.Upstream) > 0 {
+			if len(m.optr.updateService) > 0 {
+				upstream = string(m.optr.updateService)
+			} else if len(cv.Spec.Upstream) > 0 {
 				upstream = string(cv.Spec.Upstream)
 			}
 			g := m.availableUpdates.WithLabelValues(upstream, cv.Spec.Channel)

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -66,6 +66,11 @@ type Options struct {
 	PromQLTarget              clusterconditions.PromQLTarget
 	InjectClusterIdIntoPromQL bool
 
+	// UpdateService configures the preferred update service.  If set,
+	// this option overrides any upstream value configured in ClusterVersion
+	// spec.
+	UpdateService string
+
 	// Exclude is used to determine whether to exclude
 	// certain manifests based on an annotation:
 	// exclude.release.openshift.io/<identifier>=true
@@ -509,6 +514,7 @@ func (o *Options) NewControllerContext(cb *ClientBuilder, startingFeatureSet str
 		o.ClusterProfile,
 		o.PromQLTarget,
 		o.InjectClusterIdIntoPromQL,
+		o.UpdateService,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[XCMSTRAT-513](https://issues.redhat.com/browse/XCMSTRAT-513) includes [OTA-1185](https://issues.redhat.com/browse/OTA-1185) pitching local update services in managed regions. However, HyperShift [currently][3] forces ClusterVersion `spec.upstream` empty.  This commit is part of making the upstream update service configurable on HyperShift, so those clusters can hear about and assess known issues with updates in environments where the default https://api.openshift.com/api/upgrades_info update service is not accessible, or in which an alternative update service was desired for testing or policy reasons. This includes [OTA-1185](https://issues.redhat.com/browse/OTA-1185), mentioned above, but would also include any other instance of disconnected/restricted-network use. The alternative for folks who want HyperShift updates in places where api.openshift.com is inaccessible are:

* Don't use an update service and manage that aspect manually.  But the update service declares multiple new releases each week, as well as delivering information about known risks/issues for local clusters to evalute their exposure.  That's a lot of information to manage manually, if folks decide not to plug into the existing update service tooling.
* Run a local update service, and fiddle with DNS and X.509 certs so that packets aimed at api.openshift.com get routed to your local service . This one requires less long-term effort than manually replacing the entire update service system, but it requires your clusters to trust an X.509 Certificate Authority that is willing to sign certificates for your local service saying "yup, that one is definitely api.openshift.com".

One possible data path would be:

1. HostedCluster (management cluster).
2. HostedControlPlane (management cluster).
3. ClusterVersion `spec.upstream` (hosted API).
4. Cluster-version operator container (managment cluster).

that pathway would only require changes to the HyperShift repo.  But to avoid URI passing through the customer-accessible hosted API, this commit adds a new `--upstream` command-line option to support:

1. HostedCluster (management cluster).
2. HostedControlPlane (management cluster).
3. Cluster-version operator Deployment `--upstream` command line option (management cluster).
4. Cluster-version operator container (managment cluster).

If, in the future, we grow an option to give the hosted CVO kubeconfig access to both the management and hosted Kubernetes APIs, we could drop `--upstream` and have the hosted CVO reach out and read this configuration off HostedControlPlane or HostedCluster directly.

[1]: 
[2]: 
[3]: https://github.com/openshift/hypershift/blob/5e50e633fefd88aab9588d660c4b5daddd950d9a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go#L1059