### PR TITLE
NO-JIRA: Fix a few AMD64-oriented tests on Non-AMD64 machines

### DIFF
--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -125,7 +126,7 @@ func newOperator(url, version string, promqlMock clusterconditions.Condition) (*
 		release:               currentRelease,
 	}
 	availableUpdates := &availableUpdates{
-		Architecture: "amd64",
+		Architecture: runtime.GOARCH,
 		Current:      configv1.Release{Version: version, Image: "payload/" + version},
 	}
 	return availableUpdates, operator

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2357,7 +2357,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2400,7 +2400,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2442,7 +2442,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2491,7 +2491,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,
@@ -2555,7 +2555,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Current: configv1.Release{
 					Version:  "4.0.1",
 					Image:    "image/image:v4.0.1",
@@ -2622,7 +2622,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Current:       configv1.Release{Version: "4.0.1", Image: "image/image:v4.0.1"},
 				Updates: []configv1.Release{
 					{Version: "4.0.2", Image: "image/image:v4.0.2"},
@@ -2723,7 +2723,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 			wantUpdates: &availableUpdates{
 				UpdateService: "http://localhost:8080/graph",
 				Channel:       "fast",
-				Architecture:  "amd64",
+				Architecture:  runtime.GOARCH,
 				Condition: configv1.ClusterOperatorStatusCondition{
 					Type:    configv1.RetrievedUpdates,
 					Status:  configv1.ConditionFalse,


### PR DESCRIPTION
Those tests fail on e.g., the arm64 machine.

```console
$ go test -v -count 1 ./pkg/cvo/... | rg 'SKIP:|Skipped'
    availableupdates_test.go:167: Skipped the test on arm64
--- SKIP: TestSyncAvailableUpdates (0.00s)
    cvo_test.go:2786: Skipped the test case "no operator or ClusterVersion upstream uses the default update service" on arm64
    cvo_test.go:2786: Skipped the test case "report an error condition when channel isn't set" on arm64
    cvo_test.go:2786: Skipped the test case "report an error condition when no current version is set" on arm64
    cvo_test.go:2786: Skipped the test case "report an error condition when the http server reports an error" on arm64
    cvo_test.go:2786: Skipped the test case "set available updates and clear error state when success and empty" on arm64
    cvo_test.go:2786: Skipped the test case "calculate available update edges" on arm64
    cvo_test.go:2786: Skipped the test case "operator update service takes precedence over ClusterVersion upstream" on arm64
    --- SKIP: TestOperator_availableUpdatesSync/no_operator_or_ClusterVersion_upstream_uses_the_default_update_service (0.16s)
    --- SKIP: TestOperator_availableUpdatesSync/report_an_error_condition_when_channel_isn't_set (0.00s)
    --- SKIP: TestOperator_availableUpdatesSync/report_an_error_condition_when_no_current_version_is_set (0.00s)
    --- SKIP: TestOperator_availableUpdatesSync/report_an_error_condition_when_the_http_server_reports_an_error (0.00s)
    --- SKIP: TestOperator_availableUpdatesSync/set_available_updates_and_clear_error_state_when_success_and_empty (0.00s)
    --- SKIP: TestOperator_availableUpdatesSync/calculate_available_update_edges (0.00s)
    --- SKIP: TestOperator_availableUpdatesSync/operator_update_service_takes_precedence_over_ClusterVersion_upstream (0.00s)
```