### PR TITLE
OCPBUGS-62861: pkg/cvo/metrics: Do not require auth when --hypershift is set

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -350,7 +350,7 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 						resultChannelCount++
 						go func() {
 							defer utilruntime.HandleCrash()
-							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig)
+							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, o.HyperShift, restConfig)
 							resultChannel <- asyncResult{name: "metrics server", error: err}
 						}()
 					}


### PR DESCRIPTION
This is addressing the same HyperShift-scraping issue as #1240.  While 1240 is trying to find a long-term path, it requires HyperShift-repo changes to wire up, and those haven't been written yet.  This pull request buys time by by wiring the existing `--hypershift` option to code that disables the authentication requirement in that environment.  Standalone clusters will continue to require `prometheus-k8s` ServiceAccount tokens.