### PR TITLE
OTA-861: Generate an accepted risk for Y-then-Z upgrade

### DIFF
--- a/pkg/cvo/status_history.go
+++ b/pkg/cvo/status_history.go
@@ -215,21 +215,3 @@ func getEffectiveMicro(version string) string {
 	}
 	return splits[2]
 }
-
-// getCurrentVersion determines and returns the cluster's current version by iterating through the
-// provided update history until it finds the first version with update State of Completed. If a
-// Completed version is not found the version of the oldest history entry, which is the originally
-// installed version, is returned. If history is empty the empty string is returned.
-func getCurrentVersion(history []configv1.UpdateHistory) string {
-	for _, h := range history {
-		if h.State == configv1.CompletedUpdate {
-			klog.V(2).Infof("Cluster current version=%s", h.Version)
-			return h.Version
-		}
-	}
-	// Empty history should only occur if method is called early in startup before history is populated.
-	if len(history) != 0 {
-		return history[len(history)-1].Version
-	}
-	return ""
-}

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/cluster-version-operator/lib/resourcedelete"
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
 	"github.com/openshift/cluster-version-operator/pkg/internal"
+	"github.com/openshift/cluster-version-operator/pkg/payload/precondition/clusterversion"
 )
 
 const (
@@ -365,7 +366,7 @@ func (check *clusterAdminAcksCompletedUpgradeable) Check() *configv1.ClusterOper
 			Message: message,
 		}
 	}
-	currentVersion := getCurrentVersion(cv.Status.History)
+	currentVersion := clusterversion.GetCurrentVersion(cv.Status.History)
 
 	// This can occur in early start up when the configmap is first added and version history
 	// has not yet been populated.


### PR DESCRIPTION
https://issues.redhat.com/browse/OTA-861

This one will be rebased after https://github.com/openshift/cluster-version-operator/pull/1094 is merged.