### PR TITLE
OCPBUGS-23514: Failing=Unknown upon long CO updating

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -565,59 +565,67 @@ func convertErrorToProgressing(now time.Time, statusFailure error) (reason strin
 	case payload.UpdateEffectReport:
 		return uErr.Reason, uErr.Error(), false
 	case payload.UpdateEffectNone:
-		var exceeded []string
-		names := uErr.Names
-		if len(names) == 0 {
-			names = []string{uErr.Name}
-		}
-		var machineConfig bool
-		for _, name := range names {
-			m := 30 * time.Minute
-			// It takes longer to upgrade MCO
-			if name == "machine-config" {
-				m = 3 * m
-			}
-			t := payload.COUpdateStartTimesGet(name)
-			if (!t.IsZero()) && t.Before(now.Add(-(m))) {
-				if name == "machine-config" {
-					machineConfig = true
-				} else {
-					exceeded = append(exceeded, name)
-				}
-			}
-		}
-		// returns true in those slow cases because it is still only a suspicion
-		if len(exceeded) > 0 && !machineConfig {
-			return slowCOUpdatePrefix + uErr.Reason, fmt.Sprintf("waiting on %s over 30 minutes which is longer than expected", strings.Join(exceeded, ", ")), true
-		}
-		if len(exceeded) > 0 && machineConfig {
-			return slowCOUpdatePrefix + uErr.Reason, fmt.Sprintf("waiting on %s over 30 minutes and machine-config over 90 minutes which is longer than expected", strings.Join(exceeded, ", ")), true
-		}
-		if len(exceeded) == 0 && machineConfig {
-			return slowCOUpdatePrefix + uErr.Reason, "waiting on machine-config over 90 minutes which is longer than expected", true
-		}
-		return uErr.Reason, fmt.Sprintf("waiting on %s", strings.Join(names, ", ")), true
+		return convertErrorToProgressingForUpdateEffectNone(uErr, now)
 	case payload.UpdateEffectFail:
 		return "", "", false
 	case payload.UpdateEffectFailAfterInterval:
-		var exceeded []string
-		threshold := now.Add(-(40 * time.Minute))
-		names := uErr.Names
-		if len(names) == 0 {
-			names = []string{uErr.Name}
+		return convertErrorToProgressingForUpdateEffectFailAfterInterval(uErr, now)
+	}
+	return "", "", false
+}
+
+func convertErrorToProgressingForUpdateEffectNone(uErr *payload.UpdateError, now time.Time) (string, string, bool) {
+	var exceeded []string
+	names := uErr.Names
+	if len(names) == 0 {
+		names = []string{uErr.Name}
+	}
+	var machineConfig bool
+	for _, name := range names {
+		m := 30 * time.Minute
+		// It takes longer to upgrade MCO
+		if name == "machine-config" {
+			m = 3 * m
 		}
-		for _, name := range names {
-			if payload.COUpdateStartTimesGet(name).Before(threshold) {
+		t := payload.COUpdateStartTimesGet(name)
+		if (!t.IsZero()) && t.Before(now.Add(-(m))) {
+			if name == "machine-config" {
+				machineConfig = true
+			} else {
 				exceeded = append(exceeded, name)
 			}
 		}
-		if len(exceeded) > 0 {
-			return uErr.Reason, fmt.Sprintf("wait has exceeded 40 minutes for these operators: %s", strings.Join(exceeded, ", ")), false
-		} else {
-			return uErr.Reason, fmt.Sprintf("waiting up to 40 minutes on %s", uErr.Name), true
+	}
+	// returns true in those slow cases because it is still only a suspicion
+	if len(exceeded) > 0 && !machineConfig {
+		return slowCOUpdatePrefix + uErr.Reason, fmt.Sprintf("waiting on %s over 30 minutes which is longer than expected", strings.Join(exceeded, ", ")), true
+	}
+	if len(exceeded) > 0 && machineConfig {
+		return slowCOUpdatePrefix + uErr.Reason, fmt.Sprintf("waiting on %s over 30 minutes and machine-config over 90 minutes which is longer than expected", strings.Join(exceeded, ", ")), true
+	}
+	if len(exceeded) == 0 && machineConfig {
+		return slowCOUpdatePrefix + uErr.Reason, "waiting on machine-config over 90 minutes which is longer than expected", true
+	}
+	return uErr.Reason, fmt.Sprintf("waiting on %s", strings.Join(names, ", ")), true
+}
+
+func convertErrorToProgressingForUpdateEffectFailAfterInterval(uErr *payload.UpdateError, now time.Time) (string, string, bool) {
+	var exceeded []string
+	threshold := now.Add(-(40 * time.Minute))
+	names := uErr.Names
+	if len(names) == 0 {
+		names = []string{uErr.Name}
+	}
+	for _, name := range names {
+		if payload.COUpdateStartTimesGet(name).Before(threshold) {
+			exceeded = append(exceeded, name)
 		}
 	}
-	return "", "", false
+	if len(exceeded) > 0 {
+		return uErr.Reason, fmt.Sprintf("wait has exceeded 40 minutes for these operators: %s", strings.Join(exceeded, ", ")), false
+	} else {
+		return uErr.Reason, fmt.Sprintf("waiting up to 40 minutes on %s", uErr.Name), true
+	}
 }
 
 // syncFailingStatus handles generic errors in the cluster version. It tries to preserve

--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -47,9 +47,15 @@ func InitCOUpdateStartTimes() {
 // COUpdateStartTimesEnsure adds name to clusterOperatorUpdateStartTimes map and sets to
 // current time if name does not already exist in map.
 func COUpdateStartTimesEnsure(name string) {
+	COUpdateStartTimesAt(name, time.Now())
+}
+
+// COUpdateStartTimesAt adds name to clusterOperatorUpdateStartTimes map and sets to
+// t if name does not already exist in map.
+func COUpdateStartTimesAt(name string, t time.Time) {
 	clusterOperatorUpdateStartTimes.lock.Lock()
 	if _, ok := clusterOperatorUpdateStartTimes.m[name]; !ok {
-		clusterOperatorUpdateStartTimes.m[name] = time.Now()
+		clusterOperatorUpdateStartTimes.m[name] = t
 	}
 	clusterOperatorUpdateStartTimes.lock.Unlock()
 }


### PR DESCRIPTION
When it takes too long (90m+ for machine-config and 30m+ for
others) to upgrade a cluster operator, clusterversion shows
a message with the indication that the upgrade might hit
some issue.

This will cover the case in the related OCPBUGS-23538: for some
reason, the pod under the deployment that manages the CO hit
CrashLoopBackOff. Deployment controller does not give useful
conditions in this situation [1]. Otherwise, checkDeploymentHealth [2]
would detect it.

Instead of CVO's figuring out the underlying pod's
CrashLoopBackOff which might be better to be implemented by
deployment controller, it is expected that our cluster admin
starts to dig into the cluster when such a message pops up.

In addition to the condition's message. We propagate Fail=Unknown
to make it available for other automations, such as update-status
command.

[1]. https://github.com/kubernetes/kubernetes/issues/106054

[2]. https://github.com/openshift/cluster-version-operator/blob/08c0459df5096e9f16fad3af2831b62d06d415ee/lib/resourcebuilder/apps.go#L79-L136