### PR TITLE
OCPBUGS-41642: vendor: Update openshift/api to pick up the v4.17 capability sets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.0
-	github.com/openshift/api v0.0.0-20240709002213-329ea3755649
+	github.com/openshift/api v0.0.0-20240912201240-0a8800162826
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
 	github.com/openshift/library-go v0.0.0-20240709182732-b94141242b0c
 	github.com/operator-framework/api v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY
 github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
 github.com/onsi/gomega v1.31.0 h1:54UJxxj6cPInHS3a35wm6BK/F9nHYueZ1NVujHDrnXE=
 github.com/onsi/gomega v1.31.0/go.mod h1:DW9aCi7U6Yi40wNVAvT6kzFnEVEI5n3DloYBiKiT6zk=
-github.com/openshift/api v0.0.0-20240709002213-329ea3755649 h1:SNRfdvELziNiUypTjDGz4L48Zg/pwpXB/Ktj1KiG210=
-github.com/openshift/api v0.0.0-20240709002213-329ea3755649/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
+github.com/openshift/api v0.0.0-20240912201240-0a8800162826 h1:A8D9SN/hJUwAbdO0rPCVTqmuBOctdgurr53gK701SYo=
+github.com/openshift/api v0.0.0-20240912201240-0a8800162826/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
 github.com/openshift/library-go v0.0.0-20240709182732-b94141242b0c h1:J79MQ2jYap7l9ugCosp73mIcb6PNcXeczINlyfGC7XA=

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
@@ -428,7 +428,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;v4.16;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;v4.16;v4.17;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -471,6 +471,12 @@ const (
 	// OpenShift.  This list will remain the same no matter which
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_16 ClusterVersionCapabilitySet = "v4.16"
+
+	// ClusterVersionCapabilitySet4_17 is the recommended set of
+	// optional capabilities to enable for the 4.17 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_17 ClusterVersionCapabilitySet = "v4.17"
 
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
@@ -539,6 +545,24 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityCloudCredential,
 	},
 	ClusterVersionCapabilitySet4_16: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
+		ClusterVersionCapabilityCloudCredential,
+		ClusterVersionCapabilityIngress,
+		ClusterVersionCapabilityCloudControllerManager,
+	},
+	ClusterVersionCapabilitySet4_17: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
 		ClusterVersionCapabilityInsights,

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -68,6 +68,7 @@ type FeatureGateSelection struct {
 	// Turning on or off features may cause irreversible changes in your cluster which cannot be undone.
 	// +unionDiscriminator
 	// +optional
+	// +kubebuilder:validation:Enum=CustomNoUpgrade;DevPreviewNoUpgrade;TechPreviewNoUpgrade;""
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'CustomNoUpgrade' ? self == 'CustomNoUpgrade' : true",message="CustomNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'TechPreviewNoUpgrade' ? self == 'TechPreviewNoUpgrade' : true",message="TechPreviewNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'DevPreviewNoUpgrade' ? self == 'DevPreviewNoUpgrade' : true",message="DevPreviewNoUpgrade may not be changed"

--- a/vendor/github.com/openshift/api/config/v1/types_network.go
+++ b/vendor/github.com/openshift/api/config/v1/types_network.go
@@ -55,11 +55,11 @@ type NetworkSpec struct {
 	// +listType=atomic
 	ServiceNetwork []string `json:"serviceNetwork"`
 
-	// NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN).
+	// NetworkType is the plugin that is to be deployed (e.g. OVNKubernetes).
 	// This should match a value that the cluster-network-operator understands,
 	// or else no networking will be installed.
 	// Currently supported values are:
-	// - OpenShiftSDN
+	// - OVNKubernetes
 	// This field is immutable after installation.
 	NetworkType string `json:"networkType"`
 
@@ -101,7 +101,7 @@ type NetworkStatus struct {
 	// +listType=atomic
 	ServiceNetwork []string `json:"serviceNetwork,omitempty"`
 
-	// NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+	// NetworkType is the plugin that is deployed (e.g. OVNKubernetes).
 	NetworkType string `json:"networkType,omitempty"`
 
 	// ClusterNetworkMTU is the MTU for inter-pod networking.
@@ -111,15 +111,12 @@ type NetworkStatus struct {
 	Migration *NetworkMigration `json:"migration,omitempty"`
 
 	// conditions represents the observations of a network.config current state.
-	// Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady",
-	// "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse",
-	// "NetworkTypeMigrationOriginalCNIPurged" and "NetworkDiagnosticsAvailable"
+	// Known .status.conditions.type are: "NetworkDiagnosticsAvailable"
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	// +openshift:enable:FeatureGate=NetworkLiveMigration
 	// +openshift:enable:FeatureGate=NetworkDiagnosticsConfig
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
@@ -186,15 +183,15 @@ type NetworkList struct {
 	Items []Network `json:"items"`
 }
 
-// NetworkMigration represents the cluster network configuration.
+// NetworkMigration represents the network migration status.
 type NetworkMigration struct {
-	// NetworkType is the target plugin that is to be deployed.
-	// Currently supported values are: OpenShiftSDN, OVNKubernetes
-	// +kubebuilder:validation:Enum={"OpenShiftSDN","OVNKubernetes"}
+	// NetworkType is the target plugin that is being deployed.
+	// DEPRECATED: network type migration is no longer supported,
+	// so this should always be unset.
 	// +optional
 	NetworkType string `json:"networkType,omitempty"`
 
-	// MTU contains the MTU migration configuration.
+	// MTU is the MTU configuration that is being deployed.
 	// +optional
 	MTU *MTUMigration `json:"mtu,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
@@ -73,6 +73,11 @@ spec:
                   default is empty.  Be very careful adjusting this setting. Turning
                   on or off features may cause irreversible changes in your cluster
                   which cannot be undone.
+                enum:
+                - CustomNoUpgrade
+                - DevPreviewNoUpgrade
+                - TechPreviewNoUpgrade
+                - ""
                 type: string
                 x-kubernetes-validations:
                 - message: CustomNoUpgrade may not be changed

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1378,7 +1378,124 @@ spec:
                         description: region holds the region for new GCP resources
                           created for the cluster.
                         type: string
+                      resourceLabels:
+                        description: resourceLabels is a list of additional labels
+                          to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources
+                          for information on labeling GCP resources. GCP supports
+                          a maximum of 64 labels per resource. OpenShift reserves
+                          32 labels for internal use, allowing 32 labels for user
+                          configuration.
+                        items:
+                          description: GCPResourceLabel is a label to apply to GCP
+                            resources created for the cluster.
+                          properties:
+                            key:
+                              description: key is the key part of the label. A label
+                                key can have a maximum of 63 characters and cannot
+                                be empty. Label key must begin with a lowercase letter,
+                                and must contain only lowercase letters, numeric characters,
+                                and the following special characters `_-`. Label key
+                                must not have the reserved prefixes `kubernetes-io`
+                                and `openshift-io`.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z][0-9a-z_-]{0,62}$
+                              type: string
+                              x-kubernetes-validations:
+                              - message: label keys must not start with either `openshift-io`
+                                  or `kubernetes-io`
+                                rule: '!self.startsWith(''openshift-io'') && !self.startsWith(''kubernetes-io'')'
+                            value:
+                              description: value is the value part of the label. A
+                                label value can have a maximum of 63 characters and
+                                cannot be empty. Value must contain only lowercase
+                                letters, numeric characters, and the following special
+                                characters `_-`.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[0-9a-z_-]{1,63}$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: resourceLabels are immutable and may only be configured
+                            during installation
+                          rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      resourceTags:
+                        description: resourceTags is a list of additional tags to
+                          apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview
+                          for information on tagging GCP resources. GCP supports a
+                          maximum of 50 tags per resource.
+                        items:
+                          description: GCPResourceTag is a tag to apply to GCP resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: key is the key part of the tag. A tag key
+                                can have a maximum of 63 characters and cannot be
+                                empty. Tag key must begin and end with an alphanumeric
+                                character, and must contain only uppercase, lowercase
+                                alphanumeric characters, and the following special
+                                characters `._-`.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                              type: string
+                            parentID:
+                              description: 'parentID is the ID of the hierarchical
+                                resource where the tags are defined, e.g. at the Organization
+                                or the Project level. To find the Organization or
+                                Project ID refer to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id,
+                                https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects.
+                                An OrganizationID must consist of decimal numbers,
+                                and cannot have leading zeroes. A ProjectID must be
+                                6 to 30 characters in length, can only contain lowercase
+                                letters, numbers, and hyphens, and must start with
+                                a letter, and cannot end with a hyphen.'
+                              maxLength: 32
+                              minLength: 1
+                              pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                              type: string
+                            value:
+                              description: value is the value part of the tag. A tag
+                                value can have a maximum of 63 characters and cannot
+                                be empty. Tag value must begin and end with an alphanumeric
+                                character, and must contain only uppercase, lowercase
+                                alphanumeric characters, and the following special
+                                characters `_-.@%=+:,*#&(){}[]` and spaces.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                              type: string
+                          required:
+                          - key
+                          - parentID
+                          - value
+                          type: object
+                        maxItems: 50
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: resourceTags are immutable and may only be configured
+                            during installation
+                          rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
                     type: object
+                    x-kubernetes-validations:
+                    - message: resourceLabels may only be configured during installation
+                      rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels)
+                        || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                    - message: resourceTags may only be configured during installation
+                      rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                        || has(oldSelf.resourceTags) && has(self.resourceTags)'
                   ibmcloud:
                     description: IBMCloud contains settings specific to the IBMCloud
                       infrastructure provider.

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks.crd.yaml
@@ -248,9 +248,9 @@ spec:
                 type: object
               networkType:
                 description: 'NetworkType is the plugin that is to be deployed (e.g.
-                  OpenShiftSDN). This should match a value that the cluster-network-operator
+                  OVNKubernetes). This should match a value that the cluster-network-operator
                   understands, or else no networking will be installed. Currently
-                  supported values are: - OpenShiftSDN This field is immutable after
+                  supported values are: - OVNKubernetes This field is immutable after
                   installation.'
                 type: string
               serviceNetwork:
@@ -303,10 +303,7 @@ spec:
                 type: integer
               conditions:
                 description: 'conditions represents the observations of a network.config
-                  current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress",
-                  "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable",
-                  "NetworkTypeMigrationTargetCNIInUse", "NetworkTypeMigrationOriginalCNIPurged"
-                  and "NetworkDiagnosticsAvailable"'
+                  current state. Known .status.conditions.type are: "NetworkDiagnosticsAvailable"'
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -381,7 +378,7 @@ spec:
                 description: Migration contains the cluster network migration configuration.
                 properties:
                   mtu:
-                    description: MTU contains the MTU migration configuration.
+                    description: MTU is the MTU configuration that is being deployed.
                     properties:
                       machine:
                         description: Machine contains MTU migration configuration
@@ -415,15 +412,13 @@ spec:
                         type: object
                     type: object
                   networkType:
-                    description: 'NetworkType is the target plugin that is to be deployed.
-                      Currently supported values are: OpenShiftSDN, OVNKubernetes'
-                    enum:
-                    - OpenShiftSDN
-                    - OVNKubernetes
+                    description: 'NetworkType is the target plugin that is being deployed.
+                      DEPRECATED: network type migration is no longer supported, so
+                      this should always be unset.'
                     type: string
                 type: object
               networkType:
-                description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                description: NetworkType is the plugin that is deployed (e.g. OVNKubernetes).
                 type: string
               serviceNetwork:
                 description: IP address pool for services. Currently, we only support

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -359,7 +359,6 @@ networks.config.openshift.io:
   Category: ""
   FeatureGates:
   - NetworkDiagnosticsConfig
-  - NetworkLiveMigration
   FilenameOperatorName: config-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_10"

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -2027,9 +2027,9 @@ func (NetworkList) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkMigration = map[string]string{
-	"":            "NetworkMigration represents the cluster network configuration.",
-	"networkType": "NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes",
-	"mtu":         "MTU contains the MTU migration configuration.",
+	"":            "NetworkMigration represents the network migration status.",
+	"networkType": "NetworkType is the target plugin that is being deployed. DEPRECATED: network type migration is no longer supported, so this should always be unset.",
+	"mtu":         "MTU is the MTU configuration that is being deployed.",
 }
 
 func (NetworkMigration) SwaggerDoc() map[string]string {
@@ -2040,7 +2040,7 @@ var map_NetworkSpec = map[string]string{
 	"":                     "NetworkSpec is the desired network configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.",
 	"clusterNetwork":       "IP address pool to use for pod IPs. This field is immutable after installation.",
 	"serviceNetwork":       "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
-	"networkType":          "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
+	"networkType":          "NetworkType is the plugin that is to be deployed (e.g. OVNKubernetes). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OVNKubernetes This field is immutable after installation.",
 	"externalIP":           "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
 	"serviceNodePortRange": "The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.",
 	"networkDiagnostics":   "networkDiagnostics defines network diagnostics configuration.\n\nTakes precedence over spec.disableNetworkDiagnostics in network.operator.openshift.io. If networkDiagnostics is not specified or is empty, and the spec.disableNetworkDiagnostics flag in network.operator.openshift.io is set to true, the network diagnostics feature will be disabled.",
@@ -2054,10 +2054,10 @@ var map_NetworkStatus = map[string]string{
 	"":                  "NetworkStatus is the current network configuration.",
 	"clusterNetwork":    "IP address pool to use for pod IPs.",
 	"serviceNetwork":    "IP address pool for services. Currently, we only support a single entry here.",
-	"networkType":       "NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).",
+	"networkType":       "NetworkType is the plugin that is deployed (e.g. OVNKubernetes).",
 	"clusterNetworkMTU": "ClusterNetworkMTU is the MTU for inter-pod networking.",
 	"migration":         "Migration contains the cluster network migration configuration.",
-	"conditions":        "conditions represents the observations of a network.config current state. Known .status.conditions.type are: \"NetworkTypeMigrationInProgress\", \"NetworkTypeMigrationMTUReady\", \"NetworkTypeMigrationTargetCNIAvailable\", \"NetworkTypeMigrationTargetCNIInUse\", \"NetworkTypeMigrationOriginalCNIPurged\" and \"NetworkDiagnosticsAvailable\"",
+	"conditions":        "conditions represents the observations of a network.config current state. Known .status.conditions.type are: \"NetworkDiagnosticsAvailable\"",
 }
 
 func (NetworkStatus) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_image_policy.go
+++ b/vendor/github.com/openshift/api/config/v1alpha1/types_cluster_image_policy.go
@@ -14,7 +14,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1457
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
-// +openshift:enable:FeatureGate=ImagePolicy
+// +openshift:enable:FeatureGate=SigstoreImageVerification
 // +openshift:compatibility-gen:level=4
 type ClusterImagePolicy struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/api/config/v1alpha1/types_image_policy.go
+++ b/vendor/github.com/openshift/api/config/v1alpha1/types_image_policy.go
@@ -13,7 +13,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:subresource:status
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1457
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
-// +openshift:enable:FeatureGate=ImagePolicy
+// +openshift:enable:FeatureGate=SigstoreImageVerification
 // +openshift:compatibility-gen:level=4
 type ImagePolicy struct {
 	metav1.TypeMeta `json:",inline"`

--- a/vendor/github.com/openshift/api/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/vendor/github.com/openshift/api/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -28,7 +28,7 @@ clusterimagepolicies.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   FilenameOperatorName: config-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_10"
@@ -41,7 +41,7 @@ clusterimagepolicies.config.openshift.io:
   Scope: Cluster
   ShortNames: null
   TopLevelFeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   Version: v1alpha1
 
 imagepolicies.config.openshift.io:
@@ -51,7 +51,7 @@ imagepolicies.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   FilenameOperatorName: config-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_10"
@@ -64,7 +64,7 @@ imagepolicies.config.openshift.io:
   Scope: Namespaced
   ShortNames: null
   TopLevelFeatureGates:
-  - ImagePolicy
+  - SigstoreImageVerification
   Version: v1alpha1
 
 insightsdatagathers.config.openshift.io:

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -57,11 +57,18 @@ var (
 				enableIn(configv1.DevPreviewNoUpgrade).
 				mustRegister()
 
-	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").
-							reportProblemsToJiraComponent("auth").
-							contactPerson("stlaz").
+	FeatureGateSetEIPForNLBIngressController = newFeatureGate("SetEIPForNLBIngressController").
+							reportProblemsToJiraComponent("Networking / router").
+							contactPerson("miheer").
 							productScope(ocpSpecific).
 							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").
+							reportProblemsToJiraComponent("auth").
+							contactPerson("ibihim").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 							mustRegister()
 
 	FeatureGateExternalCloudProvider = newFeatureGate("ExternalCloudProvider").
@@ -172,7 +179,7 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("bhb").
 					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateAlibabaPlatform = newFeatureGate("AlibabaPlatform").
@@ -224,6 +231,20 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
+	FeatureGateAdditionalRoutingCapabilities = newFeatureGate("AdditionalRoutingCapabilities").
+							reportProblemsToJiraComponent("Networking/cluster-network-operator").
+							contactPerson("jcaamano").
+							productScope(ocpSpecific).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateRouteAdvertisements = newFeatureGate("RouteAdvertisements").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("jcaamano").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
 	FeatureGateNetworkLiveMigration = newFeatureGate("NetworkLiveMigration").
 					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
 					contactPerson("pliu").
@@ -237,6 +258,13 @@ var (
 						productScope(ocpSpecific).
 						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
+
+	FeatureGateOVNObservability = newFeatureGate("OVNObservability").
+					reportProblemsToJiraComponent("Networking").
+					contactPerson("npinaeva").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
 
 	FeatureGateHardwareSpeed = newFeatureGate("HardwareSpeed").
 					reportProblemsToJiraComponent("etcd").
@@ -324,7 +352,7 @@ var (
 					reportProblemsToJiraComponent("MachineConfigOperator").
 					contactPerson("djoshy").
 					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateManagedBootImagesAWS = newFeatureGate("ManagedBootImagesAWS").
@@ -344,6 +372,13 @@ var (
 	FeatureGateOnClusterBuild = newFeatureGate("OnClusterBuild").
 					reportProblemsToJiraComponent("MachineConfigOperator").
 					contactPerson("dkhater").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBootcNodeManagement = newFeatureGate("BootcNodeManagement").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("inesqyx").
 					productScope(ocpSpecific).
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
@@ -419,13 +454,6 @@ var (
 				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 				mustRegister()
 
-	FeatureGateExternalRouteCertificate = newFeatureGate("ExternalRouteCertificate").
-						reportProblemsToJiraComponent("network-edge").
-						contactPerson("miciah").
-						productScope(ocpSpecific).
-						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-						mustRegister()
-
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
 						reportProblemsToJiraComponent("insights").
 						contactPerson("tremes").
@@ -447,18 +475,11 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
-	FeatureGateImagePolicy = newFeatureGate("ImagePolicy").
-				reportProblemsToJiraComponent("node").
-				contactPerson("rphillips").
-				productScope(ocpSpecific).
-				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-				mustRegister()
-
 	FeatureGateNodeDisruptionPolicy = newFeatureGate("NodeDisruptionPolicy").
 					reportProblemsToJiraComponent("MachineConfigOperator").
 					contactPerson("jerzhang").
 					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateMetricsCollectionProfiles = newFeatureGate("MetricsCollectionProfiles").
@@ -486,13 +507,14 @@ var (
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("jhixson74").
 						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallGCP = newFeatureGate("ClusterAPIInstallGCP").
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("bfournie").
 					productScope(ocpSpecific).
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateClusterAPIInstallIBMCloud = newFeatureGate("ClusterAPIInstallIBMCloud").
@@ -519,7 +541,7 @@ var (
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("mjturek").
 						productScope(ocpSpecific).
-						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallVSphere = newFeatureGate("ClusterAPIInstallVSphere").
@@ -533,7 +555,7 @@ var (
 				reportProblemsToJiraComponent("Image Registry").
 				contactPerson("flavianmissi").
 				productScope(ocpSpecific).
-				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 				mustRegister()
 
 	FeatureGateMachineAPIMigration = newFeatureGate("MachineAPIMigration").
@@ -560,6 +582,7 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("r4f4").
 					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateMultiArchInstallAzure = newFeatureGate("MultiArchInstallAzure").
@@ -572,5 +595,34 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("r4f4").
 					productScope(ocpSpecific).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateIngressControllerLBSubnetsAWS = newFeatureGate("IngressControllerLBSubnetsAWS").
+							reportProblemsToJiraComponent("Routing").
+							contactPerson("miciah").
+							productScope(ocpSpecific).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateAWSEFSDriverVolumeMetrics = newFeatureGate("AWSEFSDriverVolumeMetrics").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("fbertina").
+						productScope(ocpSpecific).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateUserNamespacesSupport = newFeatureGate("UserNamespacesSupport").
+						reportProblemsToJiraComponent("Node").
+						contactPerson("haircommander").
+						productScope(kubernetes).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateProcMountType = newFeatureGate("ProcMountType").
+					reportProblemsToJiraComponent("Node").
+					contactPerson("haircommander").
+					productScope(kubernetes).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 )

--- a/vendor/github.com/openshift/api/security/v1/consts.go
+++ b/vendor/github.com/openshift/api/security/v1/consts.go
@@ -10,4 +10,7 @@ const (
 	// This annotation pins required SCCs for core OpenShift workloads to prevent preemption of custom SCCs.
 	// It is being used in the SCC admission plugin.
 	RequiredSCCAnnotation = "openshift.io/required-scc"
+
+	// MinimallySufficientPodSecurityStandard indicates the PodSecurityStandard that matched the SCCs available to the users of the namespace.
+	MinimallySufficientPodSecurityStandard = "security.openshift.io/MinimallySufficientPodSecurityStandard"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/openshift/api v0.0.0-20240709002213-329ea3755649
+# github.com/openshift/api v0.0.0-20240912201240-0a8800162826
 ## explicit; go 1.22.0
 github.com/openshift/api/config
 github.com/openshift/api/config/v1


### PR DESCRIPTION
Catching up with openshift/api#2023, and a backport-ish of 6abe8bb8be (#1086).  Generated with:

```console
$ GOPROXY=direct go get github.com/openshift/api@release-4.17
$ go mod tidy
$ go mod vendor
$ git add -A go.* vendor
```

all using:

```console
$ go version
go version go1.22.2 linux/amd64
```

where `GOPROXY=direct` avoids [a caching delay][2]:

> *I committed a new change (or released a new version) to a repository, why isn't it showing up when I run `go get -u` or `go list -m --versions`?*
>
> In order to improve our services' caching and serving latencies, new versions may not show up right away. If you want new code to be immediately available in the mirror, then first make sure there is a semantically versioned tag for this revision in the underlying source repository. Then explicitly request that version via go get module@version. The new version should be available within one minute. Note that if someone requested the version before the tag was pushed, it may take up to 30 minutes for the mirror's cache to expire and fresh data about the version to become available. If the version is still not available after 30 minutes, please [file an issue](https://golang.org/issue/new?title=proxy.golang.org%3A+).

[1]: https://github.com/openshift/api/pull/2023
[2]: https://proxy.golang.org/