### PR TITLE
OTA-1786: pkg/payload/precondition/clusterversion/gianthop: Allow updates to 5.0

### DIFF
--- a/pkg/payload/precondition/clusterversion/gianthop.go
+++ b/pkg/payload/precondition/clusterversion/gianthop.go
@@ -66,6 +66,16 @@ func (p *GiantHop) Run(ctx context.Context, releaseContext precondition.ReleaseC
 	}
 
 	if targetVersion.Major > currentVersion.Major {
+		if targetVersion.Major == 5 && currentVersion.Major == 4 { // TODO: temporary access from v4 to 5.0, to be reverted once we are in v5 development
+			if targetVersion.Minor == 0 {
+				return nil
+			}
+			return &precondition.Error{
+				Reason:  "MajorVersionUpdate",
+				Message: fmt.Sprintf("%s has a larger major version than the current target %s (%d > %d), and only updates within the current major version or to 5.0 are supported.", targetVersion, currentVersion, targetVersion.Major, currentVersion.Major),
+				Name:    p.Name(),
+			}
+		}
 		return &precondition.Error{
 			Reason:  "MajorVersionUpdate",
 			Message: fmt.Sprintf("%s has a larger major version than the current target %s (%d > %d), and only updates within the current major version are supported.", targetVersion, currentVersion, targetVersion.Major, currentVersion.Major),

--- a/pkg/payload/precondition/clusterversion/gianthop_test.go
+++ b/pkg/payload/precondition/clusterversion/gianthop_test.go
@@ -65,6 +65,38 @@ func TestGiantHopRun(t *testing.T) {
 			expected: "2.0.0 has a larger major version than the current target 1.0.0 (2 > 1), and only updates within the current major version are supported.",
 		},
 		{
+			name: "major version is 5.0",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "5.0.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "4.0.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "major version is 5.1",
+			clusterVersion: configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "5.1.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{
+						Version: "4.0.0",
+					},
+				},
+			},
+			expected: "5.1.0 has a larger major version than the current target 4.0.0 (5 > 4), and only updates within the current major version or to 5.0 are supported.",
+		},
+		{
 			name: "two minor versions",
 			clusterVersion: configv1.ClusterVersion{
 				Spec: configv1.ClusterVersionSpec{


### PR DESCRIPTION
Not sure yet if OCP 5.0 will be a thing, but to help folks feeling out that space [just in case][1], relax the current giant-hop guard in 4.22 to allow updates to 5.0.  I'm special-casing 5.0 (e.g. no allowing 4 -> 6 or 4 -> 5.1) to make the smallest possible change at this early-testing stage.

[1]: https://access.redhat.com/articles/7134648