### PR TITLE
OTA-1585: Add conformance test suites to the CVO tests extension

### DIFF
--- a/cmd/cluster-version-operator-tests/main.go
+++ b/cmd/cluster-version-operator-tests/main.go
@@ -28,6 +28,15 @@ func main() {
 		},
 	})
 
+	// Serial tests run in isolation, however they must return the cluster to its original state upon exiting.
+	ext.AddSuite(extension.Suite{
+		Name:    "openshift/cluster-version-operator/conformance/serial",
+		Parents: []string{"openshift/conformance/serial"},
+		Qualifiers: []string{
+			`name.contains("[Serial]")`,
+		},
+	})
+
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))


### PR DESCRIPTION
Add two popular conformance test suites to the CVO tests extension.

Imported tests based on the qualifiers will be selected by the respective test suite and will be invoked on the execution of the suite's parent suite after the integration is completed.

Follow up PRs will:
- Include the compressed test binary in the CVO's container image (https://github.com/openshift/cluster-version-operator/pull/1236)
- Register the CVO tests extension in the origin repository (https://github.com/openshift/origin/pull/30316)
- Ideally provide a rich documentation how to select the test suites, structure, etc. in the repository,

---

Running the `openshift/cluster-version-operator/conformance/parallel` suite does execute the sole test as expected:

```
$ ./_output/linux/amd64/cluster-version-operator-tests run-suite openshift/cluster-version-operator/conformance/parallel
  Running Suite:  - /home/dhurta/GolandProjects/cluster-version-operator
  ======================================================================
  Random Seed: 1761320947 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Jira:Cluster Version Operator] cluster-version-operator-tests should support passing tests
  /home/dhurta/GolandProjects/cluster-version-operator/test/cvo/cvo.go:9
  • [0.000 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 0.000 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[Jira:Cluster Version Operator] cluster-version-operator-tests should support passing tests",
    "lifecycle": "blocking",
    "duration": 0,
    "startTime": "2025-10-24 15:49:07.914082 UTC",
    "endTime": "2025-10-24 15:49:07.914615 UTC",
    "result": "passed",
    "output": ""
  }
]
```

Running the ` openshift/cluster-version-operator/conformance/serial` suite does not execute anything as expected (there are no such tests at the moment):

```
$ ./_output/linux/amd64/cluster-version-operator-tests run-suite openshift/cluster-version-operator/conformance/serial
null
```