### PR TITLE
OTA-1269: USC: Add `DevPreviewNoUpgrade`-gated manifests

### DIFF
--- a/install/0000_00_update-status-controller_00_namespace-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_00_namespace-DevPreviewNoUpgrade.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-update-status-controller
+  annotations:
+    kubernetes.io/description: The update status controller manages OpenShift UpdateStatus API from insights collected from cluster components.
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    name: openshift-update-status-controller
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    openshift.io/cluster-monitoring: "true"

--- a/install/0000_00_update-status-controller_01_serviceaccount-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_01_serviceaccount-DevPreviewNoUpgrade.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kubernetes.io/description: SA used by the Update Status Controller.
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  name: update-status-controller
+  namespace: openshift-update-status-controller

--- a/install/0000_00_update-status-controller_02_rbac-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_02_rbac-DevPreviewNoUpgrade.yaml
@@ -1,0 +1,176 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: update-status-controller-library
+  namespace: openshift-update-status-controller
+  annotations:
+    # TODO(USC: TechPreview): Investigate if we really need all this, maybe we can make o/library-go
+    #                         functionality optional?
+    # https://github.com/openshift/cluster-version-operator/pull/1091#discussion_r1810586011
+    kubernetes.io/description: Role that allows the USC binary to operate local resources needed by shared controller code from openshift/library-go
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: update-status-controller-library
+  annotations:
+    # TODO(USC: TechPreview): Investigate if we really need all this, maybe we can make o/library-go
+    #                         functionality optional?
+    # https://github.com/openshift/cluster-version-operator/pull/1091#discussion_r1810586011
+    kubernetes.io/description: Role that allows the USC binary to operate cluster resources needed by shared controller code from openshift/library-go
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  resourceNames:
+  - cluster
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+  annotations:
+    kubernetes.io/description: Grant the update status controller permission to read and observe ConfigMaps, and modify the ConfigMap that serves as UpdateStatus API
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - status-api-cm-prototype
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: update-status-controller-control-plane-informer
+  annotations:
+    kubernetes.io/description: Role that allows the update status controller to watch and read control plane resources
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: update-status-controller-library
+  namespace: openshift-update-status-controller
+  annotations:
+    kubernetes.io/description: Grant the USC permissions to operate resource needed by shared controller code from openshift/library-go
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+subjects:
+- kind: ServiceAccount
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+roleRef:
+  kind: Role
+  name: update-status-controller-library
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: update-status-controller-library
+  annotations:
+    kubernetes.io/description: Grant the USC permissions to operate cluster resources needed by shared controller code from openshift/library-go
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: update-status-controller-library
+subjects:
+- kind: ServiceAccount
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: update-status-controller-updatestatus-api-manager
+  namespace: openshift-update-status-controller
+  annotations:
+    kubernetes.io/description: Grant the update status controller permission to manage the ConfigMap that serves as UpdateStatus API
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+subjects:
+- kind: ServiceAccount
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+roleRef:
+  kind: Role
+  name: update-status-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: update-status-controller-control-plane-informer
+  annotations:
+    kubernetes.io/description: Grant the update status controller permission to read cluster resources (temporary, until we have UpdateInformer producers)
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+subjects:
+- kind: ServiceAccount
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+roleRef:
+  kind: ClusterRole
+  name: update-status-controller-control-plane-informer
+  apiGroup: rbac.authorization.k8s.io

--- a/install/0000_00_update-status-controller_03_deployment-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_03_deployment-DevPreviewNoUpgrade.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: update-status-controller
+  namespace: openshift-update-status-controller
+  annotations:
+    kubernetes.io/description: The update status controller manages OpenShift UpdateStatus API from insights collected from cluster components.
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+spec:
+  selector:
+    matchLabels:
+      k8s-app: update-status-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: update-status-controller
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
+      labels:
+        k8s-app: update-status-controller
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: update-status-controller
+        image: {{.ReleaseImage}}
+        imagePullPolicy: IfNotPresent
+        args:
+        - "update-status-controller"
+        - -v=5 # High while in DevPreview, lower for GA
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          allowPrivilegeEscalation: false
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "openshift-user-critical"
+      serviceAccountName: update-status-controller
+      terminationGracePeriodSeconds: 130
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: Exists
+        effect: "NoSchedule"


### PR DESCRIPTION
- [x] Builds on: https://github.com/openshift/cluster-version-operator/pull/1091
- [x] Blocked by: https://github.com/openshift/hypershift/pull/5093 (fails hypershift without that change)

---

- Namespace
- ServiceAccount
- Role that allows read, watch & update ConfigMaps (+binding)
- ClusterRole that allows read & watch ConfigVersions (+rolebinding)
- Deployment

Squashed review commits:

USC: Do not tolerate taints

The original Deployment was copied from CVO which contained a bunch of
strong tolerations. It does not seem USC needs to be this robust against
node conditions and can be easily evicted if necessary.

https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#taints-and-tolerations

USC: Use `openshift-user-critical` priority class

The original USC deployment was copied from CVO which is obviously very
important component and should be protected from OOM kills and preemption
but USC does not seem to need it.

https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#priority-classes

> If it is fine for your operator/operand to be preempted by user-workload and OOMKilled use openshift-user-critical priority class
