### PR TITLE
OTA-1403: Update and Verify Test Metadata Using Makefile

### DIFF
--- a/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
+++ b/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "[cvo-testing] cluster-version-operator-tests should support passing tests",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:cluster-version-operator",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
+  }
+]

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,16 @@ format:
 	go fmt ./...
 .PHONY: format
 
-verify: verify-yaml
+verify: verify-yaml verify-update
 .PHONY: verify
 
 verify-yaml:
 	hack/verify-yaml.sh
 .PHONY: verify-yaml
+
+verify-update: update
+	git diff --exit-code HEAD
+.PHONY: verify-update
 
 clean:
 	rm -rf _output/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ integration-test:
 	./hack/integration-test.sh
 .PHONY: integration-test
 
+update: build
+	hack/update-test-metadata.sh
+.PHONY: update
+
 format:
 	go fmt ./...
 .PHONY: format

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -2,29 +2,11 @@
 
 set -eu
 
-REPO=github.com/openshift/cluster-version-operator
-GOFLAGS=${GOFLAGS:--mod=vendor}
-GLDFLAGS=${GLDFLAGS:-}
-
-eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
-
-GOOS=${GOOS:-${GOHOSTOS}}
-GOARCH=${GOARCH:-${GOHOSTARCH}}
-
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"
 
-VERSION_OVERRIDE=${VERSION_OVERRIDE:-${OS_GIT_VERSION:-}}
-if [ -z "${VERSION_OVERRIDE:-}" ]; then
-	echo "Using version from git..."
-	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
-fi
-
-eval $(go env)
-
-if [ -z ${BIN_PATH+a} ]; then
-	export BIN_PATH=_output/${GOOS}/${GOARCH}
-fi
+# Source build variables
+source hack/build-info.sh
 
 echo "Building binaries into ${BIN_PATH}"
 mkdir -p ${BIN_PATH}

--- a/hack/build-info.sh
+++ b/hack/build-info.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eu
+
+REPO=github.com/openshift/cluster-version-operator
+GOFLAGS=${GOFLAGS:--mod=vendor}
+GLDFLAGS=${GLDFLAGS:-}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+GOOS=${GOOS:-${GOHOSTOS}}
+GOARCH=${GOARCH:-${GOHOSTARCH}}
+
+VERSION_OVERRIDE=${VERSION_OVERRIDE:-${OS_GIT_VERSION:-}}
+if [ -z "${VERSION_OVERRIDE:-}" ]; then
+	echo "Using version from git..."
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
+fi
+
+eval $(go env)
+
+if [ -z ${BIN_PATH+a} ]; then
+	export BIN_PATH=_output/${GOOS}/${GOARCH}
+fi

--- a/hack/update-test-metadata.sh
+++ b/hack/update-test-metadata.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source hack/build-info.sh
+
+# Update test metadata
+eval "${BIN_PATH}/cluster-version-operator-tests" "update"


### PR DESCRIPTION
Create an update target in the Makefile to execute the tests-extension update logic to update/validate test metadata. Add `git diff` logic to the verify target to make sure any uncommitted changes fail the execution of the target. This will be run on PRs to make sure the test metadata is commited and valid.

For more info on the update subcommand, see [ Update - Metadata Validation](https://www.github.com/openshift/enhancements/pull/1676/files#diff-3830bd2c970bd4daeeecea1e6624237b0694bdd8872c70b7042225bd6b636010R851-R867)