### PR TITLE
Gate 4.19 -> 4.20 upgrade due to admissionregistration.k8s.io/v1beta1 API removal

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -8,3 +8,6 @@ metadata:
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20: |-
+    The admissionregistration.k8s.io/v1beta1 API group is deprecated in 4.19 and will be removed in 4.20. The admissionregistration.k8s.io/v1 API versions of these resources are available for use in 4.19, and it is recommended to migrate to them before upgrading to 4.20.

--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -10,4 +10,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
 data:
   ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20: |-
-    The admissionregistration.k8s.io/v1beta1 API group is deprecated in 4.19 and will be removed in 4.20. The admissionregistration.k8s.io/v1 API versions of these resources are available for use in 4.19, and it is recommended to migrate to them before upgrading to 4.20.
+    The admissionregistration.k8s.io/v1beta1 API version is deprecated in 4.19 and will be removed in 4.20. The admissionregistration.k8s.io/v1 API versions of these resources are available for use in 4.19, and it is recommended to migrate to them before upgrading to 4.20.


### PR DESCRIPTION
Add upgrade gate for the removal of admissionregistration.k8s.io/v1beta1 between 4.19 and 4.20.