### PR TITLE
OCPBUGS-73929: lib/resourcemerge/core: Reconcile ConfigMap binaryData too

### DIFF
--- a/lib/resourcemerge/core.go
+++ b/lib/resourcemerge/core.go
@@ -15,6 +15,7 @@ import (
 func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1.ConfigMap) {
 	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
 
+	mergeByteSliceMap(modified, &existing.BinaryData, required.BinaryData)
 	mergeMap(modified, &existing.Data, required.Data)
 }
 

--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -40,6 +40,21 @@ func mergeMap(modified *bool, existing *map[string]string, required map[string]s
 	}
 }
 
+func mergeByteSliceMap(modified *bool, existing *map[string][]byte, required map[string][]byte) {
+	if *existing == nil {
+		if required == nil {
+			return
+		}
+		*existing = map[string][]byte{}
+	}
+	for k, v := range required {
+		if existingV, ok := (*existing)[k]; !ok || string(v) != string(existingV) {
+			*modified = true
+			(*existing)[k] = v
+		}
+	}
+}
+
 func mergeOwnerRefs(modified *bool, existing *[]metav1.OwnerReference, required []metav1.OwnerReference) {
 	for ridx := range required {
 		found := false


### PR DESCRIPTION
Since 4.20, some Cluster-API ConfigMap manifests have wanted to set this:

```console
$ oc adm release extract --to manifests quay.io/openshift-release-dev/ocp-release:4.20.10-x86_64
$ grep -r binaryData manifests
manifests/0000_30_cluster-api_04_cm.infrastructure-aws.yaml:binaryData:
```

so we need to compare the in-cluster ConfigMap with this property as well, when deciding if the resource needs updating.