### PR TITLE
NO-JIRA: manifests: make template manifests valid YAML

### DIFF
--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
-        image: {{.ReleaseImage}}
+        image: '{{.ReleaseImage}}'
         imagePullPolicy: IfNotPresent
         args:
         - "start"
@@ -70,7 +70,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: CLUSTER_PROFILE
-          value: {{ .ClusterProfile }}
+          value: '{{ .ClusterProfile }}'
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
-        image: quay.io/cvo/release:latest
+        image: 'quay.io/cvo/release:latest'
         imagePullPolicy: IfNotPresent
         args:
         - "start"
@@ -70,7 +70,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: CLUSTER_PROFILE
-          value: some-profile
+          value: 'some-profile'
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default


### PR DESCRIPTION
CVO manifests present in the payload contain plain templating `{{yada}}` placeholders where final manifests expect to contain strings, and because `{ }` has meaning in YAML, these manifests are invalid without template engine processing. 

CVO manifests are applied by CVO itself, which processes them through the templating engine, which makes them valid YAML. In an attempt to address OCPBUGS-30080, I want to process the CVO manifests through `oc adm release new` machinery, which requires them to be valid YAML.
