### PR TITLE
OCPBUGS-44328: Fix desired before sync_worker's work is initialized

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -675,7 +675,7 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 		}
 		if !initialized {
 			klog.V(2).Infof("Desired version from operator is %#v with user's request to go to %#v. "+
-				"We are currently initializing the work for the request and will evaluate the version later", desired, pendingDesired)
+				"We are currently initializing the worker and will evaluate the request later", desired, pendingDesired)
 			// enqueue to trigger a reconciliation on ClusterVersion
 			optr.queue.Add(optr.queueKey())
 		} else {

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -663,15 +663,25 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// identify the desired next version
 	desired, ok := findUpdateFromConfig(config, optr.getArchitecture())
-	if ok {
-		klog.V(2).Infof("Desired version from spec is %#v", desired)
+	stillInitializing := optr.configSync.StillInitializing()
+	if ok && !stillInitializing {
+		klog.V(2).Infof("Desired version from spec is %#v after initialization", desired)
 	} else {
+		userDesired := desired
 		currentVersion := optr.currentVersion()
 		desired = configv1.Update{
 			Version: currentVersion.Version,
 			Image:   currentVersion.Image,
 		}
-		klog.V(2).Infof("Desired version from operator is %#v", desired)
+		if ok {
+			// It implies stillInitializing == true
+			klog.V(2).Infof("Desired version from operator is %#v with user's request to go to %#v. "+
+				"We are currently initializing the work for the request and will evaluate the version later", desired, userDesired)
+			// enqueue to trigger a reconciliation on ClusterVersion
+			optr.queue.Add(optr.queueKey())
+		} else {
+			klog.V(2).Infof("Desired version from operator is %#v", desired)
+		}
 	}
 
 	// handle the case of a misconfigured CVO by doing nothing

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -663,7 +663,7 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// identify the desired next version
 	desired, ok := findUpdateFromConfig(config, optr.getArchitecture())
-	stillInitializing := optr.configSync.StillInitializing()
+	stillInitializing := optr.configSync.StillInitializingFunc()()
 	if ok && !stillInitializing {
 		klog.V(2).Infof("Desired version from spec is %#v after initialization", desired)
 	} else {

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -33,9 +33,18 @@ import (
 )
 
 var architecture string
+var sortedCaps = configv1.ClusterVersionCapabilitySets[configv1.ClusterVersionCapabilitySetCurrent]
+var sortedKnownCaps = configv1.KnownClusterVersionCapabilities
 
 func init() {
 	architecture = runtime.GOARCH
+
+	sort.Slice(sortedCaps, func(i, j int) bool {
+		return sortedCaps[i] < sortedCaps[j]
+	})
+	sort.Slice(sortedKnownCaps, func(i, j int) bool {
+		return sortedKnownCaps[i] < sortedKnownCaps[j]
+	})
 }
 
 func setupCVOTest(payloadDir string) (*Operator, map[string]apiruntime.Object, *fake.Clientset, *dynamicfake.FakeDynamicClient, func()) {

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1390,6 +1390,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -1645,7 +1646,7 @@ func TestCVO_ResetPayloadLoadStatus(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-
+	worker.stillInitializingFunc = func() bool { return false }
 	// checked by SyncWorker.syncPayload
 	worker.payload = &payload.Update{Release: o.release}
 
@@ -1896,6 +1897,7 @@ func TestCVO_UpgradeFailedPayloadLoadWithCapsChanges(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -2014,6 +2016,7 @@ func TestCVO_InitImplicitlyEnabledCaps(t *testing.T) {
 
 	defer shutdownFn()
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 
 	go worker.Start(ctx, 1)
 
@@ -2180,6 +2183,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -2468,6 +2472,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	defer shutdownFn()
 
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	worker.preconditions = []precondition.Precondition{&testPrecondition{SuccessAfter: 3}}
 
 	go worker.Start(ctx, 1)
@@ -2742,6 +2747,7 @@ func TestCVO_UpgradePreconditionFailingAcceptedRisks(t *testing.T) {
 	defer shutdownFn()
 
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	worker.preconditions = []precondition.Precondition{&testPreconditionAlwaysFail{PreConditionName: "PreCondition1"}, &testPreconditionAlwaysFail{PreConditionName: "PreCondition2"}}
 
 	go worker.Start(ctx, 1)
@@ -2897,6 +2903,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
+	worker.stillInitializingFunc = func() bool { return false }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 	retriever.Set(PayloadInfo{Directory: "testdata/payloadtest-2", Verified: true}, nil)

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -1390,7 +1390,7 @@ func TestCVO_UpgradeUnverifiedPayload(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -1646,7 +1646,7 @@ func TestCVO_ResetPayloadLoadStatus(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	// checked by SyncWorker.syncPayload
 	worker.payload = &payload.Update{Release: o.release}
 
@@ -1897,7 +1897,7 @@ func TestCVO_UpgradeFailedPayloadLoadWithCapsChanges(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -2016,7 +2016,7 @@ func TestCVO_InitImplicitlyEnabledCaps(t *testing.T) {
 
 	defer shutdownFn()
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 
 	go worker.Start(ctx, 1)
 
@@ -2183,7 +2183,7 @@ func TestCVO_UpgradeUnverifiedPayloadRetrieveOnce(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 
@@ -2472,7 +2472,7 @@ func TestCVO_UpgradePreconditionFailing(t *testing.T) {
 	defer shutdownFn()
 
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	worker.preconditions = []precondition.Precondition{&testPrecondition{SuccessAfter: 3}}
 
 	go worker.Start(ctx, 1)
@@ -2747,7 +2747,7 @@ func TestCVO_UpgradePreconditionFailingAcceptedRisks(t *testing.T) {
 	defer shutdownFn()
 
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	worker.preconditions = []precondition.Precondition{&testPreconditionAlwaysFail{PreConditionName: "PreCondition1"}, &testPreconditionAlwaysFail{PreConditionName: "PreCondition2"}}
 
 	go worker.Start(ctx, 1)
@@ -3011,7 +3011,7 @@ func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 		t.Fatal("not the correct error type")
 	}
 	worker := o.configSync.(*SyncWorker)
-	worker.stillInitializingFunc = func() bool { return false }
+	worker.initializedFunc = func() bool { return true }
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
 	retriever.Set(PayloadInfo{}, payloadErr)
 	retriever.Set(PayloadInfo{Directory: "testdata/payloadtest-2", Verified: true}, nil)

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -2850,6 +2850,114 @@ func TestCVO_UpgradePreconditionFailingAcceptedRisks(t *testing.T) {
 	})
 }
 
+func TestCVO_UpgradeVerifiedPayloadStillInitializing(t *testing.T) {
+	o, cvs, client, _, shutdownFn := setupCVOTest("testdata/payloadtest")
+
+	// Setup: a successful sync from a previous run, and the operator at the same image as before
+	//
+	o.release.Image = "image/image:0"
+	o.release.Version = "1.0.0-abc"
+	desired := configv1.Release{Version: "1.0.1-abc", Image: "image/image:1"}
+	uid, _ := uuid.NewRandom()
+	clusterUID := configv1.ClusterID(uid.String())
+	cvs["version"] = &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+			Generation:      1,
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID:     clusterUID,
+			Channel:       "fast",
+			DesiredUpdate: &configv1.Update{Version: desired.Version, Image: desired.Image},
+		},
+		Status: configv1.ClusterVersionStatus{
+			// Prefers the image version over the operator's version (although in general they will remain in sync)
+			Desired:     desired,
+			VersionHash: "DL-FFQ2Uem8=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer shutdownFn()
+
+	// make the image report unverified
+	payloadErr := &payload.UpdateError{
+		Reason:  "ImageVerificationFailed",
+		Message: "The update cannot be verified: some random error",
+		Nested:  fmt.Errorf("some random error"),
+	}
+	if !isImageVerificationError(payloadErr) {
+		t.Fatal("not the correct error type")
+	}
+	worker := o.configSync.(*SyncWorker)
+	retriever := worker.retriever.(*fakeDirectoryRetriever)
+	retriever.Set(PayloadInfo{}, payloadErr)
+	retriever.Set(PayloadInfo{Directory: "testdata/payloadtest", Verified: true}, nil)
+
+	go worker.Start(ctx, 1)
+
+	// Step 1: Simulate a verified payload being retrieved and ensure the operator sets verified
+	//
+	client.ClearActions()
+	err := o.sync(ctx, o.queueKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	actions := client.Actions()
+	if len(actions) != 2 {
+		t.Fatalf("%s", spew.Sdump(actions))
+	}
+	expectGet(t, actions[0], "clusterversions", "", "version")
+	expectUpdateStatus(t, actions[1], "clusterversions", "", &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "version",
+			ResourceVersion: "1",
+			Generation:      1,
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID:     clusterUID,
+			Channel:       "fast",
+			DesiredUpdate: &configv1.Update{Version: desired.Version, Image: desired.Image},
+		},
+		Status: configv1.ClusterVersionStatus{
+			ObservedGeneration: 1,
+			// Prefers the operator's version
+			Desired:     configv1.Release{Version: o.release.Version, Image: o.release.Image},
+			VersionHash: "DL-FFQ2Uem8=",
+			History: []configv1.UpdateHistory{
+				{State: configv1.CompletedUpdate, Image: "image/image:0", Version: "1.0.0-abc", Verified: true, StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+			},
+			Capabilities: configv1.ClusterVersionCapabilitiesStatus{
+				EnabledCapabilities: sortedCaps,
+				KnownCapabilities:   sortedKnownCaps,
+			},
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
+				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
+				// cleared failing status and set progressing
+				{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
+				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
+				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+				{Type: DesiredReleaseAccepted, Status: configv1.ConditionTrue, Reason: "PayloadLoaded",
+					Message: `Payload loaded version="1.0.0-abc" image="image/image:0" architecture="` + architecture + `"`},
+			},
+		},
+	})
+}
+
 func TestCVO_UpgradeVerifiedPayload(t *testing.T) {
 	o, cvs, client, _, shutdownFn := setupCVOTest("testdata/payloadtest-2")
 

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -2850,10 +2850,10 @@ func TestCVO_UpgradePreconditionFailingAcceptedRisks(t *testing.T) {
 	})
 }
 
-func TestCVO_UpgradeVerifiedPayloadStillInitializing(t *testing.T) {
+func TestCVO_UpgradePayloadStillInitializing(t *testing.T) {
 	o, cvs, client, _, shutdownFn := setupCVOTest("testdata/payloadtest")
 
-	// Setup: a successful sync from a previous run, and the operator at the same image as before
+	// Setup: an upgrade request from user to a new image and the operator at the same image as before
 	//
 	o.release.Image = "image/image:0"
 	o.release.Version = "1.0.0-abc"
@@ -2893,24 +2893,14 @@ func TestCVO_UpgradeVerifiedPayloadStillInitializing(t *testing.T) {
 
 	defer shutdownFn()
 
-	// make the image report unverified
-	payloadErr := &payload.UpdateError{
-		Reason:  "ImageVerificationFailed",
-		Message: "The update cannot be verified: some random error",
-		Nested:  fmt.Errorf("some random error"),
-	}
-	if !isImageVerificationError(payloadErr) {
-		t.Fatal("not the correct error type")
-	}
 	worker := o.configSync.(*SyncWorker)
 	retriever := worker.retriever.(*fakeDirectoryRetriever)
-	retriever.Set(PayloadInfo{}, payloadErr)
 	retriever.Set(PayloadInfo{Directory: "testdata/payloadtest", Verified: true}, nil)
 
 	go worker.Start(ctx, 1)
 
-	// Step 1: Simulate a verified payload being retrieved and ensure the operator sets verified
-	//
+	// Step 1: Simulate a payload being retrieved while the sync worker is not initialized
+	// and ensure the desired version from the operator is taken from the operator and a reconciliation is enqueued
 	client.ClearActions()
 	err := o.sync(ctx, o.queueKey())
 	if err != nil {
@@ -2947,7 +2937,6 @@ func TestCVO_UpgradeVerifiedPayloadStillInitializing(t *testing.T) {
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
 				{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue, Message: "Done applying 1.0.0-abc"},
-				// cleared failing status and set progressing
 				{Type: ClusterStatusFailing, Status: configv1.ConditionFalse},
 				{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse, Message: "Cluster version is 1.0.0-abc"},
 				{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
@@ -2956,6 +2945,10 @@ func TestCVO_UpgradeVerifiedPayloadStillInitializing(t *testing.T) {
 			},
 		},
 	})
+	if l := o.queue.Len(); l != 1 {
+		t.Errorf("expecting queue length is 1 but got %d", l)
+	}
+
 }
 
 func TestCVO_UpgradeVerifiedPayload(t *testing.T) {

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -471,8 +471,18 @@ func newAction(gvk schema.GroupVersionKind, namespace, name string) action {
 }
 
 type fakeSyncRecorder struct {
-	Returns *SyncWorkerStatus
-	Updates []configv1.Update
+	Returns               *SyncWorkerStatus
+	Updates               []configv1.Update
+	stillInitializingFunc func() bool
+}
+
+func (r *fakeSyncRecorder) StillInitializingFunc() func() bool {
+	if r.stillInitializingFunc != nil {
+		return r.stillInitializingFunc
+	}
+	return func() bool {
+		return false
+	}
 }
 
 func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -471,18 +471,13 @@ func newAction(gvk schema.GroupVersionKind, namespace, name string) action {
 }
 
 type fakeSyncRecorder struct {
-	Returns               *SyncWorkerStatus
-	Updates               []configv1.Update
-	stillInitializingFunc func() bool
+	Returns         *SyncWorkerStatus
+	Updates         []configv1.Update
+	initializedFunc func() bool
 }
 
-func (r *fakeSyncRecorder) StillInitializingFunc() func() bool {
-	if r.stillInitializingFunc != nil {
-		return r.stillInitializingFunc
-	}
-	return func() bool {
-		return false
-	}
+func (r *fakeSyncRecorder) Initialized() bool {
+	return r.initializedFunc == nil || r.initializedFunc()
 }
 
 func (r *fakeSyncRecorder) StatusCh() <-chan SyncWorkerStatus {

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -35,6 +35,8 @@ type ConfigSyncWorker interface {
 
 	// NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.
 	NotifyAboutManagedResourceActivity(msg string)
+	// StillInitializing returns true if ConfigSyncWorker has no work to do yet
+	StillInitializing() bool
 }
 
 // PayloadInfo returns details about the payload when it was retrieved.
@@ -227,6 +229,10 @@ func NewSyncWorkerWithPreconditions(retriever PayloadRetriever, builder payload.
 // can be lost, so this is best used as a trigger to read the latest status.
 func (w *SyncWorker) StatusCh() <-chan SyncWorkerStatus {
 	return w.report
+}
+
+func (w *SyncWorker) StillInitializing() bool {
+	return w.work == nil
 }
 
 // NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -35,7 +35,7 @@ type ConfigSyncWorker interface {
 
 	// NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.
 	NotifyAboutManagedResourceActivity(msg string)
-	// Initialized returns true if ConfigSyncWorker has work to do already
+	// Initialized returns true if the worker has work to do already
 	Initialized() bool
 }
 

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -191,11 +191,6 @@ type SyncWorker struct {
 
 	clusterProfile string
 
-	// alwaysEnableCapabilities is a list of cluster capabilities which should
-	// always be implicitly enabled.
-	// This contributes to whether or not some manifests are included for reconciliation.
-	alwaysEnableCapabilities []configv1.ClusterVersionCapability
-
 	// initializedFunc is only for the unit-test purpose
 	initializedFunc func() bool
 }

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -35,8 +35,8 @@ type ConfigSyncWorker interface {
 
 	// NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.
 	NotifyAboutManagedResourceActivity(msg string)
-	// StillInitializingFunc a function that returns true if ConfigSyncWorker has no work to do yet
-	StillInitializingFunc() func() bool
+	// Initialized returns true if ConfigSyncWorker has work to do already
+	Initialized() bool
 }
 
 // PayloadInfo returns details about the payload when it was retrieved.
@@ -196,7 +196,8 @@ type SyncWorker struct {
 	// This contributes to whether or not some manifests are included for reconciliation.
 	alwaysEnableCapabilities []configv1.ClusterVersionCapability
 
-	stillInitializingFunc func() bool
+	// initializedFunc is only for the unit-test purpose
+	initializedFunc func() bool
 }
 
 // NewSyncWorker initializes a ConfigSyncWorker that will retrieve payloads to disk, apply them via builder
@@ -238,13 +239,11 @@ func (w *SyncWorker) StatusCh() <-chan SyncWorkerStatus {
 	return w.report
 }
 
-func (w *SyncWorker) StillInitializingFunc() func() bool {
-	if w.stillInitializingFunc != nil {
-		return w.stillInitializingFunc
+func (w *SyncWorker) Initialized() bool {
+	if w.initializedFunc != nil {
+		return w.initializedFunc()
 	}
-	return func() bool {
-		return w.work == nil
-	}
+	return w.work != nil
 }
 
 // NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -35,8 +35,8 @@ type ConfigSyncWorker interface {
 
 	// NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.
 	NotifyAboutManagedResourceActivity(msg string)
-	// StillInitializing returns true if ConfigSyncWorker has no work to do yet
-	StillInitializing() bool
+	// StillInitializingFunc a function that returns true if ConfigSyncWorker has no work to do yet
+	StillInitializingFunc() func() bool
 }
 
 // PayloadInfo returns details about the payload when it was retrieved.
@@ -190,6 +190,13 @@ type SyncWorker struct {
 	requiredFeatureSet string
 
 	clusterProfile string
+
+	// alwaysEnableCapabilities is a list of cluster capabilities which should
+	// always be implicitly enabled.
+	// This contributes to whether or not some manifests are included for reconciliation.
+	alwaysEnableCapabilities []configv1.ClusterVersionCapability
+
+	stillInitializingFunc func() bool
 }
 
 // NewSyncWorker initializes a ConfigSyncWorker that will retrieve payloads to disk, apply them via builder
@@ -231,8 +238,13 @@ func (w *SyncWorker) StatusCh() <-chan SyncWorkerStatus {
 	return w.report
 }
 
-func (w *SyncWorker) StillInitializing() bool {
-	return w.work == nil
+func (w *SyncWorker) StillInitializingFunc() func() bool {
+	if w.stillInitializingFunc != nil {
+		return w.stillInitializingFunc
+	}
+	return func() bool {
+		return w.work == nil
+	}
 }
 
 // NotifyAboutManagedResourceActivity informs the sync worker about activity for a managed resource.


### PR DESCRIPTION
This PR is generated by 

```
$ git cherry-pick a411e9da061c6ba1b71bb2b1ce5972a8e0c03307 6906bbfb9d075450e93680cdf8ccfc51d4e62c24 e3a05d439a609e1eb5fc3c63c70a7825ee48f41f a1ee1ca6c050b752c622264c6903823210671334 ae4e180b19aa4f67f2a53785813ff040ee1690da
```

and then fix [the backported unit test](https://github.com/openshift/cluster-version-operator/pull/1097/files#diff-6cca1696ca6d83b25f5baf586b99602d32827c05c4276dd03ebfcb6825ff2558R2865) `TestCVO_UpgradePayloadStillInitializing` by the following editting:

```console
git --no-pager diff 
diff --git a/pkg/cvo/cvo_scenarios_test.go b/pkg/cvo/cvo_scenarios_test.go
index c195e26c..9f060195 100644
--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -33,9 +33,18 @@ import (
 )
 
 var architecture string
+var sortedCaps = configv1.ClusterVersionCapabilitySets[configv1.ClusterVersionCapabilitySetCurrent]
+var sortedKnownCaps = configv1.KnownClusterVersionCapabilities
 
 func init() {
        architecture = runtime.GOARCH
+
+       sort.Slice(sortedCaps, func(i, j int) bool {
+               return sortedCaps[i] < sortedCaps[j]
+       })
+       sort.Slice(sortedKnownCaps, func(i, j int) bool {
+               return sortedKnownCaps[i] < sortedKnownCaps[j]
+       })
 }
 
 func setupCVOTest(payloadDir string) (*Operator, map[string]apiruntime.Object, *fake.Clientset, *dynamicfake.FakeDynamicClient, func()) {
diff --git a/pkg/cvo/sync_worker.go b/pkg/cvo/sync_worker.go
index 22ec05b9..eb2fb500 100644
--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -191,11 +191,6 @@ type SyncWorker struct {
 
        clusterProfile string
 
-       // alwaysEnableCapabilities is a list of cluster capabilities which should
-       // always be implicitly enabled.
-       // This contributes to whether or not some manifests are included for reconciliation.
-       alwaysEnableCapabilities []configv1.ClusterVersionCapability
-
        // initializedFunc is only for the unit-test purpose
        initializedFunc func() bool
 }

```

where `alwaysEnableCapabilities` is removed because it is not used in 4.15 and the variables `sortedCaps` and `sortedKnownCaps` are added because they are [used](https://github.com/openshift/cluster-version-operator/pull/1097/files#diff-6cca1696ca6d83b25f5baf586b99602d32827c05c4276dd03ebfcb6825ff2558R2946-R2947) in the backported unit test.

Note that https://github.com/openshift/cluster-version-operator/pull/1097/commits/e94580f609e346bf8bee71ef2e362bf76cc8b0df is not picked to keep the manual work simple. Otherwise it would lead to more manual work such as fixing using constants from the new API like `configv1.ClusterVersionCapabilityIngress` which is not available for 4.15.


