### PR TITLE
OCPBUGS-52258: pkg/cvo/updatepayload: Context around ValidateDirectory calls

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -173,15 +173,15 @@ func (r *payloadRetriever) targetUpdatePayloadDir(ctx context.Context, update co
 	if err := payload.ValidateDirectory(tdir); os.IsNotExist(err) {
 		// the dirs don't exist, try fetching the payload to tdir.
 		if err := r.fetchUpdatePayloadToDir(ctx, tdir, update); err != nil {
-			return "", err
+			return "", fmt.Errorf("fetching update payload: %s", err)
 		}
 	} else if err != nil {
-		return "", err
+		return "", fmt.Errorf("checking to see if %q already holds release-image content: %w", tdir, err)
 	}
 
 	// now that payload has been loaded check validation.
 	if err := payload.ValidateDirectory(tdir); err != nil {
-		return "", err
+		return "", fmt.Errorf("confirming the presence of release-image content in %q: %w", tdir, err)
 	}
 	return tdir, nil
 }

--- a/pkg/payload/image.go
+++ b/pkg/payload/image.go
@@ -3,22 +3,20 @@ package payload
 import (
 	"fmt"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 // ImageForShortName returns the image using the updatepayload embedded in
 // the Operator.
 func ImageForShortName(name string) (string, error) {
 	if err := ValidateDirectory(DefaultPayloadDir); err != nil {
-		return "", err
+		return "", fmt.Errorf("error validating %q as a release-image directory: %w", DefaultPayloadDir, err)
 	}
 
 	releaseDir := filepath.Join(DefaultPayloadDir, ReleaseManifestDir)
 
 	imageRef, err := loadImageReferences(releaseDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "error loading image references from %q", releaseDir)
+		return "", fmt.Errorf("error loading image references from %q: %w", releaseDir, err)
 	}
 
 	for _, tag := range imageRef.Spec.Tags {


### PR DESCRIPTION
These usually either succeed or give `os.IsNotExist`, but in [some cases can return errors like][1]:

    Unable to download and prepare the update: stat /etc/cvo/updatepayloads/7WNaprXJNWTsPAepCHJ00Q/release-manifests/release-metadata: permission denied.

To make it easier to debug those situations, this commit adds context to errors near `ValidateDirectory` calls, so it's more clear that the issue is the CVO's attempts to read `/etc/cvo/...` failing, and not an error with the `version-...` Pod, registry access, etc.

Also while I'm in this space, I've replaced the old `errors.Wrap` in `ImageForShortName` with `fmt.Errorf(...%w, ...)`, now that the Go standard libraries support error-wrapping like that.  One fewer 3rd-party dependency call-site.

[1]: https://issues.redhat.com/browse/OCPBUGS-52258