### PR TITLE
NO-JIRA: Rename fields in ClusterCapabilities for readability

### DIFF
--- a/lib/capability/capability_test.go
+++ b/lib/capability/capability_test.go
@@ -108,20 +108,20 @@ func TestSetCapabilities(t *testing.T) {
 				test.wantKnownKeys = configv1.KnownClusterVersionCapabilities
 				test.wantEnabledKeys = configv1.ClusterVersionCapabilitySets[configv1.ClusterVersionCapabilitySetCurrent]
 			}
-			if len(caps.KnownCapabilities) != len(test.wantKnownKeys) {
-				t.Errorf("Incorrect number of KnownCapabilities keys, wanted: %q. KnownCapabilities returned: %v", test.wantKnownKeys, caps.KnownCapabilities)
+			if len(caps.Known) != len(test.wantKnownKeys) {
+				t.Errorf("Incorrect number of Known keys, wanted: %q. Known returned: %v", test.wantKnownKeys, caps.Known)
 			}
 			for _, v := range test.wantKnownKeys {
-				if _, ok := caps.KnownCapabilities[v]; !ok {
-					t.Errorf("Missing KnownCapabilities key %q. KnownCapabilities returned : %v", v, caps.KnownCapabilities)
+				if _, ok := caps.Known[v]; !ok {
+					t.Errorf("Missing Known key %q. Known returned : %v", v, caps.Known)
 				}
 			}
-			if len(caps.EnabledCapabilities) != len(test.wantEnabledKeys) {
-				t.Errorf("Incorrect number of EnabledCapabilities keys, wanted: %q. EnabledCapabilities returned: %v", test.wantEnabledKeys, caps.EnabledCapabilities)
+			if len(caps.Enabled) != len(test.wantEnabledKeys) {
+				t.Errorf("Incorrect number of Enabled keys, wanted: %q. Enabled returned: %v", test.wantEnabledKeys, caps.Enabled)
 			}
 			for _, v := range test.wantEnabledKeys {
-				if _, ok := caps.EnabledCapabilities[v]; !ok {
-					t.Errorf("Missing EnabledCapabilities key %q. EnabledCapabilities returned : %v", v, caps.EnabledCapabilities)
+				if _, ok := caps.Enabled[v]; !ok {
+					t.Errorf("Missing Enabled key %q. Enabled returned : %v", v, caps.Enabled)
 				}
 			}
 		})
@@ -150,19 +150,19 @@ func TestSetCapabilitiesWithImplicitlyEnabled(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			caps := SetCapabilities(test.config, test.priorEnabled)
-			if len(caps.ImplicitlyEnabledCapabilities) != len(test.wantImplicit) {
-				t.Errorf("Incorrect number of implicitly enabled keys, wanted: %q. ImplicitlyEnabledCapabilities returned: %v", test.wantImplicit, caps.ImplicitlyEnabledCapabilities)
+			if len(caps.ImplicitlyEnabled) != len(test.wantImplicit) {
+				t.Errorf("Incorrect number of implicitly enabled keys, wanted: %q. ImplicitlyEnabled returned: %v", test.wantImplicit, caps.ImplicitlyEnabled)
 			}
 			for _, wanted := range test.wantImplicit {
 				found := false
-				for _, have := range caps.ImplicitlyEnabledCapabilities {
+				for _, have := range caps.ImplicitlyEnabled {
 					if wanted == string(have) {
 						found = true
 						break
 					}
 				}
 				if !found {
-					t.Errorf("Missing ImplicitlyEnabledCapabilities key %q. ImplicitlyEnabledCapabilities returned : %v", wanted, caps.ImplicitlyEnabledCapabilities)
+					t.Errorf("Missing ImplicitlyEnabled key %q. ImplicitlyEnabled returned : %v", wanted, caps.ImplicitlyEnabled)
 				}
 			}
 		})
@@ -177,8 +177,8 @@ func TestGetCapabilitiesStatus(t *testing.T) {
 	}{
 		{name: "empty capabilities",
 			caps: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{},
 			},
 			wantStatus: configv1.ClusterVersionCapabilitiesStatus{
 				EnabledCapabilities: []configv1.ClusterVersionCapability{},
@@ -187,8 +187,8 @@ func TestGetCapabilitiesStatus(t *testing.T) {
 		},
 		{name: "capabilities",
 			caps: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{configv1.ClusterVersionCapabilityOpenShiftSamples: {}},
 			},
 			wantStatus: configv1.ClusterVersionCapabilitiesStatus{
 				EnabledCapabilities: []configv1.ClusterVersionCapability{configv1.ClusterVersionCapabilityOpenShiftSamples},
@@ -200,7 +200,7 @@ func TestGetCapabilitiesStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			config := GetCapabilitiesStatus(test.caps)
 			if len(config.KnownCapabilities) != len(test.wantStatus.KnownCapabilities) {
-				t.Errorf("Incorrect number of KnownCapabilities keys, wanted: %q. KnownCapabilities returned: %v",
+				t.Errorf("Incorrect number of Known keys, wanted: %q. Known returned: %v",
 					test.wantStatus.KnownCapabilities, config.KnownCapabilities)
 			}
 			for _, v := range test.wantStatus.KnownCapabilities {
@@ -211,12 +211,12 @@ func TestGetCapabilitiesStatus(t *testing.T) {
 						break
 					}
 					if !vFound {
-						t.Errorf("Missing KnownCapabilities key %q. KnownCapabilities returned : %v", v, config.KnownCapabilities)
+						t.Errorf("Missing Known key %q. Known returned : %v", v, config.KnownCapabilities)
 					}
 				}
 			}
 			if len(config.EnabledCapabilities) != len(test.wantStatus.EnabledCapabilities) {
-				t.Errorf("Incorrect number of EnabledCapabilities keys, wanted: %q. EnabledCapabilities returned: %v",
+				t.Errorf("Incorrect number of Enabled keys, wanted: %q. Enabled returned: %v",
 					test.wantStatus.EnabledCapabilities, config.EnabledCapabilities)
 			}
 			for _, v := range test.wantStatus.EnabledCapabilities {
@@ -227,7 +227,7 @@ func TestGetCapabilitiesStatus(t *testing.T) {
 						break
 					}
 					if !vFound {
-						t.Errorf("Missing EnabledCapabilities key %q. EnabledCapabilities returned : %v", v, config.EnabledCapabilities)
+						t.Errorf("Missing Enabled key %q. Enabled returned : %v", v, config.EnabledCapabilities)
 					}
 				}
 			}
@@ -249,16 +249,16 @@ func TestSetFromImplicitlyEnabledCapabilities(t *testing.T) {
 				configv1.ClusterVersionCapability("cap4"),
 			},
 			capabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{
 					configv1.ClusterVersionCapability("cap1"),
 				},
 			},
 			wantCapabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{
 					configv1.ClusterVersionCapability("cap2"),
 					configv1.ClusterVersionCapability("cap3"),
 					configv1.ClusterVersionCapability("cap4"),
@@ -270,28 +270,28 @@ func TestSetFromImplicitlyEnabledCapabilities(t *testing.T) {
 				configv1.ClusterVersionCapability("cap2"),
 			},
 			capabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 			},
 			wantCapabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{
 					configv1.ClusterVersionCapability("cap2"),
 				},
 			},
 		},
 		{name: "no implicitly enabled capabilities",
 			capabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{
 					configv1.ClusterVersionCapability("cap2"),
 				},
 			},
 			wantCapabilities: ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 		},
 	}
@@ -317,7 +317,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			enabledManCaps: []configv1.ClusterVersionCapability{"cap1", "cap3"},
 			updatedManCaps: []configv1.ClusterVersionCapability{"cap2"},
 			capabilities: ClusterCapabilities{
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []string{"cap2"},
 		},
@@ -334,7 +334,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			enabledManCaps: []configv1.ClusterVersionCapability{"cap1", "cap3"},
 			updatedManCaps: []configv1.ClusterVersionCapability{"cap1"},
 			capabilities: ClusterCapabilities{
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 		},
 		{name: "prior cap, no updated caps, no implicitly enabled capability",
@@ -344,22 +344,22 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			enabledManCaps: []configv1.ClusterVersionCapability{"cap1", "cap2"},
 			updatedManCaps: []configv1.ClusterVersionCapability{"cap2"},
 			capabilities: ClusterCapabilities{
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 			},
 		},
 		{name: "no implicitly enable capability, new cap but already enabled",
 			enabledManCaps: []configv1.ClusterVersionCapability{"cap1"},
 			updatedManCaps: []configv1.ClusterVersionCapability{"cap2"},
 			capabilities: ClusterCapabilities{
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
 			},
 		},
 		{name: "no implicitly enable capability, already implcitly enabled",
 			enabledManCaps: []configv1.ClusterVersionCapability{"cap1"},
 			updatedManCaps: []configv1.ClusterVersionCapability{"cap2"},
 			capabilities: ClusterCapabilities{
-				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap2"},
+				Enabled:           map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{"cap2"},
 			},
 		},
 	}

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -172,7 +172,7 @@ const DesiredReleaseAccepted configv1.ClusterStatusConditionType = "ReleaseAccep
 // requesting via spec.capabilities, because the cluster version operator does not support uninstalling
 // capabilities if any associated resources were previously managed by the CVO or disabling previously
 // enabled capabilities.
-const ImplicitlyEnabledCapabilities configv1.ClusterStatusConditionType = "ImplicitlyEnabledCapabilities"
+const ImplicitlyEnabledCapabilities configv1.ClusterStatusConditionType = "ImplicitlyEnabled"
 
 // syncStatus calculates the new status of the ClusterVersion based on the current sync state and any
 // validation errors found. We allow the caller to pass the original object to avoid DeepCopying twice.

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -270,7 +270,7 @@ func (w *SyncWorker) syncPayload(ctx context.Context, work *SyncWork) ([]configv
 	// so that we don't fail, then immediately start reporting an earlier status
 	reporter := &statusWrapper{w: w, previousStatus: w.status.DeepCopy()}
 
-	implicitlyEnabledCaps := work.Capabilities.ImplicitlyEnabledCapabilities
+	implicitlyEnabledCaps := work.Capabilities.ImplicitlyEnabled
 
 	desired := configv1.Update{
 		Version: work.Desired.Version,
@@ -474,7 +474,7 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 	// If this is the first time through initialize priorCaps to the last known value of enabled capabilities.
 	if w.work != nil {
 		w.work.Generation = generation
-		priorCaps = w.work.Capabilities.EnabledCapabilities
+		priorCaps = w.work.Capabilities.Enabled
 	} else {
 		klog.V(2).Info("Initializing prior known value of enabled capabilities from ClusterVersion status.")
 		priorCaps = capability.GetCapabilitiesAsMap(config.Status.Capabilities.EnabledCapabilities)
@@ -493,7 +493,7 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 		equalSyncWork(w.work, work, fmt.Sprintf("considering cluster version generation %d", generation))
 
 	// needs to be set here since changes in implicitly enabled capabilities are not considered a "capabilities change"
-	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = work.Capabilities.ImplicitlyEnabledCapabilities
+	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = work.Capabilities.ImplicitlyEnabled
 
 	if versionEqual && overridesEqual && capabilitiesEqual {
 		klog.V(2).Info("Update work is equal to current target; no change required")
@@ -553,7 +553,7 @@ func (w *SyncWorker) Update(ctx context.Context, generation int64, desired confi
 	// Update capabilities settings and status to include any capabilities that were implicitly enabled due
 	// to previously managed resources.
 	w.work.Capabilities = capability.SetFromImplicitlyEnabledCapabilities(implicit, w.work.Capabilities)
-	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = w.work.Capabilities.ImplicitlyEnabledCapabilities
+	w.status.CapabilitiesStatus.ImplicitlyEnabledCaps = w.work.Capabilities.ImplicitlyEnabled
 	w.status.CapabilitiesStatus.Status = capability.GetCapabilitiesStatus(w.work.Capabilities)
 
 	// Update syncWorker status with architecture of newly loaded payload.

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -241,7 +241,7 @@ func GetImplicitlyEnabledCapabilities(updatePayloadManifests []manifest.Manifest
 	clusterCaps := capability.GetCapabilitiesStatus(capabilities)
 
 	// Initialize so it contains existing implicitly enabled capabilities
-	implicitlyEnabledCaps := capabilities.ImplicitlyEnabledCapabilities
+	implicitlyEnabledCaps := capabilities.ImplicitlyEnabled
 
 	for _, updateManifest := range updatePayloadManifests {
 		updateManErr := updateManifest.IncludeAllowUnknownCapabilities(nil, nil, nil, &clusterCaps, nil, true)

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -232,8 +232,8 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "basic",
 			pathExt: "test1",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap2"),
@@ -244,8 +244,8 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "basic with unknown cap",
 			pathExt: "test1",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap2"),
@@ -260,25 +260,25 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "current manifest not enabled",
 			pathExt: "test3",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap2": {}},
 			},
 		},
 		{
 			name:    "new cap already enabled",
 			pathExt: "test4",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
 			},
 		},
 		{
 			name:    "already implicitly enabled",
 			pathExt: "test5",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap2"},
+				Known:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{"cap2"},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap2"),
@@ -289,8 +289,8 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "only add cap once",
 			pathExt: "test6",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap2"),
@@ -307,7 +307,7 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "complex",
 			pathExt: "test7",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities: map[configv1.ClusterVersionCapability]struct{}{
+				Known: map[configv1.ClusterVersionCapability]struct{}{
 					"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}, "cap6": {},
 					"cap7": {}, "cap8": {}, "cap9": {}, "cap10": {}, "cap11": {}, "cap12": {},
 					"cap13": {}, "cap14": {}, "cap15": {}, "cap16": {}, "cap17": {}, "cap18": {},
@@ -316,13 +316,13 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 					"cap117": {}, "cap118": {}, "cap119": {}, "cap1111": {}, "cap1113": {}, "cap1115": {},
 					"cap1110": {}, "cap1112": {}, "cap1114": {}, "cap1116": {},
 				},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{
 					"cap1": {}, "cap2": {}, "cap3": {}, "cap4": {}, "cap5": {}, "cap6": {},
 					"cap7": {}, "cap8": {}, "cap9": {}, "cap10": {}, "cap11": {}, "cap12": {},
 					"cap13": {}, "cap14": {}, "cap15": {}, "cap16": {}, "cap17": {}, "cap18": {},
 					"cap19": {}, "cap20": {}, "cap21": {}, "cap22": {}, "cap23": {}, "cap24": {},
 				},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{
 					configv1.ClusterVersionCapability("cap000"),
 					configv1.ClusterVersionCapability("cap111"),
 					configv1.ClusterVersionCapability("cap112"),
@@ -355,9 +355,9 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "no update manifests",
 			pathExt: "test8",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1"},
+				Known:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Enabled:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{"cap1"},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap1"),
@@ -368,9 +368,9 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "no current manifests",
 			pathExt: "test9",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				EnabledCapabilities:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
-				ImplicitlyEnabledCapabilities: []configv1.ClusterVersionCapability{"cap1"},
+				Known:             map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Enabled:           map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				ImplicitlyEnabled: []configv1.ClusterVersionCapability{"cap1"},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap1"),
@@ -381,8 +381,8 @@ func TestGetImplicitlyEnabledCapabilities(t *testing.T) {
 			name:    "duplicate manifests",
 			pathExt: "test10",
 			capabilities: capability.ClusterCapabilities{
-				KnownCapabilities:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
-				EnabledCapabilities: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
+				Known:   map[configv1.ClusterVersionCapability]struct{}{"cap1": {}, "cap2": {}},
+				Enabled: map[configv1.ClusterVersionCapability]struct{}{"cap1": {}},
 			},
 			wantImplicit: []configv1.ClusterVersionCapability{
 				configv1.ClusterVersionCapability("cap2"),


### PR DESCRIPTION
Follow up https://github.com/openshift/cluster-version-operator/pull/1131#pullrequestreview-2540096609

Will rebase after https://github.com/openshift/cluster-version-operator/pull/1131 gets in.

