### PR TITLE
OCPBUGS-45922: CONTRIBUTING.md: Rename `master` to `main`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Details [here][security].
 Anyone may [file issues][new-issue].
 For contributors who want to work up pull requests, the workflow is roughly:
 
-1. Create a topic branch from where you want to base your work (usually master).
+1. Create a topic branch from where you want to base your work (usually `main`).
 2. Make commits of logical units.
 3. Make sure your commit messages are in the proper format (see [below](#commit-message-format)).
 4. Make sure your [code builds][build-cvo] and follows the [coding style](#coding-style)


### PR DESCRIPTION
From OCPBUGS-45922:

> Review your repository content for any assumptions related to branch naming. In rare scenarios, this may require opening pull requests against the target git repository to adopt the new "main" branch convention. For any such PR:
>    Ensure the PR is on /hold.
>    Ensure the PR is lgtm and approved.
>    Link the PR to this ticket by adding the ticket ID to the PR's title.
 