### PR TITLE
OCPBUGS-33984: Add admin-gate for OCP 4.16

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -1,5 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
+data:
+  ack-4.15-kube-1.29-api-removals-in-4.16: |-
+      Kubernetes 1.29 and therefore OpenShift 4.16 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/7031404 for details and instructions.
 metadata:
   name: admin-gates
   namespace: openshift-config-managed


### PR DESCRIPTION
Add admin-gate ack-4.15-kube-1.29-api-removals-in-4.16

Require the admin ack for updating to next version of OpenShift