### PR TITLE
OTA-1301: WIP: pkg/cincinnati: Set DifferentChannel risk

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2614,9 +2614,9 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				fmt.Fprintf(w, `
 				{
 					"nodes": [
-						{"version":"4.0.1",            "payload": "image/image:v4.0.1"},
-						{"version":"4.0.2-prerelease", "payload": "some.other.registry/image/image:v4.0.2"},
-						{"version":"4.0.2",            "payload": "image/image:v4.0.2"}
+						{"version":"4.0.1",            "payload": "image/image:v4.0.1",                     "metadata": {"io.openshift.upgrades.graph.release.channels": "fast"}},
+						{"version":"4.0.2-prerelease", "payload": "some.other.registry/image/image:v4.0.2", "metadata": {"io.openshift.upgrades.graph.release.channels": "fast"}},
+						{"version":"4.0.2",            "payload": "image/image:v4.0.2",                     "metadata": {"io.openshift.upgrades.graph.release.channels": "fast"}}
 					],
 					"edges": [
 						[0, 1],
@@ -2663,10 +2663,10 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
 				Architecture:  "amd64",
-				Current:       configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
+				Current:       configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1", Channels: []string{"fast"}},
 				Updates: []configv1.Release{
-					{Version: "4.0.2", Image: "image/image:v4.0.2"},
-					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2"},
+					{Version: "4.0.2", Image: "image/image:v4.0.2", Channels: []string{"fast"}},
+					{Version: "4.0.2-prerelease", Image: "some.other.registry/image/image:v4.0.2", Channels: []string{"fast"}},
 				},
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:   configv1.RetrievedUpdates,


### PR DESCRIPTION
The CVO currently had been assuming all the releases in an Update Service response belong to the currently-configured channel.  With this commit, the CVO begins walking retrieved Releases and injecting a DifferentChannel conditional update risk if the current channel is not a member of the Release's channels set.  This will allow the CVO to be pointed at an Update Service returning all known (or all supported) next-hop updates, regardless of their current channel, which would make it easier for cluster administrators to self-serve answers like "why don't I see updates to 4.y.z in `stable-4.y`?" with "oh, because that target is only in `candidate-4.y` and `fast-4.y` so far".