### PR TITLE
OTA-1403: Create minimal openshift tests extension

### DIFF
--- a/cmd/cluster-version-operator-tests/main.go
+++ b/cmd/cluster-version-operator-tests/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+)
+
+func main() {
+	registry := extension.NewRegistry()
+	ext := extension.NewExtension("openshift", "payload", "cluster-version-operator")
+
+	var specs extensiontests.ExtensionTestSpecs
+	ext.AddSpecs(specs)
+	registry.Register(ext)
+
+	root := &cobra.Command{
+		Long: "OpenShift Tests Extension for Cluster Version Operator",
+	}
+	root.AddCommand(cmd.DefaultExtensionCommands(registry)...)
+
+	if err := func() error {
+		return root.Execute()
+	}(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
 	github.com/openshift/api v0.0.0-20250207102212-9e59a77ed2e0
 	github.com/openshift/client-go v0.0.0-20250131180035-f7ec47e2d87a
 	github.com/openshift/library-go v0.0.0-20250203131244-80620876b7c2
@@ -100,7 +101,7 @@ require (
 	golang.org/x/term v0.26.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61 // indirect
 	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45 h1:hXpbYtP3iTh8oy/RKwKkcMziwchY3fIk95ciczf7cOA=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift/api v0.0.0-20250207102212-9e59a77ed2e0 h1:5n8BKML7fkmR4tz81WI0jc722rbta4t7pzT21lcd/Ec=
 github.com/openshift/api v0.0.0-20250207102212-9e59a77ed2e0/go.mod h1:yk60tHAmHhtVpJQo3TwVYq2zpuP70iJIFDCmeKMIzPw=
 github.com/openshift/client-go v0.0.0-20250131180035-f7ec47e2d87a h1:duO3JMrUOqVx50QhzxvDeOYIwTNOB8/EEuRLPyvAMBg=
@@ -297,8 +299,8 @@ google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 h1:KAeGQVN3M9nD0/b
 google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80/go.mod h1:cc8bqMqtv9gMOr0zHg2Vzff5ULhhL2IXP4sbcn32Dro=
 google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 h1:YcyjlL1PRr2Q17/I0dPk2JmYS5CDXfcdb2Z3YRioEbw=
 google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7/go.mod h1:OCdP9MfskevB/rbYvHTsXTtKC+3bHWajPdoKgjcYkfo=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 h1:2035KHhUv+EpyB+hWgJnaWKJOdX1E95w2S8Rr4uWKTs=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61 h1:N9BgCIAUvn/M+p4NJccWPWb3BWh88+zyL0ll9HgbEeM=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
 google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -47,6 +47,9 @@ GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}   
   -o "${BIN_PATH}/cluster-version-operator-tests"                               \
   "${REPO}/cmd/cluster-version-operator-tests/..."
 
+echo "Compressing the cluster-version-operator-tests binary"
+gzip --keep --force "${BIN_PATH}/cluster-version-operator-tests"
+
 # Build the cluster-version-operator binary
 GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
 echo "Building ${REPO} cluster-version-operator binary (${VERSION_OVERRIDE})"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -20,15 +20,34 @@ if [ -z "${VERSION_OVERRIDE:-}" ]; then
 	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
-GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
-
 eval $(go env)
 
 if [ -z ${BIN_PATH+a} ]; then
 	export BIN_PATH=_output/${GOOS}/${GOARCH}
 fi
 
+echo "Building binaries into ${BIN_PATH}"
 mkdir -p ${BIN_PATH}
 
-echo "Building ${REPO} (${VERSION_OVERRIDE})"
+# Build the cluster-version-operator-tests binary and compress it
+OPENSHIFT_TESTS_EXTENSION_MODULE="github.com/openshift-eng/openshift-tests-extension"
+GIT_COMMIT=$(git rev-parse --short HEAD)
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+GIT_TREE_STATE=$(if git diff --quiet; then echo clean; else echo dirty; fi)
+LDFLAGS_TEST_EXTENSION=$GLDFLAGS
+LDFLAGS_TEST_EXTENSION+=" -X '${OPENSHIFT_TESTS_EXTENSION_MODULE}/pkg/version.CommitFromGit=${GIT_COMMIT}'"
+LDFLAGS_TEST_EXTENSION+=" -X '${OPENSHIFT_TESTS_EXTENSION_MODULE}/pkg/version.BuildDate=${BUILD_DATE}'"
+LDFLAGS_TEST_EXTENSION+=" -X '${OPENSHIFT_TESTS_EXTENSION_MODULE}/pkg/version.GitTreeState=${GIT_TREE_STATE}'"
+
+echo "Building ${REPO} cluster-version-operator-tests binary (${VERSION_OVERRIDE})"
+GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH}   \
+  go build                                                                      \
+  ${GOFLAGS}                                                                    \
+  -ldflags "${LDFLAGS_TEST_EXTENSION}"                                          \
+  -o "${BIN_PATH}/cluster-version-operator-tests"                               \
+  "${REPO}/cmd/cluster-version-operator-tests/..."
+
+# Build the cluster-version-operator binary
+GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
+echo "Building ${REPO} cluster-version-operator binary (${VERSION_OVERRIDE})"
 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/cluster-version-operator ${REPO}/cmd/cluster-version-operator/...

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/LICENSE
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+)
+
+func DefaultExtensionCommands(registry *extension.Registry) []*cobra.Command {
+	return []*cobra.Command{
+		cmdrun.NewRunSuiteCommand(registry),
+		cmdrun.NewRunTestCommand(registry),
+		cmdlist.NewListCommand(registry),
+		cmdinfo.NewInfoCommand(registry),
+		cmdupdate.NewUpdateCommand(registry),
+		cmdimages.NewImagesCommand(registry),
+	}
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
@@ -1,0 +1,36 @@
+package cmdimages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewImagesCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "images",
+		Short:        "List test images",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			extension := registry.Get(componentFlags.Component)
+			if extension == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+			images, err := json.Marshal(extension.Images)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", images)
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo/info.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo/info.go
@@ -1,0 +1,38 @@
+package cmdinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewInfoCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "info",
+		Short:        "Display extension metadata",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			extension := registry.Get(componentFlags.Component)
+			if extension == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+
+			info, err := json.MarshalIndent(extension, "", "    ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stdout, "%s\n", string(info))
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist/list.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist/list.go
@@ -1,0 +1,133 @@
+package cmdlist
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewListCommand(registry *extension.Registry) *cobra.Command {
+	opts := struct {
+		componentFlags     *flags.ComponentFlags
+		suiteFlags         *flags.SuiteFlags
+		outputFlags        *flags.OutputFlags
+		environmentalFlags *flags.EnvironmentalFlags
+	}{
+		suiteFlags:         flags.NewSuiteFlags(),
+		componentFlags:     flags.NewComponentFlags(),
+		outputFlags:        flags.NewOutputFlags(),
+		environmentalFlags: flags.NewEnvironmentalFlags(),
+	}
+
+	// Tests
+	listTestsCmd := &cobra.Command{
+		Use:          "tests",
+		Short:        "List available tests",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(opts.componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("component not found: %s", opts.componentFlags.Component)
+			}
+
+			// Find suite, if specified
+			var foundSuite *extension.Suite
+			var err error
+			if opts.suiteFlags.Suite != "" {
+				foundSuite, err = ext.GetSuite(opts.suiteFlags.Suite)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Filter for suite
+			specs := ext.GetSpecs()
+			if foundSuite != nil {
+				specs, err = specs.Filter(foundSuite.Qualifiers)
+				if err != nil {
+					return err
+				}
+			}
+
+			specs, err = specs.FilterByEnvironment(*opts.environmentalFlags)
+			if err != nil {
+				return err
+			}
+
+			data, err := opts.outputFlags.Marshal(specs)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", string(data))
+			return nil
+		},
+	}
+	opts.suiteFlags.BindFlags(listTestsCmd.Flags())
+	opts.componentFlags.BindFlags(listTestsCmd.Flags())
+	opts.environmentalFlags.BindFlags(listTestsCmd.Flags())
+	opts.outputFlags.BindFlags(listTestsCmd.Flags())
+
+	// Suites
+	listSuitesCommand := &cobra.Command{
+		Use:          "suites",
+		Short:        "List available suites",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(opts.componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("component not found: %s", opts.componentFlags.Component)
+			}
+
+			suites := ext.Suites
+
+			data, err := opts.outputFlags.Marshal(suites)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", string(data))
+			return nil
+		},
+	}
+	opts.componentFlags.BindFlags(listSuitesCommand.Flags())
+	opts.outputFlags.BindFlags(listSuitesCommand.Flags())
+
+	// Components
+	listComponentsCmd := &cobra.Command{
+		Use:          "components",
+		Short:        "List available components",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var components []*extension.Component
+			registry.Walk(func(e *extension.Extension) {
+				components = append(components, &e.Component)
+			})
+
+			data, err := opts.outputFlags.Marshal(components)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", string(data))
+			return nil
+		},
+	}
+	opts.outputFlags.BindFlags(listComponentsCmd.Flags())
+
+	var listCmd = &cobra.Command{
+		Use:   "list [subcommand]",
+		Short: "List items",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listTestsCmd.RunE(cmd, args)
+		},
+	}
+	opts.suiteFlags.BindFlags(listCmd.Flags())
+	opts.componentFlags.BindFlags(listCmd.Flags())
+	opts.outputFlags.BindFlags(listCmd.Flags())
+	opts.environmentalFlags.BindFlags(listCmd.Flags())
+	listCmd.AddCommand(listTestsCmd, listComponentsCmd, listSuitesCommand)
+
+	return listCmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runsuite.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runsuite.go
@@ -1,0 +1,63 @@
+package cmdrun
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
+	opts := struct {
+		componentFlags   *flags.ComponentFlags
+		outputFlags      *flags.OutputFlags
+		concurrencyFlags *flags.ConcurrencyFlags
+	}{
+		componentFlags:   flags.NewComponentFlags(),
+		outputFlags:      flags.NewOutputFlags(),
+		concurrencyFlags: flags.NewConcurrencyFlags(),
+	}
+
+	cmd := &cobra.Command{
+		Use:          "run-suite NAME",
+		Short:        "Run a group of tests by suite",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(opts.componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("component not found: %s", opts.componentFlags.Component)
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("must specify one suite name")
+			}
+
+			w, err := extensiontests.NewResultWriter(os.Stdout, extensiontests.ResultFormat(opts.outputFlags.Output))
+			if err != nil {
+				return err
+			}
+			defer w.Flush()
+
+			suite, err := ext.GetSuite(args[0])
+			if err != nil {
+				return errors.Wrapf(err, "couldn't find suite: %s", args[0])
+			}
+
+			specs, err := ext.GetSpecs().Filter(suite.Qualifiers)
+			if err != nil {
+				return errors.Wrap(err, "couldn't filter specs")
+			}
+
+			return specs.Run(w, opts.concurrencyFlags.MaxConcurency)
+		},
+	}
+	opts.componentFlags.BindFlags(cmd.Flags())
+	opts.outputFlags.BindFlags(cmd.Flags())
+	opts.concurrencyFlags.BindFlags(cmd.Flags())
+
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runtest.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runtest.go
@@ -1,0 +1,81 @@
+package cmdrun
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
+	opts := struct {
+		componentFlags   *flags.ComponentFlags
+		concurrencyFlags *flags.ConcurrencyFlags
+		nameFlags        *flags.NamesFlags
+		outputFlags      *flags.OutputFlags
+	}{
+		componentFlags:   flags.NewComponentFlags(),
+		nameFlags:        flags.NewNamesFlags(),
+		outputFlags:      flags.NewOutputFlags(),
+		concurrencyFlags: flags.NewConcurrencyFlags(),
+	}
+
+	cmd := &cobra.Command{
+		Use:          "run-test [-n NAME...] [NAME]",
+		Short:        "Runs tests by name",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(opts.componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("component not found: %s", opts.componentFlags.Component)
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("use --names to specify more than one test")
+			}
+			opts.nameFlags.Names = append(opts.nameFlags.Names, args...)
+
+			// allow reading tests from an stdin pipe
+			info, err := os.Stdin.Stat()
+			if err != nil {
+				return err
+			}
+			if info.Mode()&os.ModeCharDevice == 0 { // Check if input is from a pipe
+				scanner := bufio.NewScanner(os.Stdin)
+				for scanner.Scan() {
+					opts.nameFlags.Names = append(opts.nameFlags.Names, scanner.Text())
+				}
+				if err := scanner.Err(); err != nil {
+					return fmt.Errorf("error reading from stdin: %v", err)
+				}
+			}
+
+			if len(opts.nameFlags.Names) == 0 {
+				return fmt.Errorf("must specify at least one test")
+			}
+
+			specs, err := ext.FindSpecsByName(opts.nameFlags.Names...)
+			if err != nil {
+				return err
+			}
+
+			w, err := extensiontests.NewResultWriter(os.Stdout, extensiontests.ResultFormat(opts.outputFlags.Output))
+			if err != nil {
+				return err
+			}
+			defer w.Flush()
+
+			return specs.Run(w, opts.concurrencyFlags.MaxConcurency)
+		},
+	}
+	opts.componentFlags.BindFlags(cmd.Flags())
+	opts.nameFlags.BindFlags(cmd.Flags())
+	opts.outputFlags.BindFlags(cmd.Flags())
+	opts.concurrencyFlags.BindFlags(cmd.Flags())
+
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate/update.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate/update.go
@@ -1,0 +1,84 @@
+package cmdupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+const metadataDirectory = ".openshift-tests-extension"
+
+// NewUpdateCommand adds an "update" command used to generate and verify the metadata we keep track of. This should
+// be a black box to end users, i.e. we can add more criteria later they'll consume when revendoring.  For now,
+// we prevent a test to be renamed without updating other names, or a test to be deleted.
+func NewUpdateCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "update",
+		Short:        "Update test metadata",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+
+			// Create the metadata directory if it doesn't exist
+			if err := os.MkdirAll(metadataDirectory, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", metadataDirectory, err)
+			}
+
+			// Read existing specs
+			metadataPath := filepath.Join(metadataDirectory, fmt.Sprintf("%s.json", strings.ReplaceAll(ext.Component.Identifier(), ":", "_")))
+			var oldSpecs extensiontests.ExtensionTestSpecs
+			source, err := os.Open(metadataPath)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("failed to open file: %s: %+w", metadataPath, err)
+				}
+			} else {
+				if err := json.NewDecoder(source).Decode(&oldSpecs); err != nil {
+					return fmt.Errorf("failed to decode file: %s: %+w", metadataPath, err)
+				}
+
+				missing, err := ext.FindRemovedTestsWithoutRename(oldSpecs)
+				if err != nil && len(missing) > 0 {
+					fmt.Fprintf(os.Stderr, "Missing Tests:\n")
+					for _, name := range missing {
+						fmt.Fprintf(os.Stdout, "  * %s\n", name)
+					}
+					fmt.Fprintf(os.Stderr, "\n")
+
+					return fmt.Errorf("missing tests, if you've renamed tests you must add their names to OriginalName, " +
+						"or mark them obsolete")
+				}
+			}
+
+			// no missing tests, write the results
+			newSpecs := ext.GetSpecs()
+			data, err := json.MarshalIndent(newSpecs, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal specs to JSON: %w", err)
+			}
+
+			// Write the JSON data to the file
+			if err := os.WriteFile(metadataPath, data, 0644); err != nil {
+				return fmt.Errorf("failed to write file %s: %w", metadataPath, err)
+			}
+
+			fmt.Printf("successfully updated metadata\n")
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/dbtime/time.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/dbtime/time.go
@@ -1,0 +1,26 @@
+package dbtime
+
+import "time"
+
+// DBTime is a type suitable for direct importing into databases like BigQuery,
+// formatted like 2006-01-02 15:04:05.000000 UTC.
+type DBTime time.Time
+
+func Ptr(t time.Time) *DBTime {
+	return (*DBTime)(&t)
+}
+
+func (dbt *DBTime) MarshalJSON() ([]byte, error) {
+	formattedTime := time.Time(*dbt).Format(`"2006-01-02 15:04:05.000000 UTC"`)
+	return []byte(formattedTime), nil
+}
+
+func (dbt *DBTime) UnmarshalJSON(b []byte) error {
+	timeStr := string(b[1 : len(b)-1])
+	parsedTime, err := time.Parse("2006-01-02 15:04:05.000000 UTC", timeStr)
+	if err != nil {
+		return err
+	}
+	*dbt = (DBTime)(parsedTime)
+	return nil
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
@@ -1,0 +1,159 @@
+package extension
+
+import (
+	"fmt"
+	"strings"
+
+	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/version"
+)
+
+func NewExtension(product, kind, name string) *Extension {
+	return &Extension{
+		APIVersion: CurrentExtensionAPIVersion,
+		Source: Source{
+			Commit:       version.CommitFromGit,
+			BuildDate:    version.BuildDate,
+			GitTreeState: version.GitTreeState,
+		},
+		Component: Component{
+			Product: product,
+			Kind:    kind,
+			Name:    name,
+		},
+	}
+}
+
+func (e *Extension) GetSuite(name string) (*Suite, error) {
+	var suite *Suite
+
+	for _, s := range e.Suites {
+		if s.Name == name {
+			suite = &s
+			break
+		}
+	}
+
+	if suite == nil {
+		return nil, fmt.Errorf("no such suite: %s", name)
+	}
+
+	return suite, nil
+}
+
+func (e *Extension) GetSpecs() et.ExtensionTestSpecs {
+	return e.specs
+}
+
+func (e *Extension) AddSpecs(specs et.ExtensionTestSpecs) {
+	specs.Walk(func(spec *et.ExtensionTestSpec) {
+		spec.Source = e.Component.Identifier()
+	})
+
+	e.specs = append(e.specs, specs...)
+}
+
+// IgnoreObsoleteTests allows removal of a test.
+func (e *Extension) IgnoreObsoleteTests(testNames ...string) {
+	if e.obsoleteTests == nil {
+		e.obsoleteTests = sets.New[string](testNames...)
+	} else {
+		e.obsoleteTests.Insert(testNames...)
+	}
+}
+
+// FindRemovedTestsWithoutRename compares the current set of test specs against oldSpecs, including consideration of the original name,
+// we return an error.  Can be used to detect test renames or removals.
+func (e *Extension) FindRemovedTestsWithoutRename(oldSpecs et.ExtensionTestSpecs) ([]string, error) {
+	currentSpecs := e.GetSpecs()
+	currentMap := make(map[string]bool)
+
+	// Populate current specs into a map for quick lookup by both Name and OriginalName.
+	for _, spec := range currentSpecs {
+		currentMap[spec.Name] = true
+		if spec.OriginalName != "" {
+			currentMap[spec.OriginalName] = true
+		}
+	}
+
+	var removedTests []string
+
+	// Check oldSpecs against current specs.
+	for _, oldSpec := range oldSpecs {
+		// Skip if the test is marked as obsolete.
+		if e.obsoleteTests.Has(oldSpec.Name) {
+			continue
+		}
+
+		// Check if oldSpec is missing in currentSpecs by both Name and OriginalName.
+		if !currentMap[oldSpec.Name] && (oldSpec.OriginalName == "" || !currentMap[oldSpec.OriginalName]) {
+			removedTests = append(removedTests, oldSpec.Name)
+		}
+	}
+
+	// Return error if any removed tests were found.
+	if len(removedTests) > 0 {
+		return removedTests, fmt.Errorf("tests removed without rename: %v", removedTests)
+	}
+
+	return nil, nil
+}
+
+// AddGlobalSuite adds a suite whose qualifiers will apply to all tests,
+// not just this one.  Allowing a developer to create a composed suite of
+// tests from many sources.
+func (e *Extension) AddGlobalSuite(suite Suite) *Extension {
+	if e.Suites == nil {
+		e.Suites = []Suite{suite}
+	} else {
+		e.Suites = append(e.Suites, suite)
+	}
+
+	return e
+}
+
+// AddSuite adds a suite whose qualifiers will only apply to tests present
+// in its own extension.
+func (e *Extension) AddSuite(suite Suite) *Extension {
+	expr := fmt.Sprintf("source == %q", e.Component.Identifier())
+	for i := range suite.Qualifiers {
+		suite.Qualifiers[i] = fmt.Sprintf("(%s) && (%s)", expr, suite.Qualifiers[i])
+	}
+	e.AddGlobalSuite(suite)
+	return e
+}
+
+func (e *Extension) RegisterImage(image Image) *Extension {
+	e.Images = append(e.Images, image)
+	return e
+}
+
+func (e *Extension) FindSpecsByName(names ...string) (et.ExtensionTestSpecs, error) {
+	var specs et.ExtensionTestSpecs
+	var notFound []string
+
+	for _, name := range names {
+		found := false
+		for i := range e.specs {
+			if e.specs[i].Name == name {
+				specs = append(specs, e.specs[i])
+				found = true
+				break
+			}
+		}
+		if !found {
+			notFound = append(notFound, name)
+		}
+	}
+
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("no such tests: %s", strings.Join(notFound, ", "))
+	}
+
+	return specs, nil
+}
+
+func (e *Component) Identifier() string {
+	return fmt.Sprintf("%s:%s:%s", e.Product, e.Kind, e.Name)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/environment.go
@@ -1,0 +1,76 @@
+package extensiontests
+
+import (
+	"fmt"
+	"strings"
+)
+
+func PlatformEquals(platform string) string {
+	return fmt.Sprintf(`platform=="%s"`, platform)
+}
+
+func NetworkEquals(network string) string {
+	return fmt.Sprintf(`network=="%s"`, network)
+}
+
+func NetworkStackEquals(networkStack string) string {
+	return fmt.Sprintf(`networkStack=="%s"`, networkStack)
+}
+
+func UpgradeEquals(upgrade string) string {
+	return fmt.Sprintf(`upgrade=="%s"`, upgrade)
+}
+
+func TopologyEquals(topology string) string {
+	return fmt.Sprintf(`topology=="%s"`, topology)
+}
+
+func ArchitectureEquals(arch string) string {
+	return fmt.Sprintf(`architecture=="%s"`, arch)
+}
+
+func ExternalConnectivityEquals(externalConnectivity string) string {
+	return fmt.Sprintf(`externalConnectivity=="%s"`, externalConnectivity)
+}
+
+func OptionalCapabilitiesIncludeAny(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " || ")))
+}
+
+func OptionalCapabilitiesIncludeAll(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " && ")))
+}
+
+func OptionalCapabilityExists(optionalCapability string) string {
+	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
+}
+
+func NoOptionalCapabilitiesExist() string {
+	return "size(optionalCapabilities) == 0"
+}
+
+func InstallerEquals(installer string) string {
+	return fmt.Sprintf(`installer=="%s"`, installer)
+}
+
+func VersionEquals(version string) string {
+	return fmt.Sprintf(`version=="%s"`, version)
+}
+
+func FactEquals(key, value string) string {
+	return fmt.Sprintf(`(fact_keys.exists(k, k=="%s") && facts["%s"].matches("%s"))`, key, key, value)
+}
+
+func Or(cel ...string) string {
+	return fmt.Sprintf("(%s)", strings.Join(cel, " || "))
+}
+
+func And(cel ...string) string {
+	return fmt.Sprintf("(%s)", strings.Join(cel, " && "))
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/result.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/result.go
@@ -1,0 +1,12 @@
+package extensiontests
+
+func (results ExtensionTestResults) Walk(walkFn func(*ExtensionTestResult)) {
+	for i := range results {
+		walkFn(results[i])
+	}
+}
+
+// AddDetails adds additional information to an ExtensionTestResult. Value must marshal to JSON.
+func (result *ExtensionTestResult) AddDetails(name string, value interface{}) {
+	result.Details = append(result.Details, Details{Name: name, Value: value})
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/result_writer.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/result_writer.go
@@ -1,0 +1,71 @@
+package extensiontests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type ResultWriter interface {
+	Write(result *ExtensionTestResult)
+	Flush()
+}
+
+type NullResultWriter struct{}
+
+func (NullResultWriter) Write(*ExtensionTestResult) {}
+func (NullResultWriter) Flush()                     {}
+
+type ResultFormat string
+
+var (
+	JSON  ResultFormat = "json"
+	JSONL ResultFormat = "jsonl"
+)
+
+type JSONResultWriter struct {
+	out     io.Writer
+	format  ResultFormat
+	results ExtensionTestResults
+}
+
+func NewResultWriter(out io.Writer, format ResultFormat) (*JSONResultWriter, error) {
+	switch format {
+	case JSON, JSONL:
+	// do nothing
+	default:
+		return nil, fmt.Errorf("unsupported result format: %s", format)
+	}
+
+	return &JSONResultWriter{
+		out:    out,
+		format: format,
+	}, nil
+}
+
+func (w *JSONResultWriter) Write(result *ExtensionTestResult) {
+	switch w.format {
+	case JSONL:
+		// JSONL gets written to out as we get the items
+		data, err := json.Marshal(result)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w.out, "%s\n", string(data))
+	case JSON:
+		w.results = append(w.results, result)
+	}
+}
+
+func (w *JSONResultWriter) Flush() {
+	switch w.format {
+	case JSONL:
+	// we already wrote it out
+	case JSON:
+		data, err := json.MarshalIndent(w.results, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(w.out, "%s\n", string(data))
+	}
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/spec.go
@@ -1,0 +1,507 @@
+package extensiontests
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+)
+
+// Walk iterates over all test specs, and executions the function provided. The test spec can be mutated.
+func (specs ExtensionTestSpecs) Walk(walkFn func(*ExtensionTestSpec)) ExtensionTestSpecs {
+	for i := range specs {
+		walkFn(specs[i])
+	}
+
+	return specs
+}
+
+type SelectFunction func(spec *ExtensionTestSpec) bool
+
+// Select filters the ExtensionTestSpecs to only those that match the provided SelectFunction
+func (specs ExtensionTestSpecs) Select(selectFn SelectFunction) ExtensionTestSpecs {
+	filtered := ExtensionTestSpecs{}
+	for _, spec := range specs {
+		if selectFn(spec) {
+			filtered = append(filtered, spec)
+		}
+	}
+
+	return filtered
+}
+
+// SelectAny filters the ExtensionTestSpecs to only those that match any of the provided SelectFunctions
+func (specs ExtensionTestSpecs) SelectAny(selectFns []SelectFunction) ExtensionTestSpecs {
+	filtered := ExtensionTestSpecs{}
+	for _, spec := range specs {
+		for _, selectFn := range selectFns {
+			if selectFn(spec) {
+				filtered = append(filtered, spec)
+				break
+			}
+		}
+	}
+
+	return filtered
+}
+
+// SelectAll filters the ExtensionTestSpecs to only those that match all the provided SelectFunctions
+func (specs ExtensionTestSpecs) SelectAll(selectFns []SelectFunction) ExtensionTestSpecs {
+	filtered := ExtensionTestSpecs{}
+	for _, spec := range specs {
+		anyFalse := false
+		for _, selectFn := range selectFns {
+			if !selectFn(spec) {
+				anyFalse = true
+				break
+			}
+		}
+		if !anyFalse {
+			filtered = append(filtered, spec)
+		}
+	}
+
+	return filtered
+}
+
+// NameContains returns a function that selects specs whose name contains the provided string
+func NameContains(name string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		return strings.Contains(spec.Name, name)
+	}
+}
+
+// NameContainsAll returns a function that selects specs whose name contains each of the provided contents strings
+func NameContainsAll(contents ...string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		for _, content := range contents {
+			if !strings.Contains(spec.Name, content) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// HasLabel returns a function that selects specs with the provided label
+func HasLabel(label string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		return spec.Labels.Has(label)
+	}
+}
+
+// HasTagWithValue returns a function that selects specs containing a tag with the provided key and value
+func HasTagWithValue(key, value string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		return spec.Tags[key] == value
+	}
+}
+
+// WithLifecycle returns a function that selects specs with the provided Lifecycle
+func WithLifecycle(lifecycle Lifecycle) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		return spec.Lifecycle == lifecycle
+	}
+}
+
+func (specs ExtensionTestSpecs) Names() []string {
+	var names []string
+	for _, spec := range specs {
+		names = append(names, spec.Name)
+	}
+	return names
+}
+
+// Run executes all the specs in parallel, up to maxConcurrent at the same time. Results
+// are written to the given ResultWriter after each spec has completed execution.  BeforeEach,
+// BeforeAll, AfterEach, AfterAll hooks are executed when specified. "Each" hooks must be thread
+// safe. Returns an error if any test spec failed, indicating the quantity of failures.
+func (specs ExtensionTestSpecs) Run(w ResultWriter, maxConcurrent int) error {
+	queue := make(chan *ExtensionTestSpec)
+	failures := atomic.Int64{}
+
+	// Execute beforeAll
+	for _, spec := range specs {
+		for _, beforeAllTask := range spec.beforeAll {
+			beforeAllTask.Run()
+		}
+	}
+
+	// Feed the queue
+	go func() {
+		specs.Walk(func(spec *ExtensionTestSpec) {
+			queue <- spec
+		})
+		close(queue)
+	}()
+
+	// Start consumers
+	var wg sync.WaitGroup
+	for i := 0; i < maxConcurrent; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for spec := range queue {
+				for _, beforeEachTask := range spec.beforeEach {
+					beforeEachTask.Run(*spec)
+				}
+
+				res := runSpec(spec)
+				if res.Result == ResultFailed {
+					failures.Add(1)
+				}
+
+				for _, afterEachTask := range spec.afterEach {
+					afterEachTask.Run(res)
+				}
+
+				// We can't assume the runner will set the name of a test; it may not know it. Even if
+				// it does, we may want to modify it (e.g. k8s-tests for annotations currently).
+				res.Name = spec.Name
+				w.Write(res)
+			}
+		}()
+	}
+
+	// Wait for all consumers to finish
+	wg.Wait()
+
+	// Execute afterAll
+	for _, spec := range specs {
+		for _, afterAllTask := range spec.afterAll {
+			afterAllTask.Run()
+		}
+	}
+
+	failCount := failures.Load()
+	if failCount > 0 {
+		return fmt.Errorf("%d tests failed", failCount)
+	}
+	return nil
+}
+
+// AddBeforeAll adds a function to be run once before all tests start executing.
+func (specs ExtensionTestSpecs) AddBeforeAll(fn func()) {
+	task := &OneTimeTask{fn: fn}
+	specs.Walk(func(spec *ExtensionTestSpec) {
+		spec.beforeAll = append(spec.beforeAll, task)
+	})
+}
+
+// AddAfterAll adds a function to be run once after all tests have finished.
+func (specs ExtensionTestSpecs) AddAfterAll(fn func()) {
+	task := &OneTimeTask{fn: fn}
+	specs.Walk(func(spec *ExtensionTestSpec) {
+		spec.afterAll = append(spec.afterAll, task)
+	})
+}
+
+// AddBeforeEach adds a function that runs before each test starts executing. The ExtensionTestSpec is
+// passed in for contextual information, but must not be modified. The provided function must be thread
+// safe.
+func (specs ExtensionTestSpecs) AddBeforeEach(fn func(spec ExtensionTestSpec)) {
+	task := &SpecTask{fn: fn}
+	specs.Walk(func(spec *ExtensionTestSpec) {
+		spec.beforeEach = append(spec.beforeEach, task)
+	})
+}
+
+// AddAfterEach adds a function that runs after each test has finished executing. The ExtensionTestResult
+// can be modified if needed. The provided function must be thread safe.
+func (specs ExtensionTestSpecs) AddAfterEach(fn func(task *ExtensionTestResult)) {
+	task := &TestResultTask{fn: fn}
+	specs.Walk(func(spec *ExtensionTestSpec) {
+		spec.afterEach = append(spec.afterEach, task)
+	})
+}
+
+// MustFilter filters specs using the given celExprs.  Each celExpr is OR'd together, if any
+// match the spec is included in the filtered set. If your CEL expression is invalid or filtering
+// otherwise fails, this function panics.
+func (specs ExtensionTestSpecs) MustFilter(celExprs []string) ExtensionTestSpecs {
+	specs, err := specs.Filter(celExprs)
+	if err != nil {
+		panic(fmt.Sprintf("filter did not succeed: %s", err.Error()))
+	}
+
+	return specs
+}
+
+// Filter filters specs using the given celExprs.  Each celExpr is OR'd together, if any
+// match the spec is included in the filtered set.
+func (specs ExtensionTestSpecs) Filter(celExprs []string) (ExtensionTestSpecs, error) {
+	var filteredSpecs ExtensionTestSpecs
+
+	// Empty filters returns all
+	if len(celExprs) == 0 {
+		return specs, nil
+	}
+
+	env, err := cel.NewEnv(
+		cel.Declarations(
+			decls.NewVar("source", decls.String),
+			decls.NewVar("name", decls.String),
+			decls.NewVar("originalName", decls.String),
+			decls.NewVar("labels", decls.NewListType(decls.String)),
+			decls.NewVar("tags", decls.NewMapType(decls.String, decls.String)),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	// OR all expressions together
+	for _, spec := range specs {
+		include := false
+		for _, celExpr := range celExprs {
+			prg, err := programForCEL(env, celExpr)
+			if err != nil {
+				return nil, err
+			}
+			out, _, err := prg.Eval(map[string]interface{}{
+				"name":         spec.Name,
+				"source":       spec.Source,
+				"originalName": spec.OriginalName,
+				"labels":       spec.Labels.UnsortedList(),
+				"tags":         spec.Tags,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating CEL expression: %v", err)
+			}
+
+			// If any CEL expression evaluates to true, include the TestSpec
+			if out == types.True {
+				include = true
+				break
+			}
+		}
+		if include {
+			filteredSpecs = append(filteredSpecs, spec)
+		}
+	}
+
+	return filteredSpecs, nil
+}
+
+func programForCEL(env *cel.Env, celExpr string) (cel.Program, error) {
+	// Parse CEL expression
+	ast, iss := env.Parse(celExpr)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("error parsing CEL expression '%s': %v", celExpr, iss.Err())
+	}
+
+	// Check the AST
+	checked, iss := env.Check(ast)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("error checking CEL expression '%s': %v", celExpr, iss.Err())
+	}
+
+	// Create a CEL program from the checked AST
+	prg, err := env.Program(checked)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CEL program: %v", err)
+	}
+	return prg, nil
+}
+
+// FilterByEnvironment checks both the Include and Exclude fields of the ExtensionTestSpec to return those specs which match.
+// Tests will be included by default unless they are explicitly excluded. If Include is specified, only those tests matching
+// the CEL expression will be included.
+//
+// See helper functions in extensiontests/environment.go to craft CEL expressions
+func (specs ExtensionTestSpecs) FilterByEnvironment(envFlags flags.EnvironmentalFlags) (ExtensionTestSpecs, error) {
+	var filteredSpecs ExtensionTestSpecs
+	if envFlags.IsEmpty() {
+		return specs, nil
+	}
+
+	env, err := cel.NewEnv(
+		cel.Declarations(
+			decls.NewVar("platform", decls.String),
+			decls.NewVar("network", decls.String),
+			decls.NewVar("networkStack", decls.String),
+			decls.NewVar("upgrade", decls.String),
+			decls.NewVar("topology", decls.String),
+			decls.NewVar("architecture", decls.String),
+			decls.NewVar("externalConnectivity", decls.String),
+			decls.NewVar("optionalCapabilities", decls.NewListType(decls.String)),
+			decls.NewVar("facts", decls.NewMapType(decls.String, decls.String)),
+			decls.NewVar("fact_keys", decls.NewListType(decls.String)),
+			decls.NewVar("version", decls.String),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	factKeys := make([]string, len(envFlags.Facts))
+	for k := range envFlags.Facts {
+		factKeys = append(factKeys, k)
+	}
+	vars := map[string]interface{}{
+		"platform":             envFlags.Platform,
+		"network":              envFlags.Network,
+		"networkStack":         envFlags.NetworkStack,
+		"upgrade":              envFlags.Upgrade,
+		"topology":             envFlags.Topology,
+		"architecture":         envFlags.Architecture,
+		"externalConnectivity": envFlags.ExternalConnectivity,
+		"optionalCapabilities": envFlags.OptionalCapabilities,
+		"facts":                envFlags.Facts,
+		"fact_keys":            factKeys,
+		"version":              envFlags.Version,
+	}
+
+	for _, spec := range specs {
+		envSel := spec.EnvironmentSelector
+		// If there is no include or exclude CEL, include it implicitly
+		if envSel.IsEmpty() {
+			filteredSpecs = append(filteredSpecs, spec)
+			continue
+		}
+
+		if envSel.Exclude != "" {
+			prg, err := programForCEL(env, envSel.Exclude)
+			if err != nil {
+				return nil, err
+			}
+			out, _, err := prg.Eval(vars)
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating CEL expression: %v", err)
+			}
+			// If it is explicitly excluded, don't check include
+			if out == types.True {
+				continue
+			}
+		}
+
+		if envSel.Include != "" {
+			prg, err := programForCEL(env, envSel.Include)
+			if err != nil {
+				return nil, err
+			}
+			out, _, err := prg.Eval(vars)
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating CEL expression: %v", err)
+			}
+
+			if out == types.True {
+				filteredSpecs = append(filteredSpecs, spec)
+			}
+		} else { // If it hasn't been excluded, and there is no "include" it will be implicitly included
+			filteredSpecs = append(filteredSpecs, spec)
+		}
+
+	}
+
+	return filteredSpecs, nil
+}
+
+// AddLabel adds the labels to each spec.
+func (specs ExtensionTestSpecs) AddLabel(labels ...string) ExtensionTestSpecs {
+	for i := range specs {
+		specs[i].Labels.Insert(labels...)
+	}
+
+	return specs
+}
+
+// RemoveLabel removes the labels from each spec.
+func (specs ExtensionTestSpecs) RemoveLabel(labels ...string) ExtensionTestSpecs {
+	for i := range specs {
+		specs[i].Labels.Delete(labels...)
+	}
+
+	return specs
+}
+
+// SetTag specifies a key/value pair for each spec.
+func (specs ExtensionTestSpecs) SetTag(key, value string) ExtensionTestSpecs {
+	for i := range specs {
+		specs[i].Tags[key] = value
+	}
+
+	return specs
+}
+
+// UnsetTag removes the specified key from each spec.
+func (specs ExtensionTestSpecs) UnsetTag(key string) ExtensionTestSpecs {
+	for i := range specs {
+		delete(specs[i].Tags, key)
+	}
+
+	return specs
+}
+
+// Include adds the specified CEL expression to explicitly include tests by environment to each spec
+func (specs ExtensionTestSpecs) Include(includeCEL string) ExtensionTestSpecs {
+	for _, spec := range specs {
+		spec.Include(includeCEL)
+	}
+	return specs
+}
+
+// Exclude adds the specified CEL expression to explicitly exclude tests by environment to each spec
+func (specs ExtensionTestSpecs) Exclude(excludeCEL string) ExtensionTestSpecs {
+	for _, spec := range specs {
+		spec.Exclude(excludeCEL)
+	}
+	return specs
+}
+
+// Include adds the specified CEL expression to explicitly include tests by environment.
+// If there is already an "include" defined, it will OR the expressions together
+func (spec *ExtensionTestSpec) Include(includeCEL string) *ExtensionTestSpec {
+	existingInclude := spec.EnvironmentSelector.Include
+	if existingInclude != "" {
+		includeCEL = fmt.Sprintf("(%s) || (%s)", existingInclude, includeCEL)
+	}
+
+	spec.EnvironmentSelector.Include = includeCEL
+	return spec
+}
+
+// Exclude adds the specified CEL expression to explicitly exclude tests by environment.
+// If there is already an "exclude" defined, it will OR the expressions together
+func (spec *ExtensionTestSpec) Exclude(excludeCEL string) *ExtensionTestSpec {
+	existingExclude := spec.EnvironmentSelector.Exclude
+	if existingExclude != "" {
+		excludeCEL = fmt.Sprintf("(%s) || (%s)", existingExclude, excludeCEL)
+	}
+
+	spec.EnvironmentSelector.Exclude = excludeCEL
+	return spec
+}
+
+func runSpec(spec *ExtensionTestSpec) *ExtensionTestResult {
+	startTime := time.Now().UTC()
+	res := spec.Run()
+	duration := time.Since(startTime)
+	endTime := startTime.Add(duration).UTC()
+	if res == nil {
+		// this shouldn't happen
+		panic(fmt.Sprintf("test produced no result: %s", spec.Name))
+	}
+
+	res.Lifecycle = spec.Lifecycle
+
+	// If the runner doesn't populate this info, we should set it
+	if res.StartTime == nil {
+		res.StartTime = dbtime.Ptr(startTime)
+	}
+	if res.EndTime == nil {
+		res.EndTime = dbtime.Ptr(endTime)
+	}
+	if res.Duration == 0 {
+		res.Duration = duration.Milliseconds()
+	}
+
+	return res
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/task.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/task.go
@@ -1,0 +1,31 @@
+package extensiontests
+
+import "sync/atomic"
+
+type SpecTask struct {
+	fn func(spec ExtensionTestSpec)
+}
+
+func (t *SpecTask) Run(spec ExtensionTestSpec) {
+	t.fn(spec)
+}
+
+type TestResultTask struct {
+	fn func(result *ExtensionTestResult)
+}
+
+func (t *TestResultTask) Run(result *ExtensionTestResult) {
+	t.fn(result)
+}
+
+type OneTimeTask struct {
+	fn       func()
+	executed int32 // Atomic boolean to indicate whether the function has been run
+}
+
+func (t *OneTimeTask) Run() {
+	// Ensure one-time tasks are only run once
+	if atomic.CompareAndSwapInt32(&t.executed, 0, 1) {
+		t.fn()
+	}
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
@@ -1,0 +1,101 @@
+package extensiontests
+
+import (
+	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
+)
+
+type Lifecycle string
+
+var LifecycleInforming Lifecycle = "informing"
+var LifecycleBlocking Lifecycle = "blocking"
+
+type ExtensionTestSpecs []*ExtensionTestSpec
+
+type ExtensionTestSpec struct {
+	Name string `json:"name"`
+
+	// OriginalName contains the very first name this test was ever known as, used to preserve
+	// history across all names.
+	OriginalName string `json:"originalName,omitempty"`
+
+	// Labels are single string values to apply to the test spec
+	Labels sets.Set[string] `json:"labels"`
+
+	// Tags are key:value pairs
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// Resources gives optional information about what's required to run this test.
+	Resources Resources `json:"resources"`
+
+	// Source is the origin of the test.
+	Source string `json:"source"`
+
+	// Lifecycle informs the executor whether the test is informing only, and should not cause the
+	// overall job run to fail, or if it's blocking where a failure of the test is fatal.
+	// Informing lifecycle tests can be used temporarily to gather information about a test's stability.
+	// Tests must not remain informing forever.
+	Lifecycle Lifecycle `json:"lifecycle"`
+
+	// EnvironmentSelector allows for CEL expressions to be used to control test inclusion
+	EnvironmentSelector EnvironmentSelector `json:"environmentSelector,omitempty"`
+
+	// Run invokes a test
+	Run func() *ExtensionTestResult `json:"-"`
+
+	// Hook functions
+	afterAll   []*OneTimeTask
+	beforeAll  []*OneTimeTask
+	afterEach  []*TestResultTask
+	beforeEach []*SpecTask
+}
+
+type Resources struct {
+	Isolation Isolation `json:"isolation"`
+	Memory    string    `json:"memory,omitempty"`
+	Duration  string    `json:"duration,omitempty"`
+	Timeout   string    `json:"timeout,omitempty"`
+}
+
+type Isolation struct {
+	Mode     string   `json:"mode,omitempty"`
+	Conflict []string `json:"conflict,omitempty"`
+}
+
+type EnvironmentSelector struct {
+	Include string `json:"include,omitempty"`
+	Exclude string `json:"exclude,omitempty"`
+}
+
+func (e EnvironmentSelector) IsEmpty() bool {
+	return e.Include == "" && e.Exclude == ""
+}
+
+type ExtensionTestResults []*ExtensionTestResult
+
+type Result string
+
+var ResultPassed Result = "passed"
+var ResultSkipped Result = "skipped"
+var ResultFailed Result = "failed"
+
+type ExtensionTestResult struct {
+	Name      string         `json:"name"`
+	Lifecycle Lifecycle      `json:"lifecycle"`
+	Duration  int64          `json:"duration"`
+	StartTime *dbtime.DBTime `json:"startTime"`
+	EndTime   *dbtime.DBTime `json:"endTime"`
+	Result    Result         `json:"result"`
+	Output    string         `json:"output"`
+	Error     string         `json:"error,omitempty"`
+	Details   []Details      `json:"details,omitempty"`
+}
+
+// Details are human-readable messages to further explain skips, timeouts, etc.
+// It can also be used to provide contemporaneous information about failures
+// that may not be easily returned by must-gather. For larger artifacts (greater than
+// 10KB, write them to $EXTENSION_ARTIFACTS_DIR.
+type Details struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/registry.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/registry.go
@@ -1,0 +1,39 @@
+package extension
+
+const DefaultExtension = "default"
+
+type Registry struct {
+	extensions map[string]*Extension
+}
+
+func NewRegistry() *Registry {
+	var r Registry
+	return &r
+}
+
+func (r *Registry) Walk(walkFn func(*Extension)) {
+	for k := range r.extensions {
+		if k == DefaultExtension {
+			continue
+		}
+		walkFn(r.extensions[k])
+	}
+}
+
+func (r *Registry) Get(name string) *Extension {
+	return r.extensions[name]
+}
+
+func (r *Registry) Register(extension *Extension) {
+	if r.extensions == nil {
+		r.extensions = make(map[string]*Extension)
+		// first extension is default
+		r.extensions[DefaultExtension] = extension
+	}
+
+	r.extensions[extension.Component.Identifier()] = extension
+}
+
+func (r *Registry) Deregister(name string) {
+	delete(r.extensions, name)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/types.go
@@ -1,0 +1,63 @@
+package extension
+
+import (
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
+)
+
+const CurrentExtensionAPIVersion = "v1.0"
+
+// Extension represents an extension to openshift-tests.
+type Extension struct {
+	APIVersion string    `json:"apiVersion"`
+	Source     Source    `json:"source"`
+	Component  Component `json:"component"`
+
+	// Suites that the extension wants to advertise/participate in.
+	Suites []Suite `json:"suites"`
+
+	Images []Image `json:"images"`
+
+	// Private data
+	specs         extensiontests.ExtensionTestSpecs
+	obsoleteTests sets.Set[string]
+}
+
+// Source contains the details of the commit and source URL.
+type Source struct {
+	// Commit from which this binary was compiled.
+	Commit string `json:"commit"`
+	// BuildDate ISO8601 string of when the binary was built
+	BuildDate string `json:"build_date"`
+	// GitTreeState lets you know the status of the git tree (clean/dirty)
+	GitTreeState string `json:"git_tree_state"`
+	// SourceURL contains the url of the git repository (if known) that this extension was built from.
+	SourceURL string `json:"source_url,omitempty"`
+}
+
+// Component represents the component the binary acts on.
+type Component struct {
+	// The product this component is part of.
+	Product string `json:"product"`
+	// The type of the component.
+	Kind string `json:"type"`
+	// The name of the component.
+	Name string `json:"name"`
+}
+
+// Suite represents additional suites the extension wants to advertise.
+type Suite struct {
+	// The name of the suite.
+	Name string `json:"name"`
+	// Parent suites this suite is part of.
+	Parents []string `json:"parents,omitempty"`
+	// Qualifiers are CEL expressions that are OR'd together for test selection that are members of the suite.
+	Qualifiers []string `json:"qualifiers,omitempty"`
+}
+
+type Image struct {
+	Index    int    `json:"index"`
+	Registry string `json:"registry"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/component.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/component.go
@@ -1,0 +1,25 @@
+package flags
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const DefaultExtension = "default"
+
+// ComponentFlags contains information for specifying the component.
+type ComponentFlags struct {
+	Component string
+}
+
+func NewComponentFlags() *ComponentFlags {
+	return &ComponentFlags{
+		Component: DefaultExtension,
+	}
+}
+
+func (f *ComponentFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&f.Component,
+		"component",
+		f.Component,
+		"specify the component to enable")
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/concurrency.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/concurrency.go
@@ -1,0 +1,23 @@
+package flags
+
+import "github.com/spf13/pflag"
+
+// ConcurrencyFlags contains information for configuring concurrency
+type ConcurrencyFlags struct {
+	MaxConcurency int
+}
+
+func NewConcurrencyFlags() *ConcurrencyFlags {
+	return &ConcurrencyFlags{
+		MaxConcurency: 10,
+	}
+}
+
+func (f *ConcurrencyFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.IntVarP(&f.MaxConcurency,
+		"max-concurrency",
+		"c",
+		f.MaxConcurency,
+		"maximum number of tests to run in parallel",
+	)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/environment.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/environment.go
@@ -1,0 +1,102 @@
+package flags
+
+import (
+	"reflect"
+
+	"github.com/spf13/pflag"
+)
+
+type EnvironmentalFlags struct {
+	Platform             string
+	Network              string
+	NetworkStack         string
+	Upgrade              string
+	Topology             string
+	Architecture         string
+	ExternalConnectivity string
+	OptionalCapabilities []string
+	Facts                map[string]string
+	Version              string
+}
+
+func NewEnvironmentalFlags() *EnvironmentalFlags {
+	return &EnvironmentalFlags{}
+}
+
+func (f *EnvironmentalFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&f.Platform,
+		"platform",
+		"",
+		"The hardware or cloud platform (\"aws\", \"gcp\", \"metal\", ...). Since: v1.0")
+	fs.StringVar(&f.Network,
+		"network",
+		"",
+		"The network of the target cluster (\"ovn\", \"sdn\"). Since: v1.0")
+	fs.StringVar(&f.NetworkStack,
+		"network-stack",
+		"",
+		"The network stack of the target cluster (\"ipv6\", \"ipv4\", \"dual\"). Since: v1.0")
+	fs.StringVar(&f.Upgrade,
+		"upgrade",
+		"",
+		"The upgrade that was performed prior to the test run (\"micro\", \"minor\"). Since: v1.0")
+	fs.StringVar(&f.Topology,
+		"topology",
+		"",
+		"The target cluster topology (\"ha\", \"microshift\", ...). Since: v1.0")
+	fs.StringVar(&f.Architecture,
+		"architecture",
+		"",
+		"The CPU architecture of the target cluster (\"amd64\", \"arm64\"). Since: v1.0")
+	fs.StringVar(&f.ExternalConnectivity,
+		"external-connectivity",
+		"",
+		"The External Connectivity of the target cluster (\"Disconnected\", \"Direct\", \"Proxied\"). Since: v1.0")
+	fs.StringSliceVar(&f.OptionalCapabilities,
+		"optional-capability",
+		[]string{},
+		"An Optional Capability of the target cluster. Can be passed multiple times. Since: v1.0")
+	fs.StringToStringVar(&f.Facts,
+		"fact",
+		make(map[string]string),
+		"Facts advertised by cluster components. Since: v1.0")
+	fs.StringVar(&f.Version,
+		"version",
+		"",
+		"\"major.minor\" version of target cluster. Since: v1.0")
+}
+
+func (f *EnvironmentalFlags) IsEmpty() bool {
+	v := reflect.ValueOf(*f)
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+
+		switch field.Kind() {
+		case reflect.Slice, reflect.Map:
+			if !field.IsNil() && field.Len() > 0 {
+				return false
+			}
+		default:
+			if !reflect.DeepEqual(field.Interface(), reflect.Zero(field.Type()).Interface()) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// EnvironmentFlagVersions holds the "Since" version metadata for each flag.
+var EnvironmentFlagVersions = map[string]string{
+	"platform":              "v1.0",
+	"network":               "v1.0",
+	"network-stack":         "v1.0",
+	"upgrade":               "v1.0",
+	"topology":              "v1.0",
+	"architecture":          "v1.0",
+	"external-connectivity": "v1.0",
+	"optional-capability":   "v1.0",
+	"fact":                  "v1.0",
+	"version":               "v1.0",
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/names.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/names.go
@@ -1,0 +1,24 @@
+package flags
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// NamesFlags contains information for specifying multiple test names.
+type NamesFlags struct {
+	Names []string
+}
+
+func NewNamesFlags() *NamesFlags {
+	return &NamesFlags{
+		Names: []string{},
+	}
+}
+
+func (f *NamesFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVarP(&f.Names,
+		"names",
+		"n",
+		f.Names,
+		"specify test name (can be specified multiple times)")
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/output.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/output.go
@@ -1,0 +1,95 @@
+package flags
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+// OutputFlags contains information for specifying multiple test names.
+type OutputFlags struct {
+	Output string
+}
+
+func NewOutputFlags() *OutputFlags {
+	return &OutputFlags{
+		Output: "json",
+	}
+}
+
+func (f *OutputFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&f.Output,
+		"output",
+		"o",
+		f.Output,
+		"output mode")
+}
+
+func (o *OutputFlags) Marshal(v interface{}) ([]byte, error) {
+	switch o.Output {
+	case "", "json":
+		j, err := json.MarshalIndent(&v, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		return j, nil
+	case "jsonl":
+		// Check if v is a slice or array
+		val := reflect.ValueOf(v)
+		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {
+			var result []byte
+			for i := 0; i < val.Len(); i++ {
+				item := val.Index(i).Interface()
+				j, err := json.Marshal(item)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, j...)
+				result = append(result, '\n') // Append newline after each item
+			}
+			return result, nil
+		}
+		return nil, errors.New("jsonl format requires a slice or array")
+	case "names":
+		val := reflect.ValueOf(v)
+		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {
+			var names []string
+		outerLoop:
+			for i := 0; i < val.Len(); i++ {
+				item := val.Index(i)
+				// Check for Name() or Identifier() methods
+				itemInterface := item.Interface()
+				nameFuncs := []string{"Name", "Identifier"}
+				for _, fn := range nameFuncs {
+					method := reflect.ValueOf(itemInterface).MethodByName(fn)
+					if method.IsValid() && method.Kind() == reflect.Func && method.Type().NumIn() == 0 && method.Type().NumOut() == 1 && method.Type().Out(0).Kind() == reflect.String {
+						name := method.Call(nil)[0].String()
+						names = append(names, name)
+						continue outerLoop
+					}
+				}
+
+				// Dereference pointer if needed
+				if item.Kind() == reflect.Ptr {
+					item = item.Elem()
+				}
+				// Check for struct with Name field
+				if item.Kind() == reflect.Struct {
+					nameField := item.FieldByName("Name")
+					if nameField.IsValid() && nameField.Kind() == reflect.String {
+						names = append(names, nameField.String())
+					}
+				} else {
+					return nil, errors.New("items must have a Name field or a Name() method")
+				}
+			}
+			return []byte(strings.Join(names, "\n")), nil
+		}
+		return nil, errors.New("names format requires an array of structs")
+	default:
+		return nil, errors.Errorf("invalid output format: %s", o.Output)
+	}
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/suite.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/flags/suite.go
@@ -1,0 +1,21 @@
+package flags
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// SuiteFlags contains information for specifying the suite.
+type SuiteFlags struct {
+	Suite string
+}
+
+func NewSuiteFlags() *SuiteFlags {
+	return &SuiteFlags{}
+}
+
+func (f *SuiteFlags) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&f.Suite,
+		"suite",
+		f.Suite,
+		"specify the suite to use")
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/LICENSE
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/README.md
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/README.md
@@ -1,0 +1,3 @@
+This package is copy/pasted from [k8s.io/apimachinery](https://github.com/kubernetes/apimachinery/tree/master/pkg/util/sets) 
+to avoid a circular dependency with `openshift/kubernetes` as it requires OTE and, without having done this, 
+OTE would require `kubernetes/kubernetes`.

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/byte.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/byte.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Byte is a set of bytes, implemented via map[byte]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[byte]{}
+// s2 := New[byte]()
+type Byte map[byte]Empty
+
+// NewByte creates a Byte from a list of values.
+func NewByte(items ...byte) Byte {
+	return Byte(New[byte](items...))
+}
+
+// ByteKeySet creates a Byte from a keys of a map[byte](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func ByteKeySet[T any](theMap map[byte]T) Byte {
+	return Byte(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Byte) Insert(items ...byte) Byte {
+	return Byte(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Byte) Delete(items ...byte) Byte {
+	return Byte(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Byte) Has(item byte) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Byte) HasAll(items ...byte) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Byte) HasAny(items ...byte) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Byte) Clone() Byte {
+	return Byte(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Byte) Difference(s2 Byte) Byte {
+	return Byte(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Byte) SymmetricDifference(s2 Byte) Byte {
+	return Byte(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Byte) Union(s2 Byte) Byte {
+	return Byte(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Byte) Intersection(s2 Byte) Byte {
+	return Byte(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Byte) IsSuperset(s2 Byte) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Byte) Equal(s2 Byte) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted byte slice.
+func (s Byte) List() []byte {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Byte) UnsortedList() []byte {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Byte) PopAny() (byte, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Byte) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/doc.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sets has generic set and specified sets. Generic set will
+// replace specified ones over time. And specific ones are deprecated.
+package sets // import "github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/empty.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/empty.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Empty is public since it is used by some internal API objects for conversions between external
+// string arrays and internal sets, and conversion logic requires public types today.
+type Empty struct{}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int is a set of ints, implemented via map[int]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int]{}
+// s2 := New[int]()
+type Int map[int]Empty
+
+// NewInt creates a Int from a list of values.
+func NewInt(items ...int) Int {
+	return Int(New[int](items...))
+}
+
+// IntKeySet creates a Int from a keys of a map[int](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func IntKeySet[T any](theMap map[int]T) Int {
+	return Int(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int) Insert(items ...int) Int {
+	return Int(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int) Delete(items ...int) Int {
+	return Int(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int) Has(item int) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int) HasAll(items ...int) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int) HasAny(items ...int) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int) Clone() Int {
+	return Int(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int) Difference(s2 Int) Int {
+	return Int(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int) SymmetricDifference(s2 Int) Int {
+	return Int(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int) Union(s2 Int) Int {
+	return Int(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int) Intersection(s2 Int) Int {
+	return Int(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int) IsSuperset(s2 Int) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int) Equal(s2 Int) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int slice.
+func (s Int) List() []int {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int) UnsortedList() []int {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int) PopAny() (int, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int32.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int32.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int32 is a set of int32s, implemented via map[int32]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int32]{}
+// s2 := New[int32]()
+type Int32 map[int32]Empty
+
+// NewInt32 creates a Int32 from a list of values.
+func NewInt32(items ...int32) Int32 {
+	return Int32(New[int32](items...))
+}
+
+// Int32KeySet creates a Int32 from a keys of a map[int32](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func Int32KeySet[T any](theMap map[int32]T) Int32 {
+	return Int32(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int32) Insert(items ...int32) Int32 {
+	return Int32(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int32) Delete(items ...int32) Int32 {
+	return Int32(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int32) Has(item int32) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int32) HasAll(items ...int32) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int32) HasAny(items ...int32) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int32) Clone() Int32 {
+	return Int32(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int32) Difference(s2 Int32) Int32 {
+	return Int32(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int32) SymmetricDifference(s2 Int32) Int32 {
+	return Int32(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int32) Union(s2 Int32) Int32 {
+	return Int32(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int32) Intersection(s2 Int32) Int32 {
+	return Int32(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int32) IsSuperset(s2 Int32) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int32) Equal(s2 Int32) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int32 slice.
+func (s Int32) List() []int32 {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int32) UnsortedList() []int32 {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int32) PopAny() (int32, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int32) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int64.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/int64.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Int64 is a set of int64s, implemented via map[int64]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[int64]{}
+// s2 := New[int64]()
+type Int64 map[int64]Empty
+
+// NewInt64 creates a Int64 from a list of values.
+func NewInt64(items ...int64) Int64 {
+	return Int64(New[int64](items...))
+}
+
+// Int64KeySet creates a Int64 from a keys of a map[int64](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func Int64KeySet[T any](theMap map[int64]T) Int64 {
+	return Int64(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s Int64) Insert(items ...int64) Int64 {
+	return Int64(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s Int64) Delete(items ...int64) Int64 {
+	return Int64(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Int64) Has(item int64) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Int64) HasAll(items ...int64) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Int64) HasAny(items ...int64) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Int64) Clone() Int64 {
+	return Int64(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Int64) Difference(s2 Int64) Int64 {
+	return Int64(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Int64) SymmetricDifference(s2 Int64) Int64 {
+	return Int64(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Int64) Union(s2 Int64) Int64 {
+	return Int64(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Int64) Intersection(s2 Int64) Int64 {
+	return Int64(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Int64) IsSuperset(s2 Int64) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Int64) Equal(s2 Int64) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted int64 slice.
+func (s Int64) List() []int64 {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Int64) UnsortedList() []int64 {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s Int64) PopAny() (int64, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s Int64) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/set.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/set.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"cmp"
+	"sort"
+)
+
+// Set is a set of the same type elements, implemented via map[comparable]struct{} for minimal memory consumption.
+type Set[T comparable] map[T]Empty
+
+// cast transforms specified set to generic Set[T].
+func cast[T comparable](s map[T]Empty) Set[T] { return s }
+
+// New creates a Set from a list of values.
+// NOTE: type param must be explicitly instantiated if given items are empty.
+func New[T comparable](items ...T) Set[T] {
+	ss := make(Set[T], len(items))
+	ss.Insert(items...)
+	return ss
+}
+
+// KeySet creates a Set from a keys of a map[comparable](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func KeySet[T comparable, V any](theMap map[T]V) Set[T] {
+	ret := make(Set[T], len(theMap))
+	for keyValue := range theMap {
+		ret.Insert(keyValue)
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s Set[T]) Insert(items ...T) Set[T] {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+func Insert[T comparable](set Set[T], items ...T) Set[T] {
+	return set.Insert(items...)
+}
+
+// Delete removes all items from the set.
+func (s Set[T]) Delete(items ...T) Set[T] {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+func (s Set[T]) Clear() Set[T] {
+	clear(s)
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Set[T]) Has(item T) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Set[T]) HasAll(items ...T) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Set[T]) HasAny(items ...T) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Set[T]) Clone() Set[T] {
+	result := make(Set[T], len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Set[T]) Difference(s2 Set[T]) Set[T] {
+	result := New[T]()
+	for key := range s1 {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
+	return s1.Difference(s2).Union(s2.Difference(s1))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Set[T]) Union(s2 Set[T]) Set[T] {
+	result := s1.Clone()
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Set[T]) Intersection(s2 Set[T]) Set[T] {
+	var walk, other Set[T]
+	result := New[T]()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Set[T]) IsSuperset(s2 Set[T]) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Set[T]) Equal(s2 Set[T]) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+type sortableSliceOfGeneric[T cmp.Ordered] []T
+
+func (g sortableSliceOfGeneric[T]) Len() int           { return len(g) }
+func (g sortableSliceOfGeneric[T]) Less(i, j int) bool { return less[T](g[i], g[j]) }
+func (g sortableSliceOfGeneric[T]) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+// List returns the contents as a sorted T slice.
+//
+// This is a separate function and not a method because not all types supported
+// by Generic are ordered and only those can be sorted.
+func List[T cmp.Ordered](s Set[T]) []T {
+	res := make(sortableSliceOfGeneric[T], 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Set[T]) UnsortedList() []T {
+	res := make([]T, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// PopAny returns a single element from the set.
+func (s Set[T]) PopAny() (T, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue T
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s Set[T]) Len() int {
+	return len(s)
+}
+
+func less[T cmp.Ordered](lhs, rhs T) bool {
+	return lhs < rhs
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/string.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/util/sets/string.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
+//
+// Deprecated: use generic Set instead.
+// new ways:
+// s1 := Set[string]{}
+// s2 := New[string]()
+type String map[string]Empty
+
+// NewString creates a String from a list of values.
+func NewString(items ...string) String {
+	return String(New[string](items...))
+}
+
+// StringKeySet creates a String from a keys of a map[string](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func StringKeySet[T any](theMap map[string]T) String {
+	return String(KeySet(theMap))
+}
+
+// Insert adds items to the set.
+func (s String) Insert(items ...string) String {
+	return String(cast(s).Insert(items...))
+}
+
+// Delete removes all items from the set.
+func (s String) Delete(items ...string) String {
+	return String(cast(s).Delete(items...))
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s String) Has(item string) bool {
+	return cast(s).Has(item)
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s String) HasAll(items ...string) bool {
+	return cast(s).HasAll(items...)
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s String) HasAny(items ...string) bool {
+	return cast(s).HasAny(items...)
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s String) Clone() String {
+	return String(cast(s).Clone())
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 String) Difference(s2 String) String {
+	return String(cast(s1).Difference(cast(s2)))
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 String) SymmetricDifference(s2 String) String {
+	return String(cast(s1).SymmetricDifference(cast(s2)))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 String) Union(s2 String) String {
+	return String(cast(s1).Union(cast(s2)))
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 String) Intersection(s2 String) String {
+	return String(cast(s1).Intersection(cast(s2)))
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 String) IsSuperset(s2 String) bool {
+	return cast(s1).IsSuperset(cast(s2))
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 String) Equal(s2 String) bool {
+	return cast(s1).Equal(cast(s2))
+}
+
+// List returns the contents as a sorted string slice.
+func (s String) List() []string {
+	return List(cast(s))
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s String) UnsortedList() []string {
+	return cast(s).UnsortedList()
+}
+
+// PopAny returns a single element from the set.
+func (s String) PopAny() (string, bool) {
+	return cast(s).PopAny()
+}
+
+// Len returns the size of the set.
+func (s String) Len() int {
+	return len(s)
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/version/version.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+var (
+	// CommitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	CommitFromGit string
+	// BuildDate in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	BuildDate string
+	// GitTreeState has the state of git tree, either "clean" or "dirty"
+	GitTreeState string
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -170,6 +170,20 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250220212757-b9c4d98a0c45
+## explicit; go 1.23.0
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate
+github.com/openshift-eng/openshift-tests-extension/pkg/dbtime
+github.com/openshift-eng/openshift-tests-extension/pkg/extension
+github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests
+github.com/openshift-eng/openshift-tests-extension/pkg/flags
+github.com/openshift-eng/openshift-tests-extension/pkg/util/sets
+github.com/openshift-eng/openshift-tests-extension/pkg/version
 # github.com/openshift/api v0.0.0-20250207102212-9e59a77ed2e0
 ## explicit; go 1.23.0
 github.com/openshift/api/config
@@ -507,7 +521,7 @@ google.golang.org/genproto/googleapis/api
 google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/api/expr/v1alpha1
 google.golang.org/genproto/googleapis/api/httpbody
-# google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7
+# google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61
 ## explicit; go 1.21
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status


### PR DESCRIPTION
Create a minimal Cluster Version Operator OpenShift tests extension.

For more information regarding the extension, see [openshift-eng/openshift-tests-extension](https://www.github.com/openshift-eng/openshift-tests-extension) repository or the respective [enhancement](https://www.github.com/openshift/enhancements/pull/1676).

This pull request references https://issues.redhat.com//browse/OTA-1403

---
Following PRs will:
- [ ] Include new targets in the Makefile. 
  - [ ] `update` to run `_output/$OS/$ARCH/openshift-tests-extension update` this generates a file that contains metadata about existing tests, the `update` generates an error if some invalid changes were made
  - [ ] `verify` to verify no changes are present after the `update` invocation
- [ ] Create a new job to run the `verify` on presubmits 
- [ ] Create the first test in the extension
- [ ] Update the Dockerfile to include the extension binary in a payload image
- [ ] Register the extension in origin
- [ ] Add remaining tests