### PR TITLE
OCPBUGS-62869: disable metrics auth for hypershift clusters

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -245,7 +245,8 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 						resultChannelCount++
 						go func() {
 							defer utilruntime.HandleCrash()
-							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig)
+							disableMetricsAuth := o.InjectClusterIdIntoPromQL // this is wired to the "--hypershift" flag, so when hypershfit is no, we disableMetricsAuth
+							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig, disableMetricsAuth)
 							resultChannel <- asyncResult{name: "metrics server", error: err}
 						}()
 					}


### PR DESCRIPTION
CVO does not honor client certificates per the OCP metrics standard and HCP does not configure the secret.  The combination of these two things means that on HCP, if we enable the CVO's auth handler, we lose the ability to determine if clusteroperators are functioning correctly at scale.


/assign @wking 