### PR TITLE
OCPBUGS-15200: Filter out shallowly `UpdateEffectNone` errors from a `MultipleErrors` message in the Failing condition

### DIFF
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -3568,7 +3568,7 @@ func TestCVO_ParallelError(t *testing.T) {
 		},
 		"0000_20_a_file.yaml": nil,
 		"0000_20_b_file.yaml": &payload.UpdateError{
-			UpdateEffect: payload.UpdateEffectNone,
+			UpdateEffect: payload.UpdateEffectFail,
 			Message:      "Failed to reconcile 20-b-file resource",
 		},
 	}}
@@ -3753,7 +3753,7 @@ func TestCVO_ParallelError(t *testing.T) {
 				{Type: DesiredReleaseAccepted, Status: configv1.ConditionTrue, Reason: "PayloadLoaded",
 					Message: "Payload loaded version=\"1.0.0-abc\" image=\"image/image:1\" architecture=\"" + architecture + "\""},
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
-				{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "MultipleErrors", Message: "Multiple errors are preventing progress:\n* Failed to reconcile 10-a-file resource\n* Failed to reconcile 20-b-file resource"},
+				{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Message: "Failed to reconcile 20-b-file resource"},
 				{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "MultipleErrors", Message: "Unable to apply 1.0.0-abc: an unknown error has occurred: MultipleErrors"},
 				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
 			},


### PR DESCRIPTION
Various errors get propagated to users, such as the summarized task
graph error. For example, in the form of the message in the Failing
condition. However, update errors set with the update effect of
`UpdateEffectNone` can confuse users, as these primarily informing
messages get displayed together with valid update errors that heavily
impact the update. This can result in a message such as:

```
{
  "lastTransitionTime": "2023-06-20T13:40:12Z",
  "message": "Multiple errors are preventing progress:\n* Cluster
  operator authentication is updating versions\n* Could not update
  customresourcedefinition \"alertingrules.monitoring.openshift.io\"
  (512 of 993): the object is invalid, possibly due to local cluster
  configuration",
  "reason": "MultipleErrors",
  "status": "True",
  "type": "Failing"
}
```

The Failing condition is not true because of the `UpdateEffectNone`
error (`"Cluster operator authentication is updating versions"`), but
its message still gets displayed.

This PR makes sure that update errors that do not heavily affect
the update will be removed from the Failing condition message to an
extent.

This pull request references https://issues.redhat.com/browse/OCPBUGS-15200