### PR TITLE
OCPBUGS-37770: cmd/render: Add --feature-gate-manifest-path option

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -19,8 +19,9 @@ var (
 	}
 
 	renderOpts struct {
-		releaseImage string
-		outputDir    string
+		releaseImage            string
+		featureGateManifestPath string
+		outputDir               string
 	}
 )
 
@@ -28,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(renderCmd)
 	renderCmd.PersistentFlags().StringVar(&renderOpts.outputDir, "output-dir", "", "The output directory where the manifests will be rendered.")
 	renderCmd.PersistentFlags().StringVar(&renderOpts.releaseImage, "release-image", "", "The Openshift release image url.")
+	renderCmd.PersistentFlags().StringVar(&renderOpts.featureGateManifestPath, "feature-gate-manifest-path", "", "FeatureGate manifest input path.")
 }
 
 func runRenderCmd(cmd *cobra.Command, args []string) {
@@ -40,7 +42,7 @@ func runRenderCmd(cmd *cobra.Command, args []string) {
 	if renderOpts.releaseImage == "" {
 		klog.Fatalf("missing --release-image flag, it is required")
 	}
-	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, clusterProfile()); err != nil {
+	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, renderOpts.featureGateManifestPath, clusterProfile()); err != nil {
 		klog.Fatalf("Render command failed: %v", err)
 	}
 }


### PR DESCRIPTION
455abd6acc (#1076) taught the `render` command to extract (Cluster)ImagePolicy manifests so the bootstrap machine-config controller could consume them.  That got the cluster-update-keys ClusterImagePolicy manifest working on `TechPreviewNoUpgrade` installs, because that feature-set needs the manifest to get into the boostrap MCC to avoid "missing MachineConfig `rendered-...`" hash mismatches.

But the ClusterImagePolicy manifest and CustomResourceDefinition are currently feature-gated, so the boostrap ClusterImagePolicy render broke default feature-set installs, [like][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-update-keys/60/pull-ci-openshift-cluster-update-keys-master-e2e-aws/1821360664451485696/artifacts/e2e-aws/ipi-install-install/artifacts/log-bundle-20240808024008.tar | tar -xOz log-bundle-20240808024008/bootstrap/journals/bootkube.log | grep 'no matches for kind' | tail -n2
Aug 08 02:40:14 ip-10-0-169-200 cluster-bootstrap[4584]: "0000_90_openshift-cluster-image-policy.yaml": unable to get REST mapping for "0000_90_openshift-cluster-image-policy.yaml": no matches for kind "ClusterImagePolicy" in version "config.openshift.io/v1alpha1"
Aug 08 02:40:14 ip-10-0-169-200 bootkube.sh[4548]: "0000_90_openshift-cluster-image-policy.yaml": unable to get REST mapping for "0000_90_openshift-cluster-image-policy.yaml": no matches for kind "ClusterImagePolicy" in version "config.openshift.io/v1alpha1"
```

With this commit's new `--feature-gate-manifest-path`, the installer will be able to update [the CVO render call][2] to point at [its FeatureGate manifest][3].

I'm cutting some corners here (more of this render processing could use `Manifest.Include` filtering), but I'm in a hurry to get things set up in the hopes of beating the 4.17 branch cut.  I think this might be a sufficient change, and we can polish the development branch up more post-branch.

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-update-keys/60/pull-ci-openshift-cluster-update-keys-master-e2e-aws/1821360664451485696
[2]: https://github.com/openshift/installer/blob/fe126cafe857fa5e4e7f88a2134a19ae2f089b85/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L164-L166
[3]: https://github.com/openshift/installer/blob/fe126cafe857fa5e4e7f88a2134a19ae2f089b85/pkg/asset/manifests/featuregate.go#L17