### PR TITLE
[release-4.15] OCPBUGS-36817: Set required-scc for openshift workloads

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -18,6 +18,7 @@ spec:
       name: cluster-version-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: hostaccess
       labels:
         k8s-app: cluster-version-operator
     spec:


### PR DESCRIPTION
[OCPBUGS-36817](https://issues.redhat.com/browse/OCPBUGS-36817)

Manual cherry-pick of [#1038](https://github.com/openshift/cluster-version-operator/pull/1038)