### PR TITLE
Gate 4.18 -> 4.20 upgrade due to admissionregistration.k8s.io/v1beta1 API removal

### DIFF
--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -10,4 +10,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
 data:
   ack-4.18-kube-1.32-api-removals-in-4.19: |-
-      Kubernetes 1.32 and therefore OpenShift 4.19 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/7112216 for details and instructions.
+    Kubernetes 1.32 and therefore OpenShift 4.19 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/7112216 for details and instructions.
+  ack-4.18-admissionregistration-v1beta1-api-removals-in-4.20: |-
+    The admissionregistration.k8s.io/v1beta1 API version is deprecated in 4.18 and will be removed in 4.20. The admissionregistration.k8s.io/v1 API versions of these resources are available for use in 4.18, and it is recommended to migrate to them before upgrading to 4.20.

--- a/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
+++ b/install/0000_00_cluster-version-operator_01_admingate_configmap.yaml
@@ -12,4 +12,4 @@ data:
   ack-4.18-kube-1.32-api-removals-in-4.19: |-
     Kubernetes 1.32 and therefore OpenShift 4.19 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/7112216 for details and instructions.
   ack-4.18-admissionregistration-v1beta1-api-removals-in-4.20: |-
-    The admissionregistration.k8s.io/v1beta1 API version is deprecated in 4.18 and will be removed in 4.20. The admissionregistration.k8s.io/v1 API versions of these resources are available for use in 4.18, and it is recommended to migrate to them before upgrading to 4.20.
+    The admissionregistration.k8s.io/v1beta1 group version is deprecated in 4.18 and will be removed in 4.20. The admissionregistration.k8s.io/v1 group version is available for use in 4.18, and resources must be migrated to it before upgrading to 4.20.


### PR DESCRIPTION
Add upgrade gate for the removal of admissionregistration.k8s.io/v1beta1 between 4.18 and 4.20.