### PR TITLE
NO-JIRA: Refactor for readability

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -37,7 +37,6 @@ import (
 	"github.com/openshift/library-go/pkg/verify/store/configmap"
 	"github.com/openshift/library-go/pkg/verify/store/sigstore"
 
-	"github.com/openshift/cluster-version-operator/lib/capability"
 	"github.com/openshift/cluster-version-operator/lib/resourcebuilder"
 	"github.com/openshift/cluster-version-operator/lib/validation"
 	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
@@ -288,7 +287,7 @@ func (optr *Operator) LoadInitialPayload(ctx context.Context, startingRequiredFe
 	}
 
 	update, err := payload.LoadUpdate(optr.defaultPayloadDir(), optr.release.Image, optr.exclude, string(startingRequiredFeatureSet),
-		optr.clusterProfile, capability.GetKnownCapabilities())
+		optr.clusterProfile, configv1.KnownClusterVersionCapabilities)
 
 	if err != nil {
 		return nil, fmt.Errorf("the local release contents are invalid - no current version can be determined from disk: %v", err)

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -483,16 +485,8 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 		return w.status.DeepCopy()
 	}
 
-	// TODO: use slices.Collect(maps.Keys(priorCaps)) after bumping to go1.23
-	collectKeys := func(caps map[configv1.ClusterVersionCapability]struct{}) []configv1.ClusterVersionCapability {
-		var ret []configv1.ClusterVersionCapability
-		for k := range caps {
-			ret = append(ret, k)
-		}
-		return ret
-	}
 	// ensureEnabledCapabilities includes both explicitly and implicitly enabled capabilities
-	ensureEnabledCapabilities := append(collectKeys(priorCaps), w.alwaysEnableCapabilities...)
+	ensureEnabledCapabilities := append(slices.Collect(maps.Keys(priorCaps)), w.alwaysEnableCapabilities...)
 	work.Capabilities = capability.SetCapabilities(config, ensureEnabledCapabilities)
 
 	versionEqual, overridesEqual, capabilitiesEqual :=


### PR DESCRIPTION
Before we decide to use sets (K8S has util lib for sets) instead of maps for the fields from https://github.com/openshift/cluster-version-operator/blob/eb7599ced2534e0b15707947d94fe6bb5766e2cd/lib/capability/capability.go#L17-L21 
we may still do refactoring like these to improve the readability:

- Removed an unused constant `CapabilityAnnotation` and removed `DefaultCapabilitySet` and use its reference directly.
- Removed `setKnownCapabilities()` and `GetKnownCapabilities()`. Use `configv1.KnownClusterVersionCapabilities` instead. The logic is changed/improved a bit: A capability not enabled in all capSets is considered known now, but not before.
- The args`existingEnabled` and `alwaysEnabled` were handled in the same way in the function `SetCapabilities`. We removed the `alwaysEnabled` in the function and send their union when calling the function.

