### PR TITLE
NO-JIRA: task graph: test speedup and code cleaup

### DIFF
--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -514,9 +514,8 @@ func RunGraph(ctx context.Context, graph *TaskGraph, maxParallelism int, fn func
 				inflight--
 			case <-ctx.Done():
 				select {
-				case runTask := <-workCh: // workers canceled, so remove any work from the queue ourselves
+				case <-workCh: // workers canceled, so remove any work from the queue ourselves
 					inflight--
-					submitted[runTask.index] = false
 				default:
 				}
 			}

--- a/pkg/payload/task_graph_test.go
+++ b/pkg/payload/task_graph_test.go
@@ -949,7 +949,6 @@ func TestRunGraph(t *testing.T) {
 			callbacks: map[string]callbackFn{
 				"a": func(t *testing.T, name string, ctx context.Context, cancelFn func()) error {
 					cancelFn()
-					time.Sleep(time.Second)
 					return nil
 				},
 				"*": func(t *testing.T, name string, ctx context.Context, cancelFn func()) error {


### PR DESCRIPTION
[task graph test: do not wait after cancelation](https://github.com/openshift/cluster-version-operator/commit/1c71a50c41cc35a553908eae448a731dbe02bc4b)

Given correct synchronization I do not see any value in the `Sleep`, it just makes the test much slower:

```console
$ go test --count 10 --run TestRunGraph/cancelation_without_task_errors  ./pkg/payload/
ok  	github.com/openshift/cluster-version-operator/pkg/payload	10.041s

$ git checkout ocpbugs-22442-test-run-graph-mid-task-cancellation-flake
...
$ go test --count 10 --run TestRunGraph/cancellation_without_task_errors  ./pkg/payload/
ok  	github.com/openshift/cluster-version-operator/pkg/payload	0.043s
```
---

[task graph: simplify code](https://github.com/openshift/cluster-version-operator/commit/df39a81014aa4360b16496ac671a7db2dcdf2f6d)

We only start draining `workCh` when canceled (`ctx.Done()`). We never submit more work once canceled so reseting `submitted` record is useless