### PR TITLE
OTA-1627: pkg/cincinnati: Centralize release metadata parsing

### DIFF
--- a/pkg/cincinnati/cincinnati_test.go
+++ b/pkg/cincinnati/cincinnati_test.go
@@ -816,7 +816,7 @@ func Test_nodeUnmarshalJSON(t *testing.T) {
 		exp: node{
 			Version:  semver.MustParse("4.0.0-5"),
 			Image:    "quay.io/openshift-release-dev/ocp-release:4.0.0-5",
-			Metadata: map[string]string{},
+			Metadata: map[string]interface{}{},
 		},
 	}, {
 		raw: []byte(`{
@@ -829,7 +829,7 @@ func Test_nodeUnmarshalJSON(t *testing.T) {
 		exp: node{
 			Version: semver.MustParse("4.0.0-0.1"),
 			Image:   "quay.io/openshift-release-dev/ocp-release:4.0.0-0.1",
-			Metadata: map[string]string{
+			Metadata: map[string]interface{}{
 				"description": "This is the beta1 image based on the 4.0.0-0.nightly-2019-01-15-010905 build",
 			},
 		},

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -918,7 +918,24 @@ func mergeReleaseMetadata(release configv1.Release, getAvailableUpdates func() *
 					}
 				}
 			}
-			if update != nil {
+			if update == nil {
+				var versionMatch *configv1.Release
+				if availableUpdates.Current.Version == merged.Version {
+					versionMatch = &availableUpdates.Current
+				} else {
+					for i, u := range availableUpdates.Updates {
+						if u.Version == merged.Version {
+							versionMatch = &availableUpdates.Updates[i]
+							break
+						}
+					}
+				}
+				if versionMatch == nil {
+					klog.V(2).Infof("No available update found matching the digest of %q or the version %q", merged.Image, merged.Version)
+				} else {
+					klog.V(2).Infof("No available update found matching the digest of %q, although there was a match for version %q with a different tag or digest %q", merged.Image, merged.Version, versionMatch.Image)
+				}
+			} else {
 				if merged.Version == "" {
 					merged.Version = update.Version
 				}


### PR DESCRIPTION
Instead of carring similar code in the payload and Cincinnati packages, centralize in one place to make maintenance easier.  And with the logic centralized, I've also put some time into hardening the channel parsing, to grumble about some possible issues.

For payload loading, errors get a logged warning, but are not fatal. Having the CVO come up with logged warnings still allows cluster admins to update into a fix.  But a crash-looping CVO would not notice ClusterVersion `spec.desiredUpdate` changes or be able to roll out a requested update into a fix.

For Cincinnati processing, errors are fatal.  Cluster admins can take the ClusterVersion `RetrievedUpdates=False` message and complain to their Update Service maintainers, who can fix the metadata.