### PR TITLE
OCPBUGS-46410: Set `openshift.io/required-scc`: privileged annotation in `version` pods

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -225,6 +225,11 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 		Spec: batchv1.JobSpec{
 			ActiveDeadlineSeconds: deadline,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "privileged",
+					},
+				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
 						setContainerDefaults(corev1.Container{


### PR DESCRIPTION
A manual cherry-pick of the https://github.com/openshift/cluster-version-operator/pull/1106 PR for the `release-4.18` branch.