### PR TITLE
OTA-1521: Add a default-deny network policy for CVO namespace

### DIFF
--- a/install/0000_00_cluster-version-operator_02_networkpolicy.yaml
+++ b/install/0000_00_cluster-version-operator_02_networkpolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  # This NetworkPolicy is used to deny all ingress and egress traffic by default in this namespace,
+  # serving as a baseline. At the moment no other Network Policy should be needed:
+  # - CVO is a host-networked Pod, so it is not affected by network policies
+  # - Bare `version` Pods spawned by CVO do not require any network communication
+  name: default-deny
+  namespace: openshift-cluster-version
+spec:
+  # Match all pods in the namespace
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
Add a baseline NetworkPolicy to deny all network communication (both ingress and egress) to all pods in the namespace. Any necessary network traffic needs to be allowed by an additional NetworkPolicy resource (they are additive).

At the moment, the default deny all policy should be the only one needed:
- CVO is host-networked so it is [not affected by network policies](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/network-security#network-policy)
- Bare `version` pods spawned by CVO do not require any network communication

See [OTA Network Policies Working Document](https://docs.google.com/document/d/1Dzr3eYGVl6OBxqfUohugJLsbsn7sYrC3fN6yCe8zTRQ/edit?tab=t.0#heading=h.9vehq2liufe) for more information.