### PR TITLE
OCPBUGS-31462: Set `openshift.io/required-scc: privileged` annotation in `version` pods

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -227,6 +227,9 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 			Labels: map[string]string{
 				"k8s-app": "retrieve-openshift-release",
 			},
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "privileged",
+			},
 		},
 		Spec: corev1.PodSpec{
 			ActiveDeadlineSeconds: deadline,


### PR DESCRIPTION
[pkg/cvo/updatepayload.go: Set openshift.io/required-scc: privileged for version pods](https://github.com/openshift/cluster-version-operator/pull/1106/commits/9761a5b5ca847acece8f7537f78ef8a089faec6e)
Utilize the `openshift.io/required-scc` annotation [1] to pin the required SCC to
`version` pods. This will ensure that any existing custom SCCs in the cluster will
not have an effect on the `version` pods.

The `privileged` default SCC [2] was chosen as the pod accesses and modifies
host `/etc/` files. To do that, a pod must run as root and must also pass SELinux
permission checks. This is currently achieved by the pod running as a privileged
root. For such permission, the `privileged` default SCC is required.

Using the `hostmount-anyuid` default SCC is not sufficient for the existing code
as the pod is not able to pass the SELinux permissions checks.
Additional SELinux, host file system, and/or code changes would be needed.

In the future, we may implement such changes or try to use a local persistent
volume [3] as running the version pod as privileged root is undesirable for
the pod's goal of copying files into another pod.

Some of the other alternatives are modifications to the current architecture
of two separate pods or using a different type of volume.

[1] https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html#security-context-constraints-requiring_configuring-internal-oauth
[2] https://docs.openshift.com/container-platform/4.17/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth
[3] https://kubernetes.io/docs/concepts/storage/volumes/#local