### PR TITLE
OCPBUGS-62867: temporarily disable metrics auth for hypershift clusters

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -132,7 +132,16 @@ type asyncResult struct {
 	error error
 }
 
-func createHttpServer(ctx context.Context, client *authenticationclientsetv1.AuthenticationV1Client) *http.Server {
+func createHttpServer(ctx context.Context, client *authenticationclientsetv1.AuthenticationV1Client, disableAuth bool) *http.Server {
+	if disableAuth {
+		handler := http.NewServeMux()
+		handler.Handle("/metrics", promhttp.Handler())
+		server := &http.Server{
+			Handler: handler,
+		}
+		return server
+	}
+
 	auth := authHandler{downstream: promhttp.Handler(), ctx: ctx, client: client.TokenReviews()}
 	handler := http.NewServeMux()
 	handler.Handle("/metrics", &auth)
@@ -246,7 +255,7 @@ func handleServerResult(result asyncResult, lastLoopError error) error {
 // Also detects changes to metrics certificate files upon which
 // the metrics HTTP server is shutdown and recreated with a new
 // TLS configuration.
-func RunMetrics(runContext context.Context, shutdownContext context.Context, listenAddress, certFile, keyFile string, restConfig *rest.Config) error {
+func RunMetrics(runContext context.Context, shutdownContext context.Context, listenAddress, certFile, keyFile string, restConfig *rest.Config, disableMetricsAuth bool) error {
 	var tlsConfig *tls.Config
 	if listenAddress != "" {
 		var err error
@@ -263,7 +272,7 @@ func RunMetrics(runContext context.Context, shutdownContext context.Context, lis
 		return fmt.Errorf("failed to create config: %w", err)
 	}
 
-	server := createHttpServer(runContext, client)
+	server := createHttpServer(runContext, client, disableMetricsAuth)
 
 	resultChannel := make(chan asyncResult, 1)
 	resultChannelCount := 1
@@ -317,7 +326,7 @@ func RunMetrics(runContext context.Context, shutdownContext context.Context, lis
 			case result := <-resultChannel: // crashed before a shutdown was requested or metrics server recreated
 				if restartServer {
 					klog.Info("Creating metrics server with updated TLS configuration.")
-					server = createHttpServer(runContext, client)
+					server = createHttpServer(runContext, client, disableMetricsAuth)
 					go startListening(server, tlsConfig, listenAddress, resultChannel)
 					restartServer = false
 					continue

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -357,7 +357,8 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 						resultChannelCount++
 						go func() {
 							defer utilruntime.HandleCrash()
-							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig)
+							disableMetricsAuth := o.InjectClusterIdIntoPromQL // this is wired to the "--hypershift" flag, so when hypershfit is no, we disableMetricsAuth
+							err := cvo.RunMetrics(postMainContext, shutdownContext, o.ListenAddr, o.ServingCertFile, o.ServingKeyFile, restConfig, disableMetricsAuth)
 							resultChannel <- asyncResult{name: "metrics server", error: err}
 						}()
 					}


### PR DESCRIPTION
CVO does not honor client certificates per the OCP metrics standard and HCP does not configure the secret.  The combination of these two things means that on HCP, if we enable the CVO's auth handler, we lose the ability to determine if clusteroperators are functioning correctly at scale.

Clean pick from #1242 onto 4.20.