### PR TITLE
NO-JIRA: Add unit test for renderManifest

### DIFF
--- a/pkg/payload/render_test.go
+++ b/pkg/payload/render_test.go
@@ -1,0 +1,60 @@
+package payload
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRenderManifest(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		config               manifestRenderConfig
+		manifestFile         string
+		expectedManifestFile string
+		expectedErr          error
+	}{
+		{
+			name: "cvo deployment",
+			config: manifestRenderConfig{
+				ReleaseImage:   "quay.io/cvo/release:latest",
+				ClusterProfile: "some-profile",
+			},
+			manifestFile:         "../../install/0000_00_cluster-version-operator_03_deployment.yaml",
+			expectedManifestFile: "./testdata/TestRenderManifest_expected_cvo_deployment.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes, err := os.ReadFile(tt.manifestFile)
+			if err != nil {
+				t.Fatalf("failed to read manifest file: %v", err)
+			}
+			actual, actualErr := renderManifest(tt.config, bytes)
+			if strings.ToLower(os.Getenv("UPDATE")) == "true" || actualErr != nil {
+				if err := os.WriteFile(tt.expectedManifestFile, actual, 0644); err != nil {
+					t.Fatalf("failed to update manifest file: %v", err)
+				}
+			}
+			if diff := cmp.Diff(tt.expectedErr, actualErr, cmp.Comparer(func(x, y error) bool {
+				if x == nil || y == nil {
+					return x == nil && y == nil
+				}
+				return x.Error() == y.Error()
+			})); diff != "" {
+				t.Errorf("%s: the actual error differs from the expected (-want, +got): %s", tt.name, diff)
+			} else {
+				expected, err := os.ReadFile(tt.expectedManifestFile)
+				if err != nil {
+					t.Fatalf("failed to read expected manifest file: %v", err)
+				}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					t.Errorf("%s: the actual does not match the expected (-want, +got): %s", tt.name, diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -1,0 +1,130 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-version-operator
+  namespace: openshift-cluster-version
+  annotations:
+    kubernetes.io/description: The cluster-version operator manages OpenShift updates and reconciles core resources and cluster operators.
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cluster-version-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: cluster-version-operator
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: hostaccess
+      labels:
+        k8s-app: cluster-version-operator
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: cluster-version-operator
+        image: quay.io/cvo/release:latest
+        imagePullPolicy: IfNotPresent
+        args:
+          - "start"
+          - "--release-image=quay.io/cvo/release:latest"
+          - "--enable-auto-update=false"
+          - "--listen=0.0.0.0:9099"
+          - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
+          - "--serving-key-file=/etc/tls/serving-cert/tls.key"
+          - "--v=2"
+          - "--always-enable-capabilities=Ingress"
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - mountPath: /etc/ssl/certs
+            name: etc-ssl-certs
+            readOnly: true
+          - mountPath: /etc/cvo/updatepayloads
+            name: etc-cvo-updatepayloads
+            readOnly: true
+          - mountPath: /etc/tls/serving-cert
+            name: serving-cert
+            readOnly: true
+          - mountPath: /etc/tls/service-ca
+            name: service-ca
+            readOnly: true
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: kube-api-access
+            readOnly: true
+        env:
+          # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
+          - name: OPERATOR_IMAGE_VERSION
+            value: "0.0.1-snapshot"
+          - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
+            value: "6443"
+          - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
+            value: "127.0.0.1"
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: CLUSTER_PROFILE
+            value: some-profile
+      # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
+      # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
+      dnsPolicy: Default
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      terminationGracePeriodSeconds: 130
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/network-unavailable"
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule" 
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120 
+      volumes:
+        - name: etc-ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+        - name: etc-cvo-updatepayloads
+          hostPath:
+            path: /etc/cvo/updatepayloads
+        - name: serving-cert
+          secret:
+            secretName: cluster-version-operator-serving-cert
+        - name: service-ca
+          configMap:
+            name: openshift-service-ca.crt
+        - name: kube-api-access
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3600
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace


### PR DESCRIPTION
The diff makes sense, of course.

```console
$ cat ./install/0000_00_cluster-version-operator_03_deployment.yaml | grep '{{'
        image: {{.ReleaseImage}}
          - "--release-image={{.ReleaseImage}}"
            value: {{ .ClusterProfile }}

$ diff -Naupr install/0000_00_cluster-version-operator_03_deployment.yaml pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml    
--- install/0000_00_cluster-version-operator_03_deployment.yaml 2024-11-06 13:30:42
+++ pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml        2025-03-27 09:59:50
@@ -25,11 +25,11 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: cluster-version-operator
-        image: {{.ReleaseImage}}
+        image: quay.io/cvo/release:latest
         imagePullPolicy: IfNotPresent
         args:
           - "start"
-          - "--release-image={{.ReleaseImage}}"
+          - "--release-image=quay.io/cvo/release:latest"
           - "--enable-auto-update=false"
           - "--listen=0.0.0.0:9099"
           - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
@@ -70,7 +70,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: CLUSTER_PROFILE
-            value: {{ .ClusterProfile }}
+            value: some-profile
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default

```

/cc @petr-muller 