### PR TITLE
OTA-1531: [3/x] cvo: read version from release metadata on startup

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -308,17 +308,18 @@ func loadPayloadMetadata(releaseDir, releaseImage string) (*Update, error) {
 	if err != nil {
 		return nil, err
 	}
-	release.Image = releaseImage
-
-	imageRef, err := loadImageReferences(releaseDir)
-	if err != nil {
-		return nil, err
-	}
 
 	arch := string(release.Architecture)
 	if arch == "" {
 		arch = runtime.GOARCH
 		klog.V(2).Infof("Architecture from %s (%s) retrieved from runtime: %q", cincinnatiJSONFile, release.Version, arch)
+	}
+
+	release.Image = releaseImage
+
+	imageRef, err := loadImageReferences(releaseDir)
+	if err != nil {
+		return nil, err
 	}
 
 	if imageRef.Name != release.Version {

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -358,6 +358,17 @@ func loadPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) [
 	}}
 }
 
+// RootPath represents a path to the directory containing the payload
+type RootPath string
+
+const DefaultRootPath = RootPath(DefaultPayloadDir)
+
+// LoadReleaseMetadata loads the release metadata from the appropriate location inside the payload directory
+func (p RootPath) LoadReleaseMetadata() (configv1.Release, error) {
+	releaseDir := filepath.Join(string(p), ReleaseManifestDir)
+	return loadReleaseMetadata(releaseDir)
+}
+
 func loadReleaseMetadata(releaseDir string) (configv1.Release, error) {
 	var release configv1.Release
 	path := filepath.Join(releaseDir, cincinnatiJSONFile)

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -189,6 +189,31 @@ func (o *Options) Run(ctx context.Context) error {
 		return err
 	}
 
+	payloadRoot := payload.DefaultRootPath
+	if o.PayloadOverride != "" {
+		payloadRoot = payload.RootPath(o.PayloadOverride)
+	}
+
+	cvoOcpVersion := "0.0.1-snapshot"
+	// Peek at the local release metadata to determine the version of OCP this CVO belongs to. This assumes the CVO is
+	// executing in a container from the payload image. Full payload content is only read later once leader lease is
+	// acquired, and here we should only read as little data as possible to determine the version so we can establish
+	// enabled feature gate checker for all following code.
+	//
+	// We cannot refuse to start CVO if for some reason we cannot determine the OCP version on startup from the local
+	// release metadata. The only consequence is we fail to determine enabled/disabled feature gates and will have to use
+	// some defaults.
+	releaseMetadata, err := payloadRoot.LoadReleaseMetadata()
+	switch {
+	case err != nil:
+		klog.Warningf("Failed to read release metadata to determine OCP version for this CVO (will use placeholder version %q): %v", cvoOcpVersion, err)
+	case releaseMetadata.Version == "":
+		klog.Warningf("Version missing from release metadata, cannot determine OCP version for this CVO (will use placeholder version %q): %v", cvoOcpVersion, err)
+	default:
+		cvoOcpVersion = releaseMetadata.Version
+		klog.Infof("Determined OCP version for this CVO: %q", cvoOcpVersion)
+	}
+
 	// initialize the controllers and attempt to load the payload information
 	controllerCtx, err := o.NewControllerContext(cb)
 	if err != nil {


### PR DESCRIPTION
Builds on https://github.com/openshift/cluster-version-operator/pull/1185

CVO is typically executed in a Pod using the release payload image, which means its filesystem contains (among other content) the release metadata which the CVO can use to determine its OCP version, which is helpful to establish the feature gate enablement data to drive gated CVO behaviors.

It is useful to establish the feature gate enablement checker early in the CVO execution because it broadens the part of CVO code that can contain gated behavior (until the checker is established it is not possible to determine whether a gate is enabled or disabled)

Loading the full payload is still quite heavy operation and can only be done later in the execution (after the CVO acquires leader lease). The early metadata peek should read and utilize as few data as is necessary to establish the gate checker.
