### PR TITLE
OTA-1585: test: Rename an existing test to comply with the OTE integration guide

### DIFF
--- a/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
+++ b/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "[cvo-testing] cluster-version-operator-tests should support passing tests",
+    "name": "[Jira:Cluster Version Operator] cluster-version-operator-tests should support passing tests",
     "labels": {},
     "resources": {
       "isolation": {}

--- a/test/cvo/cvo.go
+++ b/test/cvo/cvo.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[cvo-testing] cluster-version-operator-tests", func() {
+var _ = Describe("[Jira:Cluster Version Operator] cluster-version-operator-tests", func() {
 	It("should support passing tests", func() {
 		Expect(true).To(BeTrue())
 	})


### PR DESCRIPTION
Per the integration guide for OTE, each test must have a clearly defined owner (by using a `[Jira:Component]` tag) or an entry in the ci-test-mapping repository. Naming the owner as `"Cluster Version Operator"` with spaces, as this is the format used to distinguish our component in the mapping repository [[1]].

Renaming tests should not be done without a proper setup, as this can lose a test's history. However, this test was never executed, and it acts as a signal of the OTE integration.

[1]: https://github.com/openshift-eng/ci-test-mapping/blob/b2ca5844ead12ede1cb72cae34321f3215beb6e3/pkg/components/clusterversionoperator/component.go#L14
