### PR TITLE
[wip]test-only;no-merge

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -973,6 +973,7 @@ func hasReachedLevel(cv *configv1.ClusterVersion, desired configv1.Update) bool 
 func (optr *Operator) defaultPreconditionChecks() precondition.List {
 	return []precondition.Precondition{
 		preconditioncv.NewRollback(optr.cvLister),
+		preconditioncv.NewGiantHop(optr.cvLister),
 		preconditioncv.NewUpgradeable(optr.cvLister),
 		preconditioncv.NewRecommendedUpdate(optr.cvLister),
 	}

--- a/pkg/payload/precondition/clusterversion/gianthop.go
+++ b/pkg/payload/precondition/clusterversion/gianthop.go
@@ -1,0 +1,87 @@
+package clusterversion
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	precondition "github.com/openshift/cluster-version-operator/pkg/payload/precondition"
+)
+
+// GiantHop blocks giant hops from the version that is currently being reconciled.
+type GiantHop struct {
+	key    string
+	lister configv1listers.ClusterVersionLister
+}
+
+// NewGiantHop returns a new GiantHop precondition check.
+func NewGiantHop(lister configv1listers.ClusterVersionLister) *GiantHop {
+	return &GiantHop{
+		key:    "version",
+		lister: lister,
+	}
+}
+
+// Name returns Name for the precondition.
+func (p *GiantHop) Name() string { return "ClusterVersionGiantHop" }
+
+// Run runs the GiantHop precondition, blocking giant hops from the
+// version that is currently being reconciled.  It returns a
+// PreconditionError when possible.
+func (p *GiantHop) Run(ctx context.Context, releaseContext precondition.ReleaseContext) error {
+	cv, err := p.lister.Get(p.key)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return nil
+	}
+	if err != nil {
+		return &precondition.Error{
+			Nested:  err,
+			Reason:  "UnknownError",
+			Message: err.Error(),
+			Name:    p.Name(),
+		}
+	}
+
+	currentVersion, err := semver.Parse(cv.Status.Desired.Version)
+	if err != nil {
+		return &precondition.Error{
+			Nested:             err,
+			Reason:             "InvalidCurrentVersion",
+			Message:            err.Error(),
+			Name:               p.Name(),
+			NonBlockingWarning: true, // do not block on issues that require an update to fix
+		}
+	}
+
+	targetVersion, err := semver.Parse(releaseContext.DesiredVersion)
+	if err != nil {
+		return &precondition.Error{
+			Nested:  err,
+			Reason:  "InvalidDesiredVersion",
+			Message: err.Error(),
+			Name:    p.Name(),
+		}
+	}
+
+	if targetVersion.Major > currentVersion.Major {
+		return &precondition.Error{
+			Reason:  "MajorVersionUpdate",
+			Message: fmt.Sprintf("%s has a larger major version than the current target %s (%d > %d), and only updates within the current major version are supported.", targetVersion, currentVersion, targetVersion.Major, currentVersion.Major),
+			Name:    p.Name(),
+		}
+	}
+
+	if targetVersion.Minor > currentVersion.Minor+1 {
+		return &precondition.Error{
+			Reason:  "MultipleMinorVersionsUpdate",
+			Message: fmt.Sprintf("%s is more than one minor version beyond the current target %s (%d.%d > %d.(%d+1)), and only updates within the current minor version or to the next minor version are supported.", targetVersion, currentVersion, targetVersion.Major, targetVersion.Minor, currentVersion.Major, currentVersion.Minor),
+			Name:    p.Name(),
+		}
+	}
+
+	return nil
+}

--- a/pkg/payload/precondition/clusterversion/gianthop_test.go
+++ b/pkg/payload/precondition/clusterversion/gianthop_test.go
@@ -1,0 +1,107 @@
+package clusterversion
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-version-operator/pkg/payload/precondition"
+)
+
+func TestGiantHopRun(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		clusterVersion configv1.ClusterVersion
+		expected       string
+	}{
+		{
+			name: "update",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.1",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "no change",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "major version",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "2.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "2.0.0 has a larger major version than the current target 1.0.0 (2 > 1), and only updates within the current major version are supported.",
+		},
+		{
+			name: "two minor versions",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "1.2.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "1.0.0",
+					},
+				},
+			},
+			expected: "1.2.0 is more than one minor version beyond the current target 1.0.0 (1.2 > 1.(0+1)), and only updates within the current minor version or to the next minor version are supported.",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.clusterVersion.ObjectMeta.Name = "version"
+			cvLister := fakeClusterVersionLister(t, &tc.clusterVersion)
+			instance := NewGiantHop(cvLister)
+
+			err := instance.Run(ctx, precondition.ReleaseContext{
+				DesiredVersion: tc.clusterVersion.Spec.DesiredUpdate.Version,
+			})
+			switch {
+			case err != nil && len(tc.expected) == 0:
+				t.Error(err)
+			case err != nil && err.Error() == tc.expected:
+			case err != nil && err.Error() != tc.expected:
+				t.Error(err)
+			case err == nil && len(tc.expected) == 0:
+			case err == nil && len(tc.expected) != 0:
+				t.Error(err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
…tion

From our docs [1]:

  Due to fundamental Kubernetes design, all OpenShift Container
  Platform updates between minor versions must be serialized. You must
  update from OpenShift Container Platform <4.y> to <4.y+1>, and then
  to <4.y+2>. You cannot update from OpenShift Container Platform
  <4.y> to <4.y+2> directly. However, administrators who want to
  update between two even-numbered minor versions can do so incurring
  only a single reboot of non-control plane hosts.

This commit adds a new precondition that enforces that policy, so cluster admins who run '--to-image ...' don't hop straight from 4.y.z to 4.(y+2).z' or similar without realizing that they were outpacing testing and policy.

[1]: https://docs.openshift.com/container-platform/4.17/updating/updating_a_cluster/control-plane-only-update.html