### PR TITLE
OCPBUGS-56114: Fix ImplicitlyEnabledCapabilities

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -172,7 +172,7 @@ const DesiredReleaseAccepted configv1.ClusterStatusConditionType = "ReleaseAccep
 // requesting via spec.capabilities, because the cluster version operator does not support uninstalling
 // capabilities if any associated resources were previously managed by the CVO or disabling previously
 // enabled capabilities.
-const ImplicitlyEnabledCapabilities configv1.ClusterStatusConditionType = "ImplicitlyEnabled"
+const ImplicitlyEnabledCapabilities configv1.ClusterStatusConditionType = "ImplicitlyEnabledCapabilities"
 
 // syncStatus calculates the new status of the ClusterVersion based on the current sync state and any
 // validation errors found. We allow the caller to pass the original object to avoid DeepCopying twice.

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -488,6 +488,12 @@ func filterOutUpdateErrors(errs []error, updateEffect payload.UpdateEffectType) 
 func setImplicitlyEnabledCapabilitiesCondition(cvStatus *configv1.ClusterVersionStatus, implicitlyEnabled []configv1.ClusterVersionCapability,
 	now metav1.Time) {
 
+	// This is to clean up the condition with type=ImplicitlyEnabled introduced by OCPBUGS-56114
+	if c := resourcemerge.FindOperatorStatusCondition(cvStatus.Conditions, "ImplicitlyEnabled"); c != nil {
+		klog.V(2).Infof("Remove the condition with type ImplicitlyEnabled")
+		resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, "ImplicitlyEnabled")
+	}
+
 	if len(implicitlyEnabled) > 0 {
 		message := "The following capabilities could not be disabled: "
 		caps := make([]string, len(implicitlyEnabled))

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -115,7 +115,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 								{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "UpdatePayloadIntegrity", Message: "unable to apply object"},
 								{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Message: "Working towards 4.0.1"},
 								{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
-								{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
+								{Type: "ImplicitlyEnabledCapabilities", Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
 							},
 						},
 					},
@@ -156,7 +156,7 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 							{Type: ClusterStatusFailing, Status: configv1.ConditionTrue, Reason: "", Message: "bad"},
 							{Type: configv1.OperatorProgressing, Status: configv1.ConditionTrue, Reason: "", Message: "Error ensuring the cluster version is up to date: bad"},
 							{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
-							{Type: ImplicitlyEnabledCapabilities, Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
+							{Type: "ImplicitlyEnabledCapabilities", Status: "False", Reason: "AsExpected", Message: "Capabilities match configured spec"},
 						},
 					},
 				})


### PR DESCRIPTION
It is a mistake introduced by https://github.com/openshift/cluster-version-operator/pull/1157/files#diff-db97dc5ae62ef3b4c4dabfdc43cbc3ae0ceae9b58748cadebde679e32b5bec2bL175

As a result, it changes the type name in ClusterVersion which was definitely not the intension of https://github.com/openshift/cluster-version-operator/pull/1157. So we change the constant back with this pull.

The mistake is [found](https://issues.redhat.com/browse/OTA-1533?focusedId=27163593&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27163593) by @jiajliu while doing the pre-merge testing for https://github.com/openshift/cluster-version-operator/pull/1133.

It looks like I was not careful enough before confirming IDE (GoLand)'s smart editing. My apologies for that.

Additionally, a couple of cases in unit tests are modified in the pull to avoid regression like this from happening again.