### PR TITLE
OCPBUGS-64732: lib/resourcemerge: Add support for hostUsers flag

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -47,6 +47,7 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 
 	setStringIfSet(modified, &existing.ServiceAccountName, required.ServiceAccountName)
 	setBool(modified, &existing.HostNetwork, required.HostNetwork)
+	setBoolPtr(modified, &existing.HostUsers, required.HostUsers)
 	mergeMap(modified, &existing.NodeSelector, required.NodeSelector)
 	ensurePodSecurityContextPtr(modified, &existing.SecurityContext, required.SecurityContext)
 	ensureAffinityPtr(modified, &existing.Affinity, required.Affinity)

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -46,6 +46,17 @@ func TestEnsurePodSpec(t *testing.T) {
 					{Name: "test"}}},
 		},
 		{
+			name:     "hostUsers flag is set",
+			existing: corev1.PodSpec{},
+			input: corev1.PodSpec{
+				HostUsers: boolPtr(false),
+			},
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				HostUsers: boolPtr(false),
+			},
+		},
+		{
 			name: "PodSecurityContext empty",
 			existing: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),


### PR DESCRIPTION
When a pod spec is being ensured, `hostUsers` flag is not taken into account.
This is now fixed and `hostUsers` is copied into the resulting pod spec.