### PR TITLE
NO-JIRA: Remove $(BIN_DIR) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-BIN_DIR?=./bin
-
 all: build
 .PHONY: all
 
@@ -49,5 +47,4 @@ verify-update: update
 
 clean:
 	rm -rf _output/
-	rm -rf bin
 .PHONY: clean


### PR DESCRIPTION
It is not used anywhere in the current Makefile.

It came from https://github.com/openshift/cluster-version-operator/commit/89771bd6e2aeaa8ff0580d39d0a7eb705ae3bf0d and should have been removed with https://github.com/openshift/cluster-version-operator/pull/792/commits/697787e05a0c614ff0a563070e09435db0fc5b39