### PR TITLE
OTA-1531: [2/x] cvo: refactor `LoadUpdate`

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -304,7 +304,7 @@ func ValidateDirectory(dir string) error {
 }
 
 func loadPayloadMetadata(releaseDir, releaseImage string) (*Update, error) {
-	release, err := loadReleaseFromMetadata(releaseDir)
+	release, err := loadReleaseMetadata(releaseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func loadPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) [
 	}}
 }
 
-func loadReleaseFromMetadata(releaseDir string) (configv1.Release, error) {
+func loadReleaseMetadata(releaseDir string) (configv1.Release, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
Builds on: https://github.com/openshift/cluster-version-operator/pull/1184

Extract loading tasks from `loadUpdatePayloadMetadata` one layer up to `LoadUpdate`, which makes more sense as a logical sequence of "loading the update". This also allows simplifying `loadUpdatePayloadMetadata` signature because the inputs for loading tasks are partially disjoint from the ones needed for loading the metadata.

The architecture is either read from release metadata when present (and in that case it must be a string and must be multi) or determined from runtime in all other cases. Refactor `loadReleaseFromMetadata` so that it only really reads the metadata, and move the "when metadata does not have architecture, read from runtime" logic to `loadPayloadMetadata` above (the `loadReleaseFromMetadata` caller). This will allow to reuse the release metadata loading code without involving more logic than necessary.

Rename loadReleaseFromMetadata->`loadReleaseMetadata`. I believe this is a better name in the context of the full loading code. Release metadata is a subset of the payload metadata, and the `LoadUpdate` -> `loadPayloadMetadata` -> `loadReleaseMetadata` chain makes the method names more cohesive.

The reason for this refactor is that for [OTA-1531](https://issues.redhat.com//browse/OTA-1531) I need to isolate the code that loads payload metadata from the code that loads the full payload. This will allow to probe the metadata for release version near the start of CVO executing, so that the version can be used to set up the desired feature gated behavior to enable or disable.
