### PR TITLE
OCPBUGS-44018: pkg/cvo/availableupdates: Preserve update advice on update-service failures

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2675,7 +2675,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			},
 		},
 		{
-			name: "if last check time was too recent, do nothing",
+			name: "if last successful check time was too recent, do nothing",
 			handler: func(w http.ResponseWriter, req *http.Request) {
 				http.Error(w, "bad things", http.StatusInternalServerError)
 			},
@@ -2683,9 +2683,10 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 				updateService:              "http://localhost:8080/graph",
 				minimumUpdateCheckInterval: 1 * time.Minute,
 				availableUpdates: &availableUpdates{
-					UpdateService: "http://localhost:8080/graph",
-					Channel:       "fast",
-					LastAttempt:   time.Now(),
+					UpdateService:          "http://localhost:8080/graph",
+					Channel:                "fast",
+					LastAttempt:            time.Now(),
+					LastSyncOrConfigChange: time.Now(),
 				},
 				release: configv1.Release{
 					Version: "4.0.1",


### PR DESCRIPTION
[`RemoteFailed`, `ResponseFailed`, and `ResponseInvalid` reasons are all server-side issues][a].  This commit makes clusters more resilient to OpenShift Update Service (OSUS) issues by preserving the cache of previously-retrieved advice for up to 24 hours, while we wait for OSUS to recover (or proxies or other network configuration between the cluster and its OSUS to be fixed).  OSUS advice does not change often, and the only risk of acting on stale advice is that you might not hear about recently-declared [Conditional Update risks][1].  The `RetrievedUpdates` condition should be displayed in the update-selection user interfaces, and [the `CannotRetrieveUpdates` alert][b] will be firing, so cluster administrators will be aware of the risk of stale data, and can decide whether to wait for OSUS to recover, or to initiate an update based on the stale information (which they can supplement with additional checks like [any new risks declared in graph-data recently?][c]).

[1]: https://docs.openshift.com/container-platform/4.17/updating/understanding_updates/understanding-update-channels-release.html#conditional-updates-overview_understanding-update-channels-releases
[a]: https://github.com/openshift/cluster-version-operator/blob/adf0cf5662854567d1ea7ce1590e0a6fed8fcaaa/pkg/cincinnati/cincinnati.go#L136-L167
[b]: https://github.com/openshift/cluster-version-operator/blob/adf0cf5662854567d1ea7ce1590e0a6fed8fcaaa/install/0000_90_cluster-version-operator_02_servicemonitor.yaml#L53-L67
[c]: https://github.com/openshift/cincinnati-graph-data/commits/master/blocked-edges