### PR TITLE
WIP: Scanner fixes

### DIFF
--- a/bootstrap/bootstrap-pod.yaml
+++ b/bootstrap/bootstrap-pod.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: cluster-version-operator
 spec:
+  automountServiceAccountToken: false
   containers:
   - name: cluster-version-operator
     image: {{.ReleaseImage}}


### PR DESCRIPTION
Bootstrap CVO does not interact with bootstrap control plane, it gets a `--kubeconfig` param. Not mounting the SA token may prevent us from unknowingly relying on it and makes some manifest scanners happy.
