### PR TITLE
OTA-209: Resolve lint issues

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"context"
-	"math/rand"
-	"time"
-
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
@@ -21,9 +18,6 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			// To help debugging, immediately log version
 			klog.Info(version.String)
-
-			//Setting seed for all the calls to rand methods in the code
-			rand.Seed(time.Now().UnixNano())
 
 			if err := opts.Run(context.Background()); err != nil {
 				klog.Fatalf("error: %v", err)

--- a/lib/resourcemerge/batch_test.go
+++ b/lib/resourcemerge/batch_test.go
@@ -414,7 +414,7 @@ func TestEnsureJob_JobSpec_Selector(t *testing.T) {
 				switch r := recover(); r {
 				case nil:
 					if test.expectedPanic {
-						t.Errorf(test.name + " should have panicked!")
+						t.Errorf("%s should have panicked!", test.name)
 					}
 				default:
 					if !test.expectedPanic {


### PR DESCRIPTION
These issues are not currently detected by the `ci/prow/lint` job as the job uses the version `v1.54.2` of the `golangci-lint` tool [[1](https://github.com/openshift/release/blob/2576d99d6c11a20958b44ec140e1f382982e0433/ci-operator/config/openshift/cluster-version-operator/openshift-cluster-version-operator-main.yaml#L2-L5)].

It is needed to update the tool to support go `1.23`, which will be introduced in https://github.com/openshift/cluster-version-operator/pull/1147 PR. However, updating the tool right now in https://github.com/openshift/release/pull/61253 would cause the `ci/prow/lint` [presubmit to fail on PRs](https://github.com/openshift/release/pull/61253#issuecomment-2634805522).

Fix the lint issues in this PR. After that, we will update the `golangci-lint` tool. No disruptions to existing PRs will be introduced.