### PR TITLE
OCPBUGS-62858: pkg/cvo/metrics: Add a new --serving-client-certificate-authorities-file option

### DIFF
--- a/cmd/cluster-version-operator/start.go
+++ b/cmd/cluster-version-operator/start.go
@@ -34,14 +34,20 @@ func init() {
 	cmd.PersistentFlags().StringVar(&opts.NodeName, "node-name", opts.NodeName, "kubernetes node name CVO is scheduled on.")
 	cmd.PersistentFlags().BoolVar(&opts.EnableAutoUpdate, "enable-auto-update", opts.EnableAutoUpdate, "Enables the autoupdate controller.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The Openshift release image url.")
+
+	// metrics serving options
 	cmd.PersistentFlags().StringVar(&opts.ServingCertFile, "serving-cert-file", opts.ServingCertFile, "The X.509 certificate file for serving metrics over HTTPS.  You must set both --serving-cert-file and --serving-key-file unless you set --listen empty.")
 	cmd.PersistentFlags().StringVar(&opts.ServingKeyFile, "serving-key-file", opts.ServingKeyFile, "The X.509 key file for serving metrics over HTTPS.  You must set both --serving-cert-file and --serving-key-file unless you set --listen empty.")
+	cmd.PersistentFlags().StringVar(&opts.ServingClientCAFile, "serving-client-certificate-authorities-file", opts.ServingClientCAFile, "The X.509 certificates file containing a series of PEM encoded certificates for Certificate Authorities trusted to sign metrics client certificates.  If set, only clients who provide mTLS client certs signed by those CAs will be trusted.  If unset, only clients with valid tokens for the prometheus-k8s ServiceAccount in the openshift-monitoring namespace will be trusted.")
+
+	// metrics/PromQL client options
 	cmd.PersistentFlags().StringVar(&opts.PromQLTarget.CABundleFile, "metrics-ca-bundle-file", opts.PromQLTarget.CABundleFile, "The service CA bundle file containing one or more X.509 certificate files for validating certificates generated from the service CA for the respective remote PromQL query service.")
 	cmd.PersistentFlags().StringVar(&opts.PromQLTarget.BearerTokenFile, "metrics-token-file", opts.PromQLTarget.BearerTokenFile, "The bearer token file used to access the remote PromQL query service.")
 	cmd.PersistentFlags().StringVar(&opts.PromQLTarget.KubeSvc.Namespace, "metrics-namespace", opts.PromQLTarget.KubeSvc.Namespace, "The name of the namespace where the the remote PromQL query service resides. Must be specified when --use-dns-for-services is disabled.")
 	cmd.PersistentFlags().StringVar(&opts.PromQLTarget.KubeSvc.Name, "metrics-service", opts.PromQLTarget.KubeSvc.Name, "The name of the remote PromQL query service. Must be specified when --use-dns-for-services is disabled.")
 	cmd.PersistentFlags().BoolVar(&opts.PromQLTarget.UseDNS, "use-dns-for-services", opts.PromQLTarget.UseDNS, "Configures the CVO to use DNS for resolution of services in the cluster.")
 	cmd.PersistentFlags().StringVar(&opts.PrometheusURLString, "metrics-url", opts.PrometheusURLString, "The URL used to access the remote PromQL query service.")
+
 	cmd.PersistentFlags().BoolVar(&opts.HyperShift, "hypershift", opts.HyperShift, "This options indicates whether the CVO is running inside a hosted control plane.")
 	cmd.PersistentFlags().StringVar(&opts.UpdateService, "update-service", opts.UpdateService, "The preferred update service.  If set, this option overrides any upstream value configured in ClusterVersion spec.")
 	cmd.PersistentFlags().StringSliceVar(&opts.AlwaysEnableCapabilities, "always-enable-capabilities", opts.AlwaysEnableCapabilities, "List of the cluster capabilities which will always be implicitly enabled.")

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -57,9 +57,10 @@ const (
 
 // Options are the valid inputs to starting the CVO.
 type Options struct {
-	ReleaseImage    string
-	ServingCertFile string
-	ServingKeyFile  string
+	ReleaseImage        string
+	ServingCertFile     string
+	ServingKeyFile      string
+	ServingClientCAFile string
 
 	Kubeconfig string
 	NodeName   string
@@ -143,6 +144,9 @@ func (o *Options) ValidateAndComplete() error {
 	}
 	if o.ListenAddr != "" && o.ServingKeyFile == "" {
 		return fmt.Errorf("--listen was not set empty, so --serving-key-file must be set")
+	}
+	if o.ListenAddr == "" && o.ServingClientCAFile != "" {
+		return fmt.Errorf("--listen was set empty, so --serving-client-certificate-authorities-file must not be set")
 	}
 	if o.PrometheusURLString == "" {
 		return fmt.Errorf("missing --metrics-url flag, it is required")
@@ -350,7 +354,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 						resultChannelCount++
 						go func() {
 							defer utilruntime.HandleCrash()
-							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig)
+							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, o.ServingClientCAFile, restConfig)
 							resultChannel <- asyncResult{name: "metrics server", error: err}
 						}()
 					}


### PR DESCRIPTION
In #1215, the `/metrics` endpoint began requiring client auth.  The only authentication system was Bearer tokens, and the only authorization system was validating that the token belonged to
system:serviceaccount:openshift-monitoring:prometheus-k8s.

That worked well for standalone clusters, where the ServiceMonitor scraper is the Prometheus from the `openshift-monitoring` namespace. But it [broke scraping on HyperShift][1], where [the ServiceMonitor does not request any client authorization][2].  Getting ServiceAccount tokens (and [keeping them fresh][3]) from the hosted cluster into a Prometheus scraper running on the management cluster is hard.  But for other ServiceMonitors, [HyperShift configures `keySecret`][4] asking the scraper to get its client certificate from a `metrics-client` Secret that [the HostedControlPlane controller maintains][5] in the management cluster namespace.

This commit adds a new `--serving-client-certificate-authorities-file` option, which HyperShift can set when [it configures the CVO Deployment][6], while mounting the root CA ConfigMap into the Pod.

Now that there are three files (serving key, serving cert, client CAs) that we might be watching for changes, I've taken the opportunity to refactor the checksumming and change-tracking to use a map from filename to checksum.  That way we can extend more easily if further configuration files are added in the future, without having to pass around a series of paths and checksums as distinct arguments.

I'm a bit sad about [`AppendCertsFromPEM` only returning a boolean][7], leaving us unsure about whether all the certificates in the file were parsed, or, if there were parsing issues, what those issues were.  But with HyperShift hopefully reliably setting up CA Secrets that do not cause parsing issues, I'm ok not coding that defensively.  If the standard library grows a parser that is more transparent about parsing issues, we can pivot to that once it exists.

[1]: https://issues.redhat.com/browse/OCPBUGS-62858
[2]: https://github.com/openshift/hypershift/blob/2728a4e2899ee58690e3d4e58b319eb5e78643af/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-version-operator/servicemonitor.yaml#L18
[3]: https://kubernetes.io/docs/concepts/configuration/secret/#serviceaccount-token-secrets
[4]: https://github.com/openshift/hypershift/blob/2728a4e2899ee58690e3d4e58b319eb5e78643af/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/servicemonitor.yaml#L24-L26
[5]: https://github.com/openshift/hypershift/blob/2728a4e2899ee58690e3d4e58b319eb5e78643af/control-plane-operator/controllers/hostedcontrolplane/pki/sa.go#L35-L36
[6]: https://github.com/openshift/hypershift/blob/2728a4e2899ee58690e3d4e58b319eb5e78643af/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-version-operator/deployment.yaml#L25-L35
[7]: https://pkg.go.dev/crypto/x509#CertPool.AppendCertsFromPEM