### PR TITLE
OTA-1531: [4/x] cvo: extract config informer creation

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -208,7 +208,7 @@ func (o *Options) Run(ctx context.Context) error {
 	case err != nil:
 		klog.Warningf("Failed to read release metadata to determine OCP version for this CVO (will use placeholder version %q): %v", cvoOcpVersion, err)
 	case releaseMetadata.Version == "":
-		klog.Warningf("Version missing from release metadata, cannot determine OCP version for this CVO (will use placeholder version %q): %v", cvoOcpVersion, err)
+		klog.Warningf("Version missing from release metadata, cannot determine OCP version for this CVO (will use placeholder version %q)", cvoOcpVersion)
 	default:
 		cvoOcpVersion = releaseMetadata.Version
 		klog.Infof("Determined OCP version for this CVO: %q", cvoOcpVersion)

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -228,9 +228,10 @@ func (o *Options) Run(ctx context.Context) error {
 
 func (o *Options) prepareConfigInformerFactories(cb *ClientBuilder) (configinformers.SharedInformerFactory, configinformers.SharedInformerFactory) {
 	client := cb.ClientOrDie("shared-informer")
-	clusterVersionConfigInformerFactory := configinformers.NewFilteredSharedInformerFactory(client, resyncPeriod(o.ResyncInterval), "", func(opts *metav1.ListOptions) {
-		opts.FieldSelector = fmt.Sprintf("metadata.name=%s", o.Name)
-	})
+	filterByName := func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.Name).String()
+	}
+	clusterVersionConfigInformerFactory := configinformers.NewSharedInformerFactoryWithOptions(client, resyncPeriod(o.ResyncInterval), configinformers.WithTweakListOptions(filterByName))
 	configInformerFactory := configinformers.NewSharedInformerFactory(client, resyncPeriod(o.ResyncInterval))
 
 	return clusterVersionConfigInformerFactory, configInformerFactory

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -188,7 +188,9 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	if err := options.ValidateAndComplete(); err != nil {
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
-	controllers, err := options.NewControllerContext(cb)
+
+	cvif, cif := options.prepareConfigInformerFactories(cb)
+	controllers, err := options.NewControllerContext(cb, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +325,9 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	if err := options.ValidateAndComplete(); err != nil {
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
-	controllers, err := options.NewControllerContext(cb)
+
+	cvif, cif := options.prepareConfigInformerFactories(cb)
+	controllers, err := options.NewControllerContext(cb, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +524,9 @@ metadata:
 	if err := options.ValidateAndComplete(); err != nil {
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
-	controllers, err := options.NewControllerContext(cb)
+
+	cvif, cif := options.prepareConfigInformerFactories(cb)
+	controllers, err := options.NewControllerContext(cb, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The code to set up informers is messy so this change attempts to make it more consistent:

- Alias all informer-related imports to `somethinginformers`
- Everything made by `NewSharedInformerFactory` methods is now called `somethingInformerFactory`
- Name factories in `Context` consistently: `SomethingFactory`
- Document the purpose of individual factories in `Context`
- Reorder code into clusters that deal with individual factory types

---

[OTA-1531](https://issues.redhat.com//browse/OTA-1531) will need the config.openshift.io group lister early in the CVO execution and outside of the `Context` structure, so this commit moves the necessary preparation code outside of `NewControllerContext` and passes these factories into it as parameters. Constructing factories at separate places is a little awkward but for now I try keeping the change small instead of trying to invent some centralized informer factory management. I think it is reasonable to treat config.openshift.io informers separately if they are actually used separately.

---

`NewFilteredSharedInformerFactory` is deprecated and can be replaced by `NewSharedInformerFactoryWithOptions`, where the filter is expressed as `TweakListOption`. The direct `FieldSelector` equality can be replaced with the `OneTermEqualSelector` helper.

---

Address an earlier review comment: https://github.com/openshift/cluster-version-operator/pull/1188#discussion_r2084906818