### PR TITLE
OTA-1531: [6/6] cvo: use early gate checker to avoid delayed initialization

### DIFF
--- a/pkg/featuregates/featurechangestopper_test.go
+++ b/pkg/featuregates/featurechangestopper_test.go
@@ -101,11 +101,10 @@ func TestTechPreviewChangeStopper(t *testing.T) {
 			client := fakeconfigv1client.NewSimpleClientset(fg)
 
 			informerFactory := configv1informer.NewSharedInformerFactory(client, 0)
-			c, err := NewChangeStopper(informerFactory.Config().V1().FeatureGates())
+			c, err := NewChangeStopper(informerFactory.Config().V1().FeatureGates(), tt.startingRequiredFeatureSet, tt.startingCvoFeatureGates)
 			if err != nil {
 				t.Fatal(err)
 			}
-			c.SetStartingFeatures(tt.startingRequiredFeatureSet, tt.startingCvoFeatureGates)
 			informerFactory.Start(ctx.Done())
 
 			if err := c.Run(ctx, shutdownFn); err != nil {

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -8,7 +8,11 @@ import (
 // StubOpenShiftVersion is the default OpenShift version placeholder for the purpose of determining
 // enabled and disabled CVO feature gates. It is assumed to never conflict with a real OpenShift
 // version. Both DefaultCvoGates and CvoGatesFromFeatureGate should return a safe conservative
-// default set of enabled and disabled gates, typically with unknownVersion set to true.
+// default set of enabled and disabled gates when StubOpenShiftVersion is passed as the version.
+// This value is an analogue to the "0.0.1-snapshot" string that is used as a placeholder in
+// second-level operator manifests. Here we use the same string for consistency, but the constant
+// should be only used by the callers of CvoGatesFromFeatureGate and DefaultCvoGates methods when
+// the caller does not know its actual OpenShift version.
 const StubOpenShiftVersion = "0.0.1-snapshot"
 
 // CvoGateChecker allows CVO code to check which feature gates are enabled

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -45,36 +45,6 @@ type CvoGateChecker interface {
 	CVOConfiguration() bool
 }
 
-type panicOnUsageBeforeInitializationFunc func()
-
-func panicOnUsageBeforeInitialization() {
-	panic("CVO feature flags were used before they were initialized")
-}
-
-// PanicOnUsageBeforeInitialization is a CvoGateChecker that panics if any of its methods are called. This checker should
-// be used before CVO feature gates are actually known and some code tries to check them.
-var PanicOnUsageBeforeInitialization = panicOnUsageBeforeInitializationFunc(panicOnUsageBeforeInitialization)
-
-func (p panicOnUsageBeforeInitializationFunc) ReconciliationIssuesCondition() bool {
-	p()
-	return false
-}
-
-func (p panicOnUsageBeforeInitializationFunc) StatusReleaseArchitecture() bool {
-	p()
-	return false
-}
-
-func (p panicOnUsageBeforeInitializationFunc) UnknownVersion() bool {
-	p()
-	return false
-}
-
-func (p panicOnUsageBeforeInitializationFunc) CVOConfiguration() bool {
-	p()
-	return false
-}
-
 // CvoGates contains flags that control CVO functionality gated by product feature gates. The
 // names do not correspond to product feature gates, the booleans here are "smaller" (product-level
 // gate will enable multiple CVO behaviors).

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -256,8 +256,8 @@ func (o *Options) processInitialFeatureGate(ctx context.Context, configInformerF
 	var clusterFeatureGate *configv1.FeatureGate
 
 	// client-go automatically retries some network blip errors on GETs for 30s by default, and we want to
-	// retry the remaining ones ourselves. If we fail longer than that, the operator won't be able to do work
-	// anyway. Return the error and crashloop.
+	// retry the remaining ones ourselves. If we fail longer than that, CVO won't be able to do work anyway.
+	// Return the error and crashloop.
 	//
 	// We implement the timeout with a context because the timeout in PollImmediateWithContext does not behave
 	// well when ConditionFunc takes longer time to execute, like here where the GET can be retried by client-go
@@ -672,8 +672,8 @@ func (c *Context) InitializeFromPayload(ctx context.Context, restConfig *rest.Co
 	var clusterFeatureGate *configv1.FeatureGate
 
 	// client-go automatically retries some network blip errors on GETs for 30s by default, and we want to
-	// retry the remaining ones ourselves. If we fail longer than that, the operator won't be able to do work
-	// anyway. Return the error and crashloop.
+	// retry the remaining ones ourselves. If we fail longer than that, CVO won't be able to do work anyway.
+	// Return the error and crashloop.
 	//
 	// We implement the timeout with a context because the timeout in PollImmediateWithContext does not behave
 	// well when ConditionFunc takes longer time to execute, like here where the GET can be retried by client-go

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -35,7 +35,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/config/clusterstatus"
@@ -190,13 +189,13 @@ func (o *Options) Run(ctx context.Context) error {
 	}
 
 	clusterVersionConfigInformerFactory, configInformerFactory := o.prepareConfigInformerFactories(cb)
-	_, _, err = o.processInitialFeatureGate(ctx, configInformerFactory)
+	startingFeatureSet, startingCvoGates, err := o.processInitialFeatureGate(ctx, configInformerFactory)
 	if err != nil {
 		return fmt.Errorf("error processing feature gates: %w", err)
 	}
 
 	// initialize the controllers and attempt to load the payload information
-	controllerCtx, err := o.NewControllerContext(cb, clusterVersionConfigInformerFactory, configInformerFactory)
+	controllerCtx, err := o.NewControllerContext(cb, startingFeatureSet, startingCvoGates, clusterVersionConfigInformerFactory, configInformerFactory)
 	if err != nil {
 		return err
 	}
@@ -244,7 +243,7 @@ func (o *Options) getOpenShiftVersion() string {
 	return releaseMetadata.Version
 }
 
-func (o *Options) processInitialFeatureGate(ctx context.Context, configInformerFactory configinformers.SharedInformerFactory) (configv1.FeatureSet, *featuregates.CvoGates, error) {
+func (o *Options) processInitialFeatureGate(ctx context.Context, configInformerFactory configinformers.SharedInformerFactory) (configv1.FeatureSet, featuregates.CvoGates, error) {
 	featureGates := configInformerFactory.Config().V1().FeatureGates().Lister()
 	configInformerFactory.Start(ctx.Done())
 	configInformerFactory.WaitForCacheSync(ctx.Done())
@@ -284,9 +283,9 @@ func (o *Options) processInitialFeatureGate(ctx context.Context, configInformerF
 		}
 	}); err != nil {
 		if lastError != nil {
-			return "", nil, lastError
+			return "", cvoGates, lastError
 		}
-		return "", nil, err
+		return "", cvoGates, err
 	}
 
 	if cvoGates.UnknownVersion() {
@@ -294,7 +293,7 @@ func (o *Options) processInitialFeatureGate(ctx context.Context, configInformerF
 	}
 	klog.Infof("CVO features for version %s enabled at startup: %+v", cvoOpenShiftVersion, cvoGates)
 
-	return startingFeatureSet, &cvoGates, nil
+	return startingFeatureSet, cvoGates, nil
 }
 
 // run launches a number of goroutines to handle manifest application,
@@ -362,7 +361,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 							resultChannel <- asyncResult{name: "metrics server", error: err}
 						}()
 					}
-					if err := controllerCtx.InitializeFromPayload(runContext, restConfig, burstRestConfig); err != nil {
+					if err := controllerCtx.CVO.InitializeFromPayload(runContext, restConfig, burstRestConfig); err != nil {
 						if firstError == nil {
 							firstError = err
 						}
@@ -577,13 +576,17 @@ type Context struct {
 	// OperatorInformerFactory should be used to get informers / listers for code that works with resources from the
 	// operator.openshift.io group
 	OperatorInformerFactory operatorinformers.SharedInformerFactory
-
-	fgLister configlistersv1.FeatureGateLister
 }
 
 // NewControllerContext initializes the default Context for the current Options. It does
 // not start any background processes.
-func (o *Options) NewControllerContext(cb *ClientBuilder, clusterVersionConfigInformerFactory, configInformerFactory configinformers.SharedInformerFactory) (*Context, error) {
+func (o *Options) NewControllerContext(
+	cb *ClientBuilder,
+	startingFeatureSet configv1.FeatureSet,
+	startingCvoGates featuregates.CvoGates,
+	clusterVersionConfigInformerFactory,
+	configInformerFactory configinformers.SharedInformerFactory,
+) (*Context, error) {
 	kubeClient := cb.KubeClientOrDie(internal.ConfigNamespace, useProtobuf)
 	openshiftConfigInformerFactory := coreinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod(o.ResyncInterval), coreinformers.WithNamespace(internal.ConfigNamespace))
 	openshiftConfigManagedInformerFactory := coreinformers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod(o.ResyncInterval), coreinformers.WithNamespace(internal.ConfigManagedNamespace))
@@ -621,12 +624,14 @@ func (o *Options) NewControllerContext(cb *ClientBuilder, clusterVersionConfigIn
 		o.InjectClusterIdIntoPromQL,
 		o.UpdateService,
 		stringsToCapabilities(o.AlwaysEnableCapabilities),
+		startingFeatureSet,
+		startingCvoGates,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	featureChangeStopper, err := featuregates.NewChangeStopper(configInformerFactory.Config().V1().FeatureGates())
+	featureChangeStopper, err := featuregates.NewChangeStopper(configInformerFactory.Config().V1().FeatureGates(), startingFeatureSet, startingCvoGates)
 	if err != nil {
 		return nil, err
 	}
@@ -639,8 +644,6 @@ func (o *Options) NewControllerContext(cb *ClientBuilder, clusterVersionConfigIn
 		OperatorInformerFactory:               operatorInformerFactory,
 		CVO:                                   cvo,
 		StopOnFeatureGateChange:               featureChangeStopper,
-
-		fgLister: configInformerFactory.Config().V1().FeatureGates().Lister(),
 	}
 
 	if o.EnableAutoUpdate {
@@ -661,70 +664,6 @@ func (o *Options) NewControllerContext(cb *ClientBuilder, clusterVersionConfigIn
 		}
 	}
 	return ctx, nil
-}
-
-// InitializeFromPayload initializes the CVO and FeatureGate ChangeStoppers controllers from the payload. It extracts the
-// current CVO version from the initial payload and uses it to determine the initial the required featureset and enabled
-// feature gates. Both the payload and determined feature information are used to initialize CVO and feature gate
-// ChangeStopper controllers.
-func (c *Context) InitializeFromPayload(ctx context.Context, restConfig *rest.Config, burstRestConfig *rest.Config) error {
-	var startingFeatureSet configv1.FeatureSet
-	var clusterFeatureGate *configv1.FeatureGate
-
-	// client-go automatically retries some network blip errors on GETs for 30s by default, and we want to
-	// retry the remaining ones ourselves. If we fail longer than that, CVO won't be able to do work anyway.
-	// Return the error and crashloop.
-	//
-	// We implement the timeout with a context because the timeout in PollImmediateWithContext does not behave
-	// well when ConditionFunc takes longer time to execute, like here where the GET can be retried by client-go
-	var lastError error
-	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 25*time.Second, true, func(ctx context.Context) (bool, error) {
-		gate, fgErr := c.fgLister.Get("cluster")
-		switch {
-		case apierrors.IsNotFound(fgErr):
-			// if we have no featuregates, then the cluster is using the default featureset, which is "".
-			// This excludes everything that could possibly depend on a different feature set.
-			startingFeatureSet = ""
-			klog.Infof("FeatureGate not found in cluster, using default feature set %q at startup", startingFeatureSet)
-			return true, nil
-		case fgErr != nil:
-			lastError = fgErr
-			klog.Warningf("Failed to get FeatureGate from cluster: %v", fgErr)
-			return false, nil
-		default:
-			clusterFeatureGate = gate
-			startingFeatureSet = gate.Spec.FeatureSet
-			klog.Infof("FeatureGate found in cluster, using its feature set %q at startup", startingFeatureSet)
-			return true, nil
-		}
-	}); err != nil {
-		if lastError != nil {
-			return lastError
-		}
-		return err
-	}
-
-	payload, err := c.CVO.LoadInitialPayload(ctx, startingFeatureSet, restConfig)
-	if err != nil {
-		return err
-	}
-
-	var cvoGates featuregates.CvoGates
-	if clusterFeatureGate != nil {
-		cvoGates = featuregates.CvoGatesFromFeatureGate(clusterFeatureGate, payload.Release.Version)
-	} else {
-		cvoGates = featuregates.DefaultCvoGates(payload.Release.Version)
-	}
-
-	if cvoGates.UnknownVersion() {
-		klog.Infof("CVO features for version %s could not be detected from FeatureGate; will use defaults plus special UnknownVersion feature gate", payload.Release.Version)
-	}
-	klog.Infof("CVO features for version %s enabled at startup: %+v", payload.Release.Version, cvoGates)
-
-	c.StopOnFeatureGateChange.SetStartingFeatures(startingFeatureSet, cvoGates)
-	c.CVO.InitializeFromPayload(payload, startingFeatureSet, cvoGates, restConfig, burstRestConfig)
-
-	return nil
 }
 
 func stringsToCapabilities(names []string) []configv1.ClusterVersionCapability {

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -190,7 +190,11 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	}
 
 	cvif, cif := options.prepareConfigInformerFactories(cb)
-	controllers, err := options.NewControllerContext(cb, cvif, cif)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +331,11 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	}
 
 	cvif, cif := options.prepareConfigInformerFactories(cb)
-	controllers, err := options.NewControllerContext(cb, cvif, cif)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -526,7 +534,11 @@ metadata:
 	}
 
 	cvif, cif := options.prepareConfigInformerFactories(cb)
-	controllers, err := options.NewControllerContext(cb, cvif, cif)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -189,12 +189,12 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
 
-	cvif, cif := options.prepareConfigInformerFactories(cb)
-	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	clusterVersionConfigInformerFactory, configInformerFactory := options.prepareConfigInformerFactories(cb)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
+	controllers, err := options.NewControllerContext(cb, featureset, gates, clusterVersionConfigInformerFactory, configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,12 +330,12 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
 
-	cvif, cif := options.prepareConfigInformerFactories(cb)
-	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	clusterVersionConfigInformerFactory, configInformerFactory := options.prepareConfigInformerFactories(cb)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
+	controllers, err := options.NewControllerContext(cb, featureset, gates, clusterVersionConfigInformerFactory, configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -533,12 +533,12 @@ metadata:
 		t.Fatalf("incorrectly initialized options: %v", err)
 	}
 
-	cvif, cif := options.prepareConfigInformerFactories(cb)
-	featureset, gates, err := options.processInitialFeatureGate(context.Background(), cvif)
+	clusterVersionConfigInformerFactory, configInformerFactory := options.prepareConfigInformerFactories(cb)
+	featureset, gates, err := options.processInitialFeatureGate(context.Background(), configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}
-	controllers, err := options.NewControllerContext(cb, featureset, gates, cvif, cif)
+	controllers, err := options.NewControllerContext(cb, featureset, gates, clusterVersionConfigInformerFactory, configInformerFactory)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previous changes prepared the code for this switch by adding code to detect enabled CVO gates and featureset early in the CVO execution, right before the controllers are initialized (well before CVO acquires its leader lease and actually starts the controllers). These early detected gate checker was not used anywhere yet.

This change makes CVO stop using its late detected gate checker (detected while loading its initial payload) and start using the early one instead. This eliminates the need for the panicking gate checker that was used to guard against checking gates before the actual checker could be established.

The change also allows to simplify some code layers. Late initialization on initial payload load is now only necessary for the actual CVO controller, not the featurechangestopper (it is already initialized at that time), so the `Context` layer does not need to coordinate anymore. The starting features set can be initialized in CVO right away, avoiding the need to wire it through call chains; it can simply be an `Operator` member.
