### PR TITLE
EXAMPLE: Motivating example for OTA-1531

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -315,6 +315,10 @@ func (optr *Operator) LoadInitialPayload(ctx context.Context, startingRequiredFe
 		return nil, fmt.Errorf("unable to create a configuration client: %v", err)
 	}
 
+	if optr.enabledFeatureGates.SomethingInPayloadLoading() {
+		fmt.Println("SomethingInPayloadLoading feature gate is enabled")
+	}
+
 	customSignatureStore := &customsignaturestore.Store{
 		Lister:     optr.cvLister,
 		Name:       optr.name,

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -206,6 +206,10 @@ type fakeRiFlags struct {
 	cvoConfiguration              bool
 }
 
+func (f fakeRiFlags) SomethingInPayloadLoading() bool {
+	return true
+}
+
 func (f fakeRiFlags) UnknownVersion() bool {
 	return f.unknownVersion
 }

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -33,6 +33,9 @@ type CvoGateChecker interface {
 	// CVOConfiguration controls whether the CVO reconciles the ClusterVersionOperator resource that corresponds
 	// to its configuration.
 	CVOConfiguration() bool
+
+	// SomethingInPayloadLoading is a hypothetical feature gate needed early in CVO execution
+	SomethingInPayloadLoading() bool
 }
 
 type panicOnUsageBeforeInitializationFunc func()
@@ -61,6 +64,11 @@ func (p panicOnUsageBeforeInitializationFunc) UnknownVersion() bool {
 }
 
 func (p panicOnUsageBeforeInitializationFunc) CVOConfiguration() bool {
+	p()
+	return false
+}
+
+func (p panicOnUsageBeforeInitializationFunc) SomethingInPayloadLoading() bool {
 	p()
 	return false
 }
@@ -94,6 +102,10 @@ func (c CvoGates) UnknownVersion() bool {
 
 func (c CvoGates) CVOConfiguration() bool {
 	return c.cvoConfiguration
+}
+
+func (c CvoGates) SomethingInPayloadLoading() bool {
+	return false
 }
 
 // DefaultCvoGates apply when actual features for given version are unknown


### PR DESCRIPTION
Illustrates the caveat of the current approach to determining which gates are enabled and disabled in the cluster. The current approach performs this initialization late in the execution (once the initial payyload is fully loaded) so there is an awkward period on CVO startup where enabled gates cannot be checked and the programmer cannot gate behavior.
