### PR TITLE
OCPBUGS-60568: lib/resourcemerge: Add support for automountServiceAccountToken

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -45,6 +45,7 @@ func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.Pod
 		}
 	}
 
+	setBoolPtr(modified, &existing.AutomountServiceAccountToken, required.AutomountServiceAccountToken)
 	setStringIfSet(modified, &existing.ServiceAccountName, required.ServiceAccountName)
 	setBool(modified, &existing.HostNetwork, required.HostNetwork)
 	setBoolPtr(modified, &existing.HostUsers, required.HostUsers)

--- a/lib/resourcemerge/core_test.go
+++ b/lib/resourcemerge/core_test.go
@@ -57,6 +57,56 @@ func TestEnsurePodSpec(t *testing.T) {
 			},
 		},
 		{
+			name:     "automountServiceAccountToken is set",
+			existing: corev1.PodSpec{},
+			input: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+		},
+		{
+			name: "automountServiceAccountToken is unset",
+			existing: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+			input: corev1.PodSpec{},
+
+			expectedModified: true,
+			expected:         corev1.PodSpec{},
+		},
+		{
+			name: "automountServiceAccountToken is changed",
+			existing: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(true),
+			},
+			input: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+
+			expectedModified: true,
+			expected: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+		},
+		{
+			name: "automountServiceAccountToken is unchanged",
+			existing: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+			input: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+
+			expectedModified: false,
+			expected: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+		},
+		{
 			name: "PodSecurityContext empty",
 			existing: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: boolPtr(false),


### PR DESCRIPTION
Take `automountServiceAccountToken` flag into account when reconciling a pod spec.

Taking over https://github.com/openshift/cluster-version-operator/pull/1225

This is needed for e.g. https://github.com/openshift/cluster-kube-controller-manager-operator/pull/858