### PR TITLE
OTA-1604: migrate ocp-46922 from otp to cvo repo

### DIFF
--- a/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
+++ b/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
@@ -18,5 +18,15 @@
     "source": "openshift:payload:cluster-version-operator",
     "lifecycle": "blocking",
     "environmentSelector": {}
+  },
+  {
+    "name": "[Jira:\"Cluster Version Operator\"] cluster-version-operator should have correct runlevel and scc",
+    "labels": {},
+    "resources": {
+      "isolation": {}
+    },
+    "source": "openshift:payload:cluster-version-operator",
+    "lifecycle": "blocking",
+    "environmentSelector": {}
   }
 ]

--- a/test/cvo/cvo.go
+++ b/test/cvo/cvo.go
@@ -1,6 +1,12 @@
 package cvo
 
 import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,6 +15,8 @@ import (
 )
 
 var logger = GinkgoLogr.WithName("cluster-version-operator-tests")
+
+const cvoNamespace = "openshift-cluster-version"
 
 var _ = Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator-tests`, func() {
 	It("should support passing tests", func() {
@@ -23,5 +31,51 @@ var _ = Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator-tes
 		output, err := ocClient.Version(ocapi.VersionOptions{Client: true})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("Client Version:"))
+	})
+})
+
+// CVO tests which need access the live cluster will be placed here
+var _ = Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator`, func() {
+	var (
+		restCfg    *rest.Config
+		kubeClient kubernetes.Interface
+	)
+
+	BeforeEach(func() {
+		var err error
+		// Respects KUBECONFIG env var
+		restCfg, err = GetRestConfig()
+		Expect(err).NotTo(HaveOccurred(), "Failed to load Kubernetes configuration. Please ensure KUBECONFIG environment variable is set.")
+
+		kubeClient, err = GetKubeClient(restCfg)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kubernetes client")
+	})
+
+	// Migrated from case NonHyperShiftHOST-Author:jiajliu-Low-46922-check runlevel and scc in cvo ns
+	// Refer to https://github.com/openshift/openshift-tests-private/blob/40374cf20946ff03c88712839a5626af2c88ab31/test/extended/ota/cvo/cvo.go#L1081
+	It("should have correct runlevel and scc", func() {
+		ctx := context.Background()
+		err := SkipIfHypershift(ctx, restCfg)
+		Expect(err).NotTo(HaveOccurred(), "Failed to determine if cluster is HyperShift")
+
+		By("Checking that the 'openshift.io/run-level' label exists on the namespace and has the empty value")
+		ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, cvoNamespace, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to get namespace %s", cvoNamespace)
+
+		runLevel, exists := ns.ObjectMeta.Labels["openshift.io/run-level"]
+		Expect(exists).To(BeTrue(), "The 'openshift.io/run-level' label on namespace %s does not exist", cvoNamespace)
+		Expect(runLevel).To(BeEmpty(), "Expected the 'openshift.io/run-level' label value on namespace %s has the empty value, but got %s", cvoNamespace, runLevel)
+
+		By("Checking that the annotation 'openshift.io/scc annotation' on the CVO pod has the value hostaccess")
+		podList, err := kubeClient.CoreV1().Pods(cvoNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=cluster-version-operator",
+			FieldSelector: "status.phase=Running",
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to list running CVO pods")
+		Expect(podList.Items).To(HaveLen(1), "Expected exactly one running CVO pod, but found: %d", len(podList.Items))
+
+		cvoPod := podList.Items[0]
+		sccAnnotation := cvoPod.ObjectMeta.Annotations["openshift.io/scc"]
+		Expect(sccAnnotation).To(Equal("hostaccess"), "Expected the annotation 'openshift.io/scc annotation' on pod %s to have the value 'hostaccess', but got %s", cvoPod.Name, sccAnnotation)
 	})
 })

--- a/test/cvo/util.go
+++ b/test/cvo/util.go
@@ -1,0 +1,56 @@
+package cvo
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	configv1 "github.com/openshift/api/config/v1"
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// IsHypershift checks if running on a HyperShift hosted cluster
+// Refer to https://github.com/openshift/origin/blob/31704414237b8bd5c66ad247c105c94abc9470b1/test/extended/util/framework.go#L2301
+func IsHypershift(ctx context.Context, restConfig *rest.Config) (bool, error) {
+	configClient, err := GetConfigClient(restConfig)
+	if err != nil {
+		return false, err
+	}
+
+	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return infrastructure.Status.ControlPlaneTopology == configv1.ExternalTopologyMode, nil
+}
+
+// SkipIfHypershift skips the test if running on a HyperShift hosted cluster
+func SkipIfHypershift(ctx context.Context, restConfig *rest.Config) error {
+	isHypershift, err := IsHypershift(ctx, restConfig)
+	if err != nil {
+		return err
+	}
+	if isHypershift {
+		Skip("Skipping test: running on HyperShift hosted cluster!")
+	}
+	return nil
+}
+
+// GetRestConfig loads the Kubernetes REST configuration from KUBECONFIG environment variable.
+func GetRestConfig() (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// GetKubeClient creates a Kubernetes client from the given REST config.
+func GetKubeClient(restConfig *rest.Config) (kubernetes.Interface, error) {
+	return kubernetes.NewForConfig(restConfig)
+}
+
+// GetConfigClient creates an OpenShift config client from the given REST config.
+func GetConfigClient(restConfig *rest.Config) (clientconfigv1.Interface, error) {
+	return clientconfigv1.NewForConfig(restConfig)
+}


### PR DESCRIPTION
This PR refactors test case OCP-46922 with client-go and migrated it from the openshift-tests-private repository to the CVO repository as an openshift-tests-extension test.