### PR TITLE
OTA-1418: USC: Make messages more robust and decoupled

### DIFF
--- a/pkg/updatestatus/controlplaneinformer.go
+++ b/pkg/updatestatus/controlplaneinformer.go
@@ -178,7 +178,7 @@ func (c *controlPlaneInformerController) sync(ctx context.Context, syncCtx facto
 
 func makeInsightMsgForClusterOperator(coInsight *ClusterOperatorStatusInsight, acquiredAt metav1.Time) (informerMsg, error) {
 	insight := ControlPlaneInsight{
-		UID:        fmt.Sprintf("usc-co-%s", coInsight.Name),
+		UID:        fmt.Sprintf("co-%s", coInsight.Name),
 		AcquiredAt: acquiredAt,
 		ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 			Type:                         ClusterOperatorStatusInsightType,
@@ -311,7 +311,7 @@ func getImagePullSpec(ctx context.Context, name string, appsClient appsv1client.
 // between controllers.
 func makeInsightMsgForClusterVersion(cvInsight *ClusterVersionStatusInsight, acquiredAt metav1.Time) (informerMsg, error) {
 	insight := ControlPlaneInsight{
-		UID:        fmt.Sprintf("usc-cv-%s", cvInsight.Resource.Name),
+		UID:        fmt.Sprintf("cv-%s", cvInsight.Resource.Name),
 		AcquiredAt: acquiredAt,
 		ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 			Type:                        ClusterVersionStatusInsightType,
@@ -335,7 +335,7 @@ func uidForHealthInsight(healthInsight *HealthInsight) string {
 	encoded := base64.StdEncoding.EncodeToString(sum)
 	encoded = strings.TrimRight(encoded, "=")
 
-	return fmt.Sprintf("usc-%s", encoded)
+	return encoded
 }
 
 func makeInsightMsgForHealthInsight(healthInsight *HealthInsight, acquiredAt metav1.Time) (informerMsg, error) {

--- a/pkg/updatestatus/controlplaneinformer_test.go
+++ b/pkg/updatestatus/controlplaneinformer_test.go
@@ -95,8 +95,8 @@ func Test_sync_with_cv(t *testing.T) {
 			cvProgressing: &progressingTrue,
 			cvHistory:     []configv1.UpdateHistory{inProgress418},
 			expectedMsgs: map[string]ControlPlaneInsight{
-				"usc-cv-version": {
-					UID:        "usc-cv-version",
+				"cv-version": {
+					UID:        "cv-version",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: ClusterVersionStatusInsightType,
@@ -130,8 +130,8 @@ func Test_sync_with_cv(t *testing.T) {
 			cvProgressing: &progressingFalse,
 			cvHistory:     []configv1.UpdateHistory{completed418},
 			expectedMsgs: map[string]ControlPlaneInsight{
-				"usc-cv-version": {
-					UID:        "usc-cv-version",
+				"cv-version": {
+					UID:        "cv-version",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: ClusterVersionStatusInsightType,
@@ -166,8 +166,8 @@ func Test_sync_with_cv(t *testing.T) {
 			cvProgressing: &progressingTrue,
 			cvHistory:     []configv1.UpdateHistory{inProgress419, completed418},
 			expectedMsgs: map[string]ControlPlaneInsight{
-				"usc-cv-version": {
-					UID:        "usc-cv-version",
+				"cv-version": {
+					UID:        "cv-version",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: ClusterVersionStatusInsightType,
@@ -202,8 +202,8 @@ func Test_sync_with_cv(t *testing.T) {
 				uscForceHealthInsightAnnotation: "value-does-not-matter",
 			},
 			expectedMsgs: map[string]ControlPlaneInsight{
-				"usc-0kmuaUQRUJDOAIAF1KWTmg": {
-					UID:        "usc-0kmuaUQRUJDOAIAF1KWTmg",
+				"0kmuaUQRUJDOAIAF1KWTmg": {
+					UID:        "0kmuaUQRUJDOAIAF1KWTmg",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: HealthInsightType,
@@ -227,8 +227,8 @@ func Test_sync_with_cv(t *testing.T) {
 						},
 					},
 				},
-				"usc-cv-version": {
-					UID:        "usc-cv-version",
+				"cv-version": {
+					UID:        "cv-version",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: ClusterVersionStatusInsightType,
@@ -530,8 +530,8 @@ func Test_sync_with_co(t *testing.T) {
 		{
 			name: "Cluster during installation",
 			expectedMsgs: map[string]ControlPlaneInsight{
-				"usc-co-some-co": {
-					UID:        "usc-co-some-co",
+				"co-some-co": {
+					UID:        "co-some-co",
 					AcquiredAt: now,
 					ControlPlaneInsightUnion: ControlPlaneInsightUnion{
 						Type: ClusterOperatorStatusInsightType,

--- a/pkg/updatestatus/controlplaneinformer_test.go
+++ b/pkg/updatestatus/controlplaneinformer_test.go
@@ -292,8 +292,9 @@ func Test_sync_with_cv(t *testing.T) {
 					t.Fatalf("Failed to marshal expected insight: %v", err)
 				}
 				expectedMsgs = append(expectedMsgs, informerMsg{
-					uid:     uid,
-					insight: raw,
+					informer: controlPlaneInformerName,
+					uid:      uid,
+					insight:  raw,
 				})
 			}
 
@@ -302,6 +303,11 @@ func Test_sync_with_cv(t *testing.T) {
 			})
 			if diff := cmp.Diff(expectedMsgs, actualMsgs, ignoreOrder, cmp.AllowUnexported(informerMsg{})); diff != "" {
 				t.Errorf("Sync messages differ from expected:\n%s", diff)
+			}
+			for _, msg := range actualMsgs {
+				if err := msg.validate(); err != nil {
+					t.Errorf("Received message is invalid: %v\nMessage content: %v", err, msg)
+				}
 			}
 		})
 	}
@@ -584,13 +590,23 @@ func Test_sync_with_co(t *testing.T) {
 					t.Fatalf("Failed to marshal expected insight: %v", err)
 				}
 				expectedMsgs = append(expectedMsgs, informerMsg{
-					uid:     uid,
-					insight: raw,
+					informer: controlPlaneInformerName,
+					uid:      uid,
+					insight:  raw,
 				})
 			}
 
-			if diff := cmp.Diff(expectedMsgs, actualMsgs, cmp.AllowUnexported(informerMsg{})); diff != "" {
+			ignoreOrder := cmpopts.SortSlices(func(a, b informerMsg) bool {
+				return a.uid < b.uid
+			})
+			if diff := cmp.Diff(expectedMsgs, actualMsgs, ignoreOrder, cmp.AllowUnexported(informerMsg{})); diff != "" {
 				t.Errorf("Sync messages differ from expected:\n%s", diff)
+			}
+
+			for _, msg := range actualMsgs {
+				if err := msg.validate(); err != nil {
+					t.Errorf("Received message is invalid: %v\nMessage content: %v", err, msg)
+				}
 			}
 		})
 	}

--- a/pkg/updatestatus/nodeinformer.go
+++ b/pkg/updatestatus/nodeinformer.go
@@ -144,7 +144,7 @@ func (c *nodeInformerController) sync(ctx context.Context, syncCtx factory.SyncC
 
 func makeInsightMsgForNode(nodeInsight *NodeStatusInsight, acquiredAt metav1.Time) (informerMsg, error) {
 	insight := WorkerPoolInsight{
-		UID:        fmt.Sprintf("usc-node-%s", nodeInsight.Resource.Name),
+		UID:        fmt.Sprintf("node-%s", nodeInsight.Resource.Name),
 		AcquiredAt: acquiredAt,
 		WorkerPoolInsightUnion: WorkerPoolInsightUnion{
 			Type:              NodeStatusInsightType,

--- a/pkg/updatestatus/nodeinformer.go
+++ b/pkg/updatestatus/nodeinformer.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,7 +124,11 @@ func (c *nodeInformerController) sync(ctx context.Context, syncCtx factory.SyncC
 
 		now := c.now()
 		if insight := assessNode(node, mcp, machineConfigVersions, mostRecentVersionInCVHistory, now); insight != nil {
-			msg = makeInsightMsgForNode(insight, now)
+			msg, err = makeInsightMsgForNode(insight, now)
+			if err != nil {
+				klog.Errorf("BUG: Could not create insight message: %v", err)
+				return nil
+			}
 		}
 	default:
 		return fmt.Errorf("invalid queue key %s with unexpected type %s", queueKey, t)
@@ -140,22 +142,17 @@ func (c *nodeInformerController) sync(ctx context.Context, syncCtx factory.SyncC
 	return nil
 }
 
-func makeInsightMsgForNode(nodeInsight *NodeStatusInsight, acquiredAt metav1.Time) informerMsg {
-	uid := fmt.Sprintf("usc-node-%s", nodeInsight.Resource.Name)
+func makeInsightMsgForNode(nodeInsight *NodeStatusInsight, acquiredAt metav1.Time) (informerMsg, error) {
 	insight := WorkerPoolInsight{
-		UID:        uid,
+		UID:        fmt.Sprintf("usc-node-%s", nodeInsight.Resource.Name),
 		AcquiredAt: acquiredAt,
 		WorkerPoolInsightUnion: WorkerPoolInsightUnion{
 			Type:              NodeStatusInsightType,
 			NodeStatusInsight: nodeInsight,
 		},
 	}
-	// Should handle errors, but ultimately we will have a proper API and won’t need to serialize ourselves
-	rawInsight, _ := yaml.Marshal(insight)
-	return informerMsg{
-		uid:     uid,
-		insight: rawInsight,
-	}
+
+	return makeWorkerPoolsInsightMsg(insight, nodesInformerName)
 }
 
 func whichMCP(node *corev1.Node, pools []*machineconfigv1.MachineConfigPool) (*machineconfigv1.MachineConfigPool, error) {
@@ -376,7 +373,8 @@ func assessNode(node *corev1.Node, mcp *machineconfigv1.MachineConfigPool, machi
 }
 
 const (
-	nodeKindName = "Node"
+	nodeKindName      = "Node"
+	nodesInformerName = "ni"
 )
 
 func parseNodeInformerControllerQueueKey(queueKey string) (string, string, error) {

--- a/pkg/updatestatus/nodeinformer_test.go
+++ b/pkg/updatestatus/nodeinformer_test.go
@@ -1040,13 +1040,20 @@ func Test_sync_with_node(t *testing.T) {
 					t.Fatalf("Failed to marshal expected insight: %v", err)
 				}
 				expectedMsgs = append(expectedMsgs, informerMsg{
-					uid:     uid,
-					insight: raw,
+					informer: nodesInformerName,
+					uid:      uid,
+					insight:  raw,
 				})
 			}
 
 			if diff := cmp.Diff(expectedMsgs, actualMsgs, cmp.AllowUnexported(informerMsg{})); diff != "" {
 				t.Errorf("Sync messages differ from expected:\n%s", diff)
+			}
+
+			for _, msg := range actualMsgs {
+				if err := msg.validate(); err != nil {
+					t.Errorf("Received message is invalid: %v\nMessage content: %v", err, msg)
+				}
 			}
 		})
 	}

--- a/pkg/updatestatus/nodeinformer_test.go
+++ b/pkg/updatestatus/nodeinformer_test.go
@@ -915,8 +915,8 @@ func Test_sync_with_node(t *testing.T) {
 				},
 			},
 			expectedMsgs: map[string]WorkerPoolInsight{
-				"usc-node-worker-1": {
-					UID:        "usc-node-worker-1",
+				"node-worker-1": {
+					UID:        "node-worker-1",
 					AcquiredAt: now,
 					WorkerPoolInsightUnion: WorkerPoolInsightUnion{
 						Type: NodeStatusInsightType,
@@ -957,8 +957,8 @@ func Test_sync_with_node(t *testing.T) {
 				},
 			},
 			expectedMsgs: map[string]WorkerPoolInsight{
-				"usc-node-worker-1": {
-					UID:        "usc-node-worker-1",
+				"node-worker-1": {
+					UID:        "node-worker-1",
 					AcquiredAt: now,
 					WorkerPoolInsightUnion: WorkerPoolInsightUnion{
 						Type: NodeStatusInsightType,

--- a/pkg/updatestatus/nodeinformer_test.go
+++ b/pkg/updatestatus/nodeinformer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1046,7 +1047,11 @@ func Test_sync_with_node(t *testing.T) {
 				})
 			}
 
-			if diff := cmp.Diff(expectedMsgs, actualMsgs, cmp.AllowUnexported(informerMsg{})); diff != "" {
+			ignoreOrder := cmpopts.SortSlices(func(a, b informerMsg) bool {
+				return a.uid < b.uid
+			})
+
+			if diff := cmp.Diff(expectedMsgs, actualMsgs, ignoreOrder, cmp.AllowUnexported(informerMsg{})); diff != "" {
 				t.Errorf("Sync messages differ from expected:\n%s", diff)
 			}
 

--- a/pkg/updatestatus/updatestatuscontroller.go
+++ b/pkg/updatestatus/updatestatuscontroller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
@@ -31,6 +32,32 @@ type informerMsg struct {
 
 	uid     string
 	insight []byte
+}
+
+func makeControlPlaneInsightMsg(insight ControlPlaneInsight, informer string) (informerMsg, error) {
+	rawInsight, err := yaml.Marshal(insight)
+	if err != nil {
+		return informerMsg{}, err
+	}
+	msg := informerMsg{
+		informer: informer,
+		uid:      insight.UID,
+		insight:  rawInsight,
+	}
+	return msg, msg.validate()
+}
+
+func makeWorkerPoolsInsightMsg(insight WorkerPoolInsight, informer string) (informerMsg, error) {
+	rawInsight, err := yaml.Marshal(insight)
+	if err != nil {
+		return informerMsg{}, err
+	}
+	msg := informerMsg{
+		informer: informer,
+		uid:      insight.UID,
+		insight:  rawInsight,
+	}
+	return msg, msg.validate()
 }
 
 type sendInsightFn func(insight informerMsg)

--- a/pkg/updatestatus/updatestatuscontroller.go
+++ b/pkg/updatestatus/updatestatuscontroller.go
@@ -151,7 +151,7 @@ func (c *updateStatusController) processInsightMsg(message informerMsg) bool {
 		klog.Warningf("USC :: Collector :: Invalid message: %v", err)
 		return false
 	}
-	klog.Infof("USC :: Collector :: Received insight from informer (uid=%s)", message.uid)
+	klog.Infof("USC :: Collector :: Received insight from informer %q (uid=%s)", message.informer, message.uid)
 	c.updateInsightInStatusApi(message)
 
 	return true
@@ -167,7 +167,6 @@ func (c *updateStatusController) setupInsightReceiver() (factory.PostStartHook, 
 		klog.V(2).Info("USC :: Collector :: Starting insight collector")
 		for {
 			select {
-			// Receive an insight from the informer, update it in the status API ConfigMap and commit it to the cluster
 			case message := <-fromInformers:
 				if c.processInsightMsg(message) {
 					syncCtx.Queue().Add(statusApiConfigMap)

--- a/pkg/updatestatus/updatestatuscontroller_test.go
+++ b/pkg/updatestatus/updatestatuscontroller_test.go
@@ -126,6 +126,54 @@ func Test_updateStatusController(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                "empty informer -> message gets dropped",
+			controllerConfigMap: nil,
+			informerMsg: []informerMsg{
+				{
+					informer: "",
+					uid:      "item",
+					insight:  []byte("msg from informer one"),
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:                "empty uid -> message gets dropped",
+			controllerConfigMap: nil,
+			informerMsg: []informerMsg{
+				{
+					informer: "one",
+					uid:      "",
+					insight:  []byte("msg from informer one"),
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:                "empty insight payload -> message gets dropped",
+			controllerConfigMap: nil,
+			informerMsg: []informerMsg{
+				{
+					informer: "one",
+					uid:      "item",
+					insight:  []byte{},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:                "nil insight payload -> message gets dropped",
+			controllerConfigMap: nil,
+			informerMsg: []informerMsg{
+				{
+					informer: "one",
+					uid:      "item",
+					insight:  nil,
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/updatestatus/updatestatuscontroller_test.go
+++ b/pkg/updatestatus/updatestatuscontroller_test.go
@@ -41,12 +41,12 @@ func Test_updateStatusController(t *testing.T) {
 			name: "no messages, state -> unchanged state",
 			controllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"usc-cv-version": "value",
+					"usc.cpi.cv-version": "value",
 				},
 			},
 			expected: &corev1.ConfigMap{
 				Data: map[string]string{
-					"usc-cv-version": "value",
+					"usc.cpi.cv-version": "value",
 				},
 			},
 		},
@@ -55,13 +55,14 @@ func Test_updateStatusController(t *testing.T) {
 			controllerConfigMap: nil,
 			informerMsg: []informerMsg{
 				{
-					uid:     "usc-cv-version",
-					insight: []byte("value"),
+					informer: "cpi",
+					uid:      "cv-version",
+					insight:  []byte("value"),
 				},
 			},
 			expected: &corev1.ConfigMap{
 				Data: map[string]string{
-					"usc-cv-version": "value",
+					"usc.cpi.cv-version": "value",
 				},
 			},
 		},
@@ -69,34 +70,59 @@ func Test_updateStatusController(t *testing.T) {
 			name: "messages over time build state over old state",
 			controllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
-					"usc-kept":        "kept",
-					"usc-overwritten": "old",
+					"usc.cpi.kept":        "kept",
+					"usc.cpi.overwritten": "old",
 				},
 			},
 			informerMsg: []informerMsg{
 				{
-					uid:     "usc-new-item",
-					insight: []byte("msg1"),
+					informer: "cpi",
+					uid:      "new-item",
+					insight:  []byte("msg1"),
 				},
 				{
-					uid:     "usc-overwritten",
-					insight: []byte("msg2 (overwritten intermediate)"),
+					informer: "cpi",
+					uid:      "overwritten",
+					insight:  []byte("msg2 (overwritten intermediate)"),
 				},
 				{
-					uid:     "usc-another",
-					insight: []byte("msg3"),
+					informer: "cpi",
+					uid:      "another",
+					insight:  []byte("msg3"),
 				},
 				{
-					uid:     "usc-overwritten",
-					insight: []byte("msg4 (overwritten final)"),
+					informer: "cpi",
+					uid:      "overwritten",
+					insight:  []byte("msg4 (overwritten final)"),
 				},
 			},
 			expected: &corev1.ConfigMap{
 				Data: map[string]string{
-					"usc-kept":        "kept",
-					"usc-new-item":    "msg1",
-					"usc-another":     "msg3",
-					"usc-overwritten": "msg4 (overwritten final)",
+					"usc.cpi.kept":        "kept",
+					"usc.cpi.new-item":    "msg1",
+					"usc.cpi.another":     "msg3",
+					"usc.cpi.overwritten": "msg4 (overwritten final)",
+				},
+			},
+		},
+		{
+			name: "messages can come from different informers",
+			informerMsg: []informerMsg{
+				{
+					informer: "one",
+					uid:      "item",
+					insight:  []byte("msg from informer one"),
+				},
+				{
+					informer: "two",
+					uid:      "item",
+					insight:  []byte("msg from informer two"),
+				},
+			},
+			expected: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.item": "msg from informer one",
+					"usc.two.item": "msg from informer two",
 				},
 			},
 		},


### PR DESCRIPTION
- Make the informer -> usc message contain an identification of the informer who sent it
- Decouple insight UIDs from usc assumptions (informers no longer need to prefix UIDs with `usc-`)
- Emulate by-informer partitioning by encoding informer in ConfigMap key name
- Make USC cope with invalid messages by dropping them (liberal in what it accepts)
- Extract code to create valid messages from insights assuming insights are valid
- NodeInformer needs to be adapted for the changes too.

There are changes in the API that separate a `ControlPlaneInsight` and `WorkerPoolsInsight`, these had to be partially accommodated in the chance, but not fully. We can expect the API to change a bit (or a lot, based on the current round of review) so I do not feel like investing effort to polish this up 100%.