### PR TITLE
Revert "OCPBUGS-34287: Updating cluster-version-operator-container image to be consistent with ART for 4.17"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.21-openshift-4.16

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
     cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator
 
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_* /manifests/

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/cluster-version-operator
 
-go 1.22
+go 1.21
 
-toolchain go1.22.1
+toolchain go1.21.6
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#1047

Might be leading to failures like:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-fips/1800906552731766784/artifacts/e2e-aws-ovn-fips/ipi-install-install/artifacts/log-bundle-20240612161314.tar | tar -tvz | grep 'cluster-version.*log'
-rw-r--r-- core/core     54653 2024-06-12 09:13 log-bundle-20240612161314/bootstrap/containers/cluster-version-operator-bd9f61984afa844dcd284f68006ffc9548377c045eff840096c74bcdcbe5cca3.log
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-fips/1800906552731766784/artifacts/e2e-aws-ovn-fips/ipi-install-install/artifacts/log-bundle-20240612161314.tar | tar -xOz log-bundle-20240612161314/bootstrap/containers/cluster-version-operator-bd9f61984afa844dcd284f68006ffc9548377c045eff840096c74bcdcbe5cca3.log | grep GPG
I0612 16:06:15.952567       1 start.go:256] Failed to initialize from payload; shutting down: the config map openshift-config-managed/release-verification has an invalid key "verifier-public-key-redhat" that must be a GPG public key: openpgp: invalid data: tag byte does not have MSB set: openpgp: invalid data: tag byte does not have MSB set
E0612 16:06:15.952600       1 start.go:309] Collected payload initialization goroutine: the config map openshift-config-managed/release-verification has an invalid key "verifier-public-key-redhat" that must be a GPG public key: openpgp: invalid data: tag byte does not have MSB set: openpgp: invalid data: tag byte does not have MSB set
```

Although that's a nightly run, and this pull should only affect CI builds?  But hey, open pulls are cheap.  Hold for testing:

/hold