### PR TITLE
OTA-1585: test: Include the compressed tests binary in the CVO container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,10 @@ WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
-    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator; \
-    cp _output/linux/$(go env GOARCH)/cluster-version-operator-tests.gz /tmp/build/cluster-version-operator-tests.gz
+    cp _output/linux/$(go env GOARCH)/cluster-version-operator _output/linux/$(go env GOARCH)/cluster-version-operator-tests.gz /tmp/build/
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
-COPY --from=builder /tmp/build/cluster-version-operator-tests.gz /usr/bin/
+COPY --from=builder /tmp/build/cluster-version-operator /tmp/build/cluster-version-operator-tests.gz /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_* /manifests/
 COPY vendor/github.com/openshift/api/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_* /manifests/

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -3,12 +3,10 @@ WORKDIR /go/src/github.com/openshift/cluster-version-operator
 COPY . .
 RUN hack/build-go.sh; \
     mkdir -p /tmp/build; \
-    cp _output/linux/$(go env GOARCH)/cluster-version-operator /tmp/build/cluster-version-operator; \
-    cp _output/linux/$(go env GOARCH)/cluster-version-operator-tests.gz /tmp/build/cluster-version-operator-tests.gz
+    cp _output/linux/$(go env GOARCH)/cluster-version-operator _output/linux/$(go env GOARCH)/cluster-version-operator-tests.gz /tmp/build/
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
-COPY --from=builder /tmp/build/cluster-version-operator /usr/bin/
-COPY --from=builder /tmp/build/cluster-version-operator-tests.gz /usr/bin/
+COPY --from=builder /tmp/build/cluster-version-operator /tmp/build/cluster-version-operator-tests.gz /usr/bin/
 COPY install /manifests
 COPY vendor/github.com/openshift/api/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_* /manifests/
 COPY vendor/github.com/openshift/api/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_* /manifests/


### PR DESCRIPTION
To make the binary discoverable to the outside world.

The following step is to register the binary in the origin repository to make the origin machine aware of the CVO tests extension.