### PR TITLE
OTA-1427: Recompute node insights when MC/MCP changes

### DIFF
--- a/pkg/updatestatus/controlplaneinformer_test.go
+++ b/pkg/updatestatus/controlplaneinformer_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
@@ -15,6 +13,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclient "k8s.io/client-go/kubernetes/fake"
@@ -662,6 +661,12 @@ func newTestSyncContext(queueKey string) factory.SyncContext {
 	return testSyncContext{
 		queueKey:      queueKey,
 		eventRecorder: events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now())),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[any](),
+			workqueue.TypedRateLimitingQueueConfig[any]{
+				Name: "test",
+			},
+		),
 	}
 }
 

--- a/pkg/updatestatus/nodeinformer_test.go
+++ b/pkg/updatestatus/nodeinformer_test.go
@@ -2,7 +2,6 @@ package updatestatus
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -1013,14 +1012,13 @@ func Test_sync_with_node(t *testing.T) {
 			},
 		},
 		{
-			name: "error",
+			name: "no error if a node belongs to no MCP",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "worker-1",
 					Labels: map[string]string{"node-role.kubernetes.io/some": ""},
 				},
 			},
-			expectedErr: fmt.Errorf("failed to determine which machine config pool the node worker-1 belongs to"),
 		},
 	}
 

--- a/pkg/updatestatus/nodeinformer_test.go
+++ b/pkg/updatestatus/nodeinformer_test.go
@@ -13,10 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -148,32 +146,6 @@ func getMCP(name string) *machineconfigv1.MachineConfigPool {
 			},
 		}
 	}
-}
-
-func (c *nodeInformerController) initializeCaches() error {
-	var errs []error
-
-	if pools, err := c.machineConfigPools.List(labels.Everything()); err != nil {
-		errs = append(errs, err)
-	} else {
-		for _, pool := range pools {
-			c.machineConfigPoolSelectorCache.ingest(pool)
-		}
-	}
-	klog.V(2).Infof("Stored %d machineConfigPools in the cache", len(c.machineConfigPoolSelectorCache.cache))
-
-	machineConfigs, err := c.machineConfigs.List(labels.Everything())
-	if err != nil {
-		errs = append(errs, err)
-	} else {
-		for _, mc := range machineConfigs {
-			c.machineConfigVersionCache.ingest(mc)
-		}
-	}
-
-	klog.V(2).Infof("Stored %d machineConfig versions in the cache", len(c.machineConfigVersionCache.cache))
-
-	return kerrors.NewAggregate(errs)
 }
 
 func Test_whichMCP(t *testing.T) {


### PR DESCRIPTION
This is to address the following comments from the review [1]:

- [ ] Decide what to do with the code we copied from MCO (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1926022555)
- [x] Avoid iterating all MCP resource and re-computing selectors on every Node-triggered sync (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1927432583, https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932496850)
- [x] Recompute Node insights when MCP selectors change (changed selectors can change MCP membership, potentially making Node insights stale) (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932496850)
- [x] Avoid iterating all MC resources on every Node-triggered sync (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932496850)
- [x] Decide how to gracefully handle Nodes that are not matched by any MCP selector (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1928890801, https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932517120)
- [ ] Polishing condition reasons, messages and the "summary" insight message (https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932555649, https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932569171, https://github.com/openshift/cluster-version-operator/pull/1136#discussion_r1932571522)

[1]. https://github.com/openshift/cluster-version-operator/pull/1136#issuecomment-2621934987