### PR TITLE
NO-JIRA: tests: fix `make integration-test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 .PHONY: test
 
 integration-test:
-	./hack/integration-test.sh
+	hack/test-integration.sh
 .PHONY: integration-test
 
 update: build


### PR DESCRIPTION
Fix the name of the script called, so that I can pass rehearsals in https://github.com/openshift/release/pull/65742 and then eventually remove the script in https://github.com/openshift/cluster-version-operator/pull/1202