### PR TITLE
OTA-1418: USC: Drop unknown insights after grace period 

### DIFF
--- a/pkg/updatestatus/updatestatuscontroller.go
+++ b/pkg/updatestatus/updatestatuscontroller.go
@@ -25,6 +25,10 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 )
 
+const (
+	unknownInsightGracePeriod = 60 * time.Second
+)
+
 // informerMsg is the communication structure between informers and the update status controller. It contains the UID of
 // the insight and the insight itself, serialized as YAML. Passing serialized avoids shared data access problems. Until
 // we have the Status API we need to serialize ourselves anyway.
@@ -72,6 +76,9 @@ func isStatusInsightKey(k string) bool {
 	return strings.HasPrefix(k, "usc.")
 }
 
+// insightExpirations is UID -> expiration time map
+type insightExpirations map[string]time.Time
+
 // updateStatusController is a controller that collects insights from informers and maintains a ConfigMap with the insights
 // until we have a proper UpdateStatus API. The controller maintains an internal desired content of the ConfigMap (even
 // if it does not exist in the cluster) and updates it in the cluster when new insights are received, or when the ConfigMap
@@ -98,11 +105,20 @@ type updateStatusController struct {
 		sync.Mutex
 		cm *corev1.ConfigMap
 
+		// unknownInsightExpirations is a map of informer -> map of UID -> expiration time. It is used to track insights
+		// that were reported by informers but are no longer known to them. The API keeps unknown insights until they
+		// expire. If an insight is reported as known again before it expires, it is removed from the map.
+		// TODO (muller): Needs to periodically rebuilt to avoid leaking memory
+		unknownInsightExpirations map[string]insightExpirations
+
 		// processed is the number of insights processed, used for testing
 		processed int
 	}
 
 	recorder events.Recorder
+	// TODO: Get rid of this and use `clock.Clock` in all controllers, passed from start.go main function's
+	// controllercmd.ControllerContext
+	now func() time.Time
 }
 
 // newUpdateStatusController creates a new update status controller and returns it. The second return value is a function
@@ -117,6 +133,7 @@ func newUpdateStatusController(
 	c := &updateStatusController{
 		configMaps: coreClient.CoreV1().ConfigMaps(uscNamespace),
 		recorder:   uscRecorder,
+		now:        time.Now,
 	}
 
 	startInsightReceiver, sendInsight := c.setupInsightReceiver()
@@ -223,17 +240,65 @@ func (c *updateStatusController) updateInsightInStatusApi(msg informerMsg) {
 }
 
 // removeUnknownInsights removes insights from the status API that are no longer reported as known to the informer
-// that originally reported them.
+// that originally reported them. The insights are kept for a grace period after they are no longer reported as known
+// and eventually dropped if they are not reported as known again within that period.
 // Assumes the statusApi field is locked.
 func (c *updateStatusController) removeUnknownInsights(message informerMsg) {
 	known := sets.New(message.knownInsights...)
 	known.Insert(message.uid)
 	informerPrefix := fmt.Sprintf("usc.%s.", message.informer)
 	for key := range c.statusApi.cm.Data {
-		if strings.HasPrefix(key, informerPrefix) && !known.Has(strings.TrimPrefix(key, informerPrefix)) {
-			delete(c.statusApi.cm.Data, key)
-			klog.V(2).Infof("USC :: Collector :: Dropped insight %q because it is no longer reported as known by informer %q", key, message.informer)
+		if strings.HasPrefix(key, informerPrefix) {
+			uid := strings.TrimPrefix(key, informerPrefix)
+			c.handleInsightExpiration(message.informer, known.Has(uid), uid)
 		}
+	}
+
+	if len(c.statusApi.unknownInsightExpirations) > 0 && len(c.statusApi.unknownInsightExpirations[message.informer]) == 0 {
+		delete(c.statusApi.unknownInsightExpirations, message.informer)
+	}
+	if len(c.statusApi.unknownInsightExpirations) == 0 {
+		c.statusApi.unknownInsightExpirations = nil
+	}
+}
+
+// handleInsightExpiration considers potential expiration of an insight present in the API based on whether the informer
+// knows about it.
+// If the informer knows about the insight, it is not dropped from the API and any previous expiration is cancelled.
+// If the informer does not know about the insight then it is either set to expire in the future if no expiration is
+// set yet, or the expiration is checked to see whether the insight should be dropped.
+func (c *updateStatusController) handleInsightExpiration(informer string, knows bool, uid string) {
+	now := c.now()
+
+	if knows {
+		if c.statusApi.unknownInsightExpirations != nil && c.statusApi.unknownInsightExpirations[informer] != nil {
+			delete(c.statusApi.unknownInsightExpirations[informer], uid)
+		}
+		return
+	}
+
+	expireIn := now.Add(unknownInsightGracePeriod)
+	keepLog := func(expire time.Time) {
+		klog.V(2).Infof("USC :: Collector :: Keeping insight %q until %s after it is no longer reported as known by informer %q", uid, expire, informer)
+	}
+	switch {
+	// Two cases when we first consider an insight as unknown -> set expiration
+	case c.statusApi.unknownInsightExpirations == nil:
+		c.statusApi.unknownInsightExpirations = map[string]insightExpirations{informer: {uid: expireIn}}
+		keepLog(expireIn)
+	case c.statusApi.unknownInsightExpirations[informer][uid].IsZero():
+		c.statusApi.unknownInsightExpirations[informer] = insightExpirations{uid: expireIn}
+		keepLog(expireIn)
+
+	// Already set for expiration but still in grace period -> keep insight
+	case c.statusApi.unknownInsightExpirations[informer][uid].After(now):
+		keepLog(c.statusApi.unknownInsightExpirations[informer][uid])
+
+	// Already set for expiration and grace period expired -> drop insight
+	default:
+		delete(c.statusApi.unknownInsightExpirations[informer], uid)
+		delete(c.statusApi.cm.Data, fmt.Sprintf("usc.%s.%s", informer, uid))
+		klog.V(2).Infof("USC :: Collector :: Dropped insight %q because it is no longer reported as known by informer %q", uid, informer)
 	}
 }
 

--- a/pkg/updatestatus/updatestatuscontroller_test.go
+++ b/pkg/updatestatus/updatestatuscontroller_test.go
@@ -16,25 +16,35 @@ import (
 )
 
 func Test_updateStatusController(t *testing.T) {
+	var now = time.Now()
+	var minus90sec = now.Add(-90 * time.Second)
+	var minus30sec = now.Add(-30 * time.Second)
+	var plus30sec = now.Add(30 * time.Second)
+	var plus60sec = now.Add(1 * time.Minute)
+
 	testCases := []struct {
-		name                string
+		name string
+
 		controllerConfigMap *corev1.ConfigMap
+		unknownExpirations  map[string]insightExpirations
 
 		informerMsg []informerMsg
-		expected    *corev1.ConfigMap
+
+		expectedControllerConfigMap *corev1.ConfigMap
+		expectedUnknownExpirations  map[string]insightExpirations
 	}{
 		{
-			name:                "no messages, no state -> no state",
-			controllerConfigMap: nil,
-			informerMsg:         []informerMsg{},
-			expected:            nil,
+			name:                        "no messages, no state -> no state",
+			controllerConfigMap:         nil,
+			informerMsg:                 []informerMsg{},
+			expectedControllerConfigMap: nil,
 		},
 		{
 			name: "no messages, empty state -> empty state",
 			controllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{},
 			},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{},
 			},
 		},
@@ -45,7 +55,7 @@ func Test_updateStatusController(t *testing.T) {
 					"usc.cpi.cv-version": "value",
 				},
 			},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.cpi.cv-version": "value",
 				},
@@ -61,7 +71,7 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  []byte("value"),
 				},
 			},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.cpi.cv-version": "value",
 				},
@@ -101,7 +111,7 @@ func Test_updateStatusController(t *testing.T) {
 					knownInsights: []string{"kept", "new-item", "another"},
 				},
 			},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.cpi.kept":        "kept",
 					"usc.cpi.new-item":    "msg1",
@@ -124,7 +134,7 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  []byte("msg from informer two"),
 				},
 			},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.one.item": "msg from informer one",
 					"usc.two.item": "msg from informer two",
@@ -141,7 +151,7 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  []byte("msg from informer one"),
 				},
 			},
-			expected: nil,
+			expectedControllerConfigMap: nil,
 		},
 		{
 			name:                "empty uid -> message gets dropped",
@@ -153,7 +163,7 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  []byte("msg from informer one"),
 				},
 			},
-			expected: nil,
+			expectedControllerConfigMap: nil,
 		},
 		{
 			name:                "empty insight payload -> message gets dropped",
@@ -165,7 +175,7 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  []byte{},
 				},
 			},
-			expected: nil,
+			expectedControllerConfigMap: nil,
 		},
 		{
 			name:                "nil insight payload -> message gets dropped",
@@ -177,10 +187,10 @@ func Test_updateStatusController(t *testing.T) {
 					insight:  nil,
 				},
 			},
-			expected: nil,
+			expectedControllerConfigMap: nil,
 		},
 		{
-			name: "unknown message gets removed from state",
+			name: "unknown insight -> not removed from state immediately but set for expiration",
 			controllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.one.old": "payload",
@@ -192,11 +202,88 @@ func Test_updateStatusController(t *testing.T) {
 				insight:       []byte("new payload"),
 				knownInsights: nil,
 			}},
-			expected: &corev1.ConfigMap{
+			expectedControllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+					"usc.one.new": "new payload",
+				},
+			},
+			expectedUnknownExpirations: map[string]insightExpirations{
+				"one": {"old": plus60sec},
+			},
+		},
+		{
+			name: "unknown insight already set for expiration -> not removed from state while not expired yet",
+			controllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+				},
+			},
+			unknownExpirations: map[string]insightExpirations{
+				"one": {"old": plus30sec},
+			},
+			informerMsg: []informerMsg{{
+				informer:      "one",
+				uid:           "new",
+				insight:       []byte("new payload"),
+				knownInsights: nil,
+			}},
+			expectedControllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+					"usc.one.new": "new payload",
+				},
+			},
+			expectedUnknownExpirations: map[string]insightExpirations{
+				"one": {"old": plus30sec},
+			},
+		},
+		{
+			name: "previously unknown insight set for expiration is known again -> kept in state and expire dropped",
+			controllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+				},
+			},
+			unknownExpirations: map[string]insightExpirations{
+				"one": {"old": minus30sec},
+			},
+			informerMsg: []informerMsg{{
+				informer:      "one",
+				uid:           "new",
+				insight:       []byte("new payload"),
+				knownInsights: []string{"old"},
+			}},
+			expectedControllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+					"usc.one.new": "new payload",
+				},
+			},
+			expectedUnknownExpirations: nil,
+		},
+		{
+			name: "previously unknown insight expired and never became known again -> dropped from state and expire dropped",
+			controllerConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"usc.one.old": "payload",
+				},
+			},
+			unknownExpirations: map[string]insightExpirations{
+				"one": {"old": minus90sec},
+			},
+			informerMsg: []informerMsg{{
+				informer:      "one",
+				uid:           "new",
+				insight:       []byte("new payload"),
+				knownInsights: nil,
+			}},
+			expectedControllerConfigMap: &corev1.ConfigMap{
 				Data: map[string]string{
 					"usc.one.new": "new payload",
 				},
 			},
+			expectedUnknownExpirations: nil,
 		},
 	}
 
@@ -208,9 +295,16 @@ func Test_updateStatusController(t *testing.T) {
 
 			controller := updateStatusController{
 				configMaps: kubeClient.CoreV1().ConfigMaps(uscNamespace),
+				now:        func() time.Time { return now },
 			}
 			controller.statusApi.Lock()
 			controller.statusApi.cm = tc.controllerConfigMap
+			for informer, expirations := range tc.unknownExpirations {
+				if controller.statusApi.unknownInsightExpirations == nil {
+					controller.statusApi.unknownInsightExpirations = make(map[string]insightExpirations)
+				}
+				controller.statusApi.unknownInsightExpirations[informer] = expirations
+			}
 			controller.statusApi.Unlock()
 
 			startInsightReceiver, sendInsight := controller.setupInsightReceiver()
@@ -227,19 +321,24 @@ func Test_updateStatusController(t *testing.T) {
 
 			expectedProcessed := len(tc.informerMsg)
 			var sawProcessed int
-			var diff string
+			var diffConfigMap string
+			var diffExpirations string
 			backoff := wait.Backoff{Duration: 5 * time.Millisecond, Factor: 2, Steps: 10}
 			if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 				controller.statusApi.Lock()
 				defer controller.statusApi.Unlock()
 
 				sawProcessed = controller.statusApi.processed
-				diff = cmp.Diff(tc.expected, controller.statusApi.cm)
+				diffConfigMap = cmp.Diff(tc.expectedControllerConfigMap, controller.statusApi.cm)
+				diffExpirations = cmp.Diff(tc.expectedUnknownExpirations, controller.statusApi.unknownInsightExpirations)
 
-				return diff == "" && sawProcessed == expectedProcessed, nil
+				return diffConfigMap == "" && diffExpirations == "" && sawProcessed == expectedProcessed, nil
 			}); err != nil {
-				if diff != "" {
-					t.Errorf("controller config map differs from expected:\n%s", diff)
+				if diffConfigMap != "" {
+					t.Errorf("controller config map differs from expected:\n%s", diffConfigMap)
+				}
+				if diffExpirations != "" {
+					t.Errorf("expirations differ from expected:\n%s", diffExpirations)
 				}
 				if controller.statusApi.processed != len(tc.informerMsg) {
 					t.Errorf("controller processed %d messages, expected %d", controller.statusApi.processed, len(tc.informerMsg))


### PR DESCRIPTION
When we first see an insight in the API that is no longer known by the informer that originally reported it, mark it for expiration instead of dropping it right away. If it becomes known again, unmark the expiration. If it does not become known until expired, drop it from the API.