### PR TITLE
NO-JIRA: hack/build-image.sh: Update Dockerfile reference

### DIFF
--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -22,4 +22,4 @@ if [ -z ${VERSION_OVERRIDE+a} ]; then
 fi
 
 set -x
-podman build -t "cluster-version-operator:${VERSION_OVERRIDE}" -f Dockerfile --no-cache
+podman build -t "cluster-version-operator:${VERSION_OVERRIDE}" -f Dockerfile.rhel --no-cache


### PR DESCRIPTION
The file named `Dockerfile` was removed in the [[1]] commit as the file was unused. Update the outdated reference to point at the sole existing Dockerfile file in the repository.

[1]: https://github.com/openshift/cluster-version-operator/commit/2f996d4c9993192be4c0d9fff3da0450b193f404