### PR TITLE
WIP: pkg/payload/task: Include filename in Task.String

### DIFF
--- a/pkg/payload/task.go
+++ b/pkg/payload/task.go
@@ -108,7 +108,7 @@ func (st *Task) Copy() *Task {
 
 func (st *Task) String() string {
 	manId := getManifestResourceId(*st.Manifest)
-	return fmt.Sprintf("%s (%d of %d)", manId, st.Index, st.Total)
+	return fmt.Sprintf("%s (%d of %d, %s)", manId, st.Index, st.Total, st.OriginalFilename)
 }
 
 // Run attempts to create the provided object until it:


### PR DESCRIPTION
To make it easier to see where the CVO is in the task-node system, by exposing the runlevel and group portions of the filename in logs.