### PR TITLE
NO-JIRA: .gitignore: Add `.idea` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 .DS_Store
 _output
+.idea/


### PR DESCRIPTION
Used by JetBrains IDEs such as GoLand for project settings files [1].

The directory may contain files, which are to be committed [1]. More fine-grained gitignore specifications are available, for example, the [2] file. However, the cluster-version-operator repository does not utilize any such files at the moment.

Ignore the entire directory for simplicity.

[1] https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder
[2] https://github.com/github/gitignore/blob/9d66dabafaf4ee6ad5126363b7ace1a46ee07850/Global/JetBrains.gitignore