### PR TITLE
NO-JIRA: Fix some issues identified by yamllint

### DIFF
--- a/install/0000_00_cluster-version-operator_00_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_00_namespace.yaml
@@ -9,7 +9,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     name: openshift-cluster-version
-    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    openshift.io/run-level: ""  # specify no run-level turns it off on install and upgrades
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged

--- a/install/0000_00_cluster-version-operator_03_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_03_deployment.yaml
@@ -28,49 +28,49 @@ spec:
         image: {{.ReleaseImage}}
         imagePullPolicy: IfNotPresent
         args:
-          - "start"
-          - "--release-image={{.ReleaseImage}}"
-          - "--enable-auto-update=false"
-          - "--listen=0.0.0.0:9099"
-          - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
-          - "--serving-key-file=/etc/tls/serving-cert/tls.key"
-          - "--v=2"
-          - "--always-enable-capabilities=Ingress"
+        - "start"
+        - "--release-image={{.ReleaseImage}}"
+        - "--enable-auto-update=false"
+        - "--listen=0.0.0.0:9099"
+        - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
+        - "--serving-key-file=/etc/tls/serving-cert/tls.key"
+        - "--v=2"
+        - "--always-enable-capabilities=Ingress"
         resources:
           requests:
             cpu: 20m
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-          - mountPath: /etc/ssl/certs
-            name: etc-ssl-certs
-            readOnly: true
-          - mountPath: /etc/cvo/updatepayloads
-            name: etc-cvo-updatepayloads
-            readOnly: true
-          - mountPath: /etc/tls/serving-cert
-            name: serving-cert
-            readOnly: true
-          - mountPath: /etc/tls/service-ca
-            name: service-ca
-            readOnly: true
-          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-            name: kube-api-access
-            readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: etc-ssl-certs
+          readOnly: true
+        - mountPath: /etc/cvo/updatepayloads
+          name: etc-cvo-updatepayloads
+          readOnly: true
+        - mountPath: /etc/tls/serving-cert
+          name: serving-cert
+          readOnly: true
+        - mountPath: /etc/tls/service-ca
+          name: service-ca
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         env:
-          # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
-          - name: OPERATOR_IMAGE_VERSION
-            value: "0.0.1-snapshot"
-          - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
-            value: "6443"
-          - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
-            value: "127.0.0.1"
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: CLUSTER_PROFILE
-            value: {{ .ClusterProfile }}
+        # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snapshot"
+        - name: KUBERNETES_SERVICE_PORT  # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
+          value: "6443"
+        - name: KUBERNETES_SERVICE_HOST  # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
+          value: "127.0.0.1"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CLUSTER_PROFILE
+          value: {{ .ClusterProfile }}
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default
@@ -88,43 +88,43 @@ spec:
         effect: "NoSchedule"
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
-        effect: "NoSchedule" 
+        effect: "NoSchedule"
       - key: "node.kubernetes.io/unreachable"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120 
+        tolerationSeconds: 120
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120 
+        tolerationSeconds: 120
       volumes:
-        - name: etc-ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
-        - name: etc-cvo-updatepayloads
-          hostPath:
-            path: /etc/cvo/updatepayloads
-        - name: serving-cert
-          secret:
-            secretName: cluster-version-operator-serving-cert
-        - name: service-ca
-          configMap:
-            name: openshift-service-ca.crt
-        - name: kube-api-access
-          projected:
-            defaultMode: 420
-            sources:
-            - serviceAccountToken:
-                expirationSeconds: 3600
-                path: token
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace
+      - name: etc-ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: etc-cvo-updatepayloads
+        hostPath:
+          path: /etc/cvo/updatepayloads
+      - name: serving-cert
+        secret:
+          secretName: cluster-version-operator-serving-cert
+      - name: service-ca
+        configMap:
+          name: openshift-service-ca.crt
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace

--- a/install/0000_00_cluster-version-operator_04_service.yaml
+++ b/install/0000_00_cluster-version-operator_04_service.yaml
@@ -16,4 +16,4 @@ spec:
     k8s-app: cluster-version-operator
   ports:
   - name: metrics
-    port: 9099 # chosen to be in the internal open range
+    port: 9099  # chosen to be in the internal open range

--- a/install/0000_00_update-status-controller_00_namespace-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_00_namespace-DevPreviewNoUpgrade.yaml
@@ -10,5 +10,5 @@ metadata:
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   labels:
     name: openshift-update-status-controller
-    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    openshift.io/run-level: ""  # specify no run-level turns it off on install and upgrades
     openshift.io/cluster-monitoring: "true"

--- a/install/0000_00_update-status-controller_03_deployment-DevPreviewNoUpgrade.yaml
+++ b/install/0000_00_update-status-controller_03_deployment-DevPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - "update-status-controller"
-        - -v=5 # High while in DevPreview, lower for GA
+        - -v=5  # High while in DevPreview, lower for GA
         securityContext:
           capabilities:
             drop:

--- a/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
+++ b/install/0000_90_cluster-version-operator_02_servicemonitor.yaml
@@ -59,8 +59,8 @@ spec:
         (
           (
             time()-cluster_version_operator_update_retrieval_timestamp_seconds
-          ) >= 3600 
-          and ignoring(condition, name, reason) 
+          ) >= 3600
+          and ignoring(condition, name, reason)
           (cluster_operator_conditions{name="version", condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"})
         )
       labels:

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -28,49 +28,49 @@ spec:
         image: quay.io/cvo/release:latest
         imagePullPolicy: IfNotPresent
         args:
-          - "start"
-          - "--release-image=quay.io/cvo/release:latest"
-          - "--enable-auto-update=false"
-          - "--listen=0.0.0.0:9099"
-          - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
-          - "--serving-key-file=/etc/tls/serving-cert/tls.key"
-          - "--v=2"
-          - "--always-enable-capabilities=Ingress"
+        - "start"
+        - "--release-image=quay.io/cvo/release:latest"
+        - "--enable-auto-update=false"
+        - "--listen=0.0.0.0:9099"
+        - "--serving-cert-file=/etc/tls/serving-cert/tls.crt"
+        - "--serving-key-file=/etc/tls/serving-cert/tls.key"
+        - "--v=2"
+        - "--always-enable-capabilities=Ingress"
         resources:
           requests:
             cpu: 20m
             memory: 50Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-          - mountPath: /etc/ssl/certs
-            name: etc-ssl-certs
-            readOnly: true
-          - mountPath: /etc/cvo/updatepayloads
-            name: etc-cvo-updatepayloads
-            readOnly: true
-          - mountPath: /etc/tls/serving-cert
-            name: serving-cert
-            readOnly: true
-          - mountPath: /etc/tls/service-ca
-            name: service-ca
-            readOnly: true
-          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-            name: kube-api-access
-            readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: etc-ssl-certs
+          readOnly: true
+        - mountPath: /etc/cvo/updatepayloads
+          name: etc-cvo-updatepayloads
+          readOnly: true
+        - mountPath: /etc/tls/serving-cert
+          name: serving-cert
+          readOnly: true
+        - mountPath: /etc/tls/service-ca
+          name: service-ca
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
         env:
-          # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
-          - name: OPERATOR_IMAGE_VERSION
-            value: "0.0.1-snapshot"
-          - name: KUBERNETES_SERVICE_PORT # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
-            value: "6443"
-          - name: KUBERNETES_SERVICE_HOST # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
-            value: "127.0.0.1"
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: CLUSTER_PROFILE
-            value: some-profile
+        # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snapshot"
+        - name: KUBERNETES_SERVICE_PORT  # allows CVO to communicate with apiserver directly on same host.  Is substituted with port from infrastructures.status.apiServerInternalURL if available.
+          value: "6443"
+        - name: KUBERNETES_SERVICE_HOST  # allows CVO to communicate with apiserver directly on same host.  Is substituted with hostname from infrastructures.status.apiServerInternalURL if available.
+          value: "127.0.0.1"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CLUSTER_PROFILE
+          value: some-profile
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default
@@ -88,43 +88,43 @@ spec:
         effect: "NoSchedule"
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
-        effect: "NoSchedule" 
+        effect: "NoSchedule"
       - key: "node.kubernetes.io/unreachable"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120 
+        tolerationSeconds: 120
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 120 
+        tolerationSeconds: 120
       volumes:
-        - name: etc-ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
-        - name: etc-cvo-updatepayloads
-          hostPath:
-            path: /etc/cvo/updatepayloads
-        - name: serving-cert
-          secret:
-            secretName: cluster-version-operator-serving-cert
-        - name: service-ca
-          configMap:
-            name: openshift-service-ca.crt
-        - name: kube-api-access
-          projected:
-            defaultMode: 420
-            sources:
-            - serviceAccountToken:
-                expirationSeconds: 3600
-                path: token
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace
+      - name: etc-ssl-certs
+        hostPath:
+          path: /etc/ssl/certs
+      - name: etc-cvo-updatepayloads
+        hostPath:
+          path: /etc/cvo/updatepayloads
+      - name: serving-cert
+        secret:
+          secretName: cluster-version-operator-serving-cert
+      - name: service-ca
+        configMap:
+          name: openshift-service-ca.crt
+      - name: kube-api-access
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace


### PR DESCRIPTION
See [the rehearsal](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63274/rehearse-63274-pull-ci-openshift-cluster-version-operator-main-yamllint/1905387572654247936) for the details.

The remained two will be fixed by https://github.com/openshift/cluster-version-operator/pull/1171/files#diff-d545314649981da131e9fa5eec88fd1fc37172eb51389689aa227464191bb133R72

```
$ yamllint -v && yamllint --strict -d '{extends: default, rules: {indentation: {indent-sequences: consistent}, document-start: disable, line-length: disable}}' ./install
yamllint 1.35.1
./install/0000_00_cluster-version-operator_03_deployment.yaml
  73:20     error    too many spaces inside braces  (braces)
  73:36     error    too many spaces inside braces  (braces)
```

