### PR TITLE
OCPBUGS-37770: pkg/payload/render: Include release image (Cluster)ImagePolicy

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -169,9 +169,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 				continue
 			}
 
-			switch filepath.Ext(file.Name()) {
-			case ".yaml", ".yml", ".json":
-			default:
+			if !hasManifestExtension(file.Name()) {
 				continue
 			}
 
@@ -436,4 +434,13 @@ func loadImageReferences(releaseDir string) (*imagev1.ImageStream, error) {
 		return imageRef, nil
 	}
 	return nil, fmt.Errorf("%s is a %T, not a v1 ImageStream", imageReferencesFile, imageRefObj)
+}
+
+func hasManifestExtension(filename string) bool {
+	switch filepath.Ext(filename) {
+	case ".yaml", ".yml", ".json":
+		return true
+	default:
+		return false
+	}
 }

--- a/vendor/github.com/openshift/api/config/.codegen.yaml
+++ b/vendor/github.com/openshift/api/config/.codegen.yaml
@@ -1,0 +1,2 @@
+swaggerdocs:
+  commentPolicy: Warn

--- a/vendor/github.com/openshift/api/config/install.go
+++ b/vendor/github.com/openshift/api/config/install.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+)
+
+const (
+	GroupName = "config.openshift.io"
+)
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(configv1.Install, configv1alpha1.Install)
+	// Install is a function which adds every version of this group to a scheme
+	Install = schemeBuilder.AddToScheme
+)
+
+func Resource(resource string) schema.GroupResource {
+	return schema.GroupResource{Group: GroupName, Resource: resource}
+}
+
+func Kind(kind string) schema.GroupKind {
+	return schema.GroupKind{Group: GroupName, Kind: kind}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,6 +106,7 @@ github.com/munnerz/goautoneg
 github.com/mwitkow/go-conntrack
 # github.com/openshift/api v0.0.0-20240709002213-329ea3755649
 ## explicit; go 1.22.0
+github.com/openshift/api/config
 github.com/openshift/api/config/v1
 github.com/openshift/api/config/v1/zz_generated.crd-manifests
 github.com/openshift/api/config/v1alpha1


### PR DESCRIPTION
Address [OCPBUGS-37770][1], where a ClusterImagePolicy manifest from the `cluster-update-keys` repository (openshift/cluster-update-keys#58) was not part of the bootstrap-rendered MachineConfigs, but was part of the production MachineConfigs.  That kind of skew causes trouble for the machine-config operator, as in [this run][2]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-api-provider-aws/519/pull-ci-openshift-cluster-api-provider-aws-master-e2e-aws-ovn-techpreview/1818614625273384960/artifacts/e2e-aws-ovn-techpreview/gather-extra/artifacts/machineconfigpools.json | jq -r '.items[0].status.conditions[] | select(.type == "NodeDegraded").message'
Node ip-10-0-107-110.us-east-2.compute.internal is reporting: "missing MachineConfig rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\nmachineconfig.machineconfiguration.openshift.io \"rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\" not found", Node ip-10-0-20-34.us-east-2.compute.internal is reporting: "missing MachineConfig rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\nmachineconfig.machineconfiguration.openshift.io \"rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\" not found", Node ip-10-0-47-251.us-east-2.compute.internal is reporting: "missing MachineConfig rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\nmachineconfig.machineconfiguration.openshift.io \"rendered-master-f78e8c7637cfbc6ca42f0f102eaef4e7\" not found"
```

To address that, this commit renders any ClusterImagePolicy and ImagePolicy manifests from the release image into the output manifests directory.  From there:

1. The installer's bootkube service [puts the manifest into the central manifests directory][3]:

    ```sh
    cp cvo-bootstrap/manifests/* manifests/
    ```
    
2. The installer's bootkube service [puts the manifest into into the machine-config controller's manifest directory][4]:

    ```sh
    cp manifests/* /etc/mcc/bootstrap/
    ```

3. The MCO renders a static MCO bootstrap pod YAML file [with `--manifest-dir=/etc/mcc/bootstrap/`][5] to configure a `manifestDir` variable.

4. The installer's bootkube service [passes the rendered static MCO bootstrap pod to the kubelet][6]:

    ```sh
    cp mco-bootstrap/bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
    ```
    
5. The bootstrap MCO static pod [pulls in the ClusterImagePolicy manifest while walking `manifestDir`][7].

6. The bootstrap MCO static pod [includes feature-gate status and any collected ClusterImagePolicy manifest when rendering bootstrap MachineConfigs][8].

My implementation uses group/kind tuples to figure out what needs rendering, because that is robust against things like manifest renames or other release-image-referenced repositories providing their own manifests (using manifest names in `skipFiles` is ok, because all the manifests we skip that way are from our own repository, where we control naming).

We could extend this to other manifest types that the MCO consumes when rendering MachineConfigs (MachineConfig itself, KubeletConfig, etc.), but I'm leaving those out for now in the optimistic hope that nobody ever needs the CVO to manage those resources.

[1]: https://issues.redhat.com/browse/OCPBUGS-37770
[2]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-api-provider-aws/519/pull-ci-openshift-cluster-api-provider-aws-master-e2e-aws-ovn-techpreview/1818614625273384960
[3]: https://github.com/openshift/installer/blob/e9c454889b638a9af3e1203d0585c756f8cf0136/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L165
[4]: https://github.com/openshift/installer/blob/e9c454889b638a9af3e1203d0585c756f8cf0136/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L431
[5]: https://github.com/openshift/machine-config-operator/blob/d72d2ed139de8f8d3c60c411b4741045edde2a34/manifests/bootstrap-pod-v2.yaml#L15
[6]: https://github.com/openshift/installer/blob/e9c454889b638a9af3e1203d0585c756f8cf0136/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L433
[7]: https://github.com/openshift/machine-config-operator/blob/d72d2ed139de8f8d3c60c411b4741045edde2a34/pkg/controller/bootstrap/bootstrap.go#L100-L142
[8]: https://github.com/openshift/machine-config-operator/blob/d72d2ed139de8f8d3c60c411b4741045edde2a34/pkg/controller/bootstrap/bootstrap.go#L183