### PR TITLE
OTA-1531: [5/x] cvo: read cluster `FeatureGate` early

### DIFF
--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -5,6 +5,12 @@ import (
 	"github.com/openshift/api/features"
 )
 
+// StubOpenShiftVersion is the default OpenShift version placeholder for the purpose of determining
+// enabled and disabled CVO feature gates. It is assumed to never conflict with a real OpenShift
+// version. Both DefaultCvoGates and CvoGatesFromFeatureGate should return a safe conservative
+// default set of enabled and disabled gates, typically with unknownVersion set to true.
+const StubOpenShiftVersion = "0.0.1-snapshot"
+
 // CvoGateChecker allows CVO code to check which feature gates are enabled
 type CvoGateChecker interface {
 	// UnknownVersion flag is set to true if CVO did not find a matching version in the FeatureGate

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -194,24 +194,24 @@ func (o *Options) Run(ctx context.Context) error {
 		payloadRoot = payload.RootPath(o.PayloadOverride)
 	}
 
-	cvoOcpVersion := "0.0.1-snapshot"
-	// Peek at the local release metadata to determine the version of OCP this CVO belongs to. This assumes the CVO is
+	cvoOpenShiftVersion := "0.0.1-snapshot"
+	// Peek at the local release metadata to determine the version of OpenShift this CVO belongs to. This assumes the CVO is
 	// executing in a container from the payload image. Full payload content is only read later once leader lease is
 	// acquired, and here we should only read as little data as possible to determine the version so we can establish
 	// enabled feature gate checker for all following code.
 	//
-	// We cannot refuse to start CVO if for some reason we cannot determine the OCP version on startup from the local
+	// We cannot refuse to start CVO if for some reason we cannot determine the OpenShift version on startup from the local
 	// release metadata. The only consequence is we fail to determine enabled/disabled feature gates and will have to use
 	// some defaults.
 	releaseMetadata, err := payloadRoot.LoadReleaseMetadata()
 	switch {
 	case err != nil:
-		klog.Warningf("Failed to read release metadata to determine OCP version for this CVO (will use placeholder version %q): %v", cvoOcpVersion, err)
+		klog.Warningf("Failed to read release metadata to determine OpenShift version for this CVO (will use placeholder version %q): %v", cvoOpenShiftVersion, err)
 	case releaseMetadata.Version == "":
-		klog.Warningf("Version missing from release metadata, cannot determine OCP version for this CVO (will use placeholder version %q)", cvoOcpVersion)
+		klog.Warningf("Version missing from release metadata, cannot determine OpenShift version for this CVO (will use placeholder version %q)", cvoOpenShiftVersion)
 	default:
-		cvoOcpVersion = releaseMetadata.Version
-		klog.Infof("Determined OCP version for this CVO: %q", cvoOcpVersion)
+		cvoOpenShiftVersion = releaseMetadata.Version
+		klog.Infof("Determined OpenShift version for this CVO: %q", cvoOpenShiftVersion)
 	}
 
 	clusterVersionConfigInformerFactory, configInformerFactory := o.prepareConfigInformerFactories(cb)


### PR DESCRIPTION
Extracting config.openshift.io informer factories allows to obtain the `FeatureGate` lister early. We need to start the the config informer factory for that but that is fine, later code can create new informers as long as it calls `Start()` again. Retrieved `FeatureGate` can then be used to read the featureSet enabled in the cluster and also the enabled and disabled CVO feature gates.

This is basically identical to what CVO currently does later in `Context.InitializeFromPayload`. For now _that_ code drives the actual CVO behavior, not the values discovered by the early code. The change to switch the CVO behavior from respecting the late code to the early code will follow; this commit just sets the stage for that and allows testing the early informer start.