### PR TITLE
NO-ISSUE: Update golang version to 1.24 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-version-operator
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Since we want to use the unified test framework and reuse [compat_otp](https://github.com/openshift/origin/tree/main/test/extended/util/compat_otp) library and compat_otp uses go 1.24, so update golang version in go.mod.

I don't know why toolchain go1.23.6 automatically removed after running go mod vendor.