### PR TITLE
NO-JIRA: Fix some lint issues

### DIFF
--- a/lib/resourcebuilder/interface.go
+++ b/lib/resourcebuilder/interface.go
@@ -83,7 +83,7 @@ type Interface interface {
 func New(mapper *ResourceMapper, rest *rest.Config, m manifest.Manifest) (Interface, error) {
 	f, ok := mapper.gvkToNew[m.GVK]
 	if !ok {
-		return nil, fmt.Errorf("No mapping found for gvk: %v", m.GVK)
+		return nil, fmt.Errorf("no mapping found for gvk: %v", m.GVK)
 	}
 	return f(rest, m), nil
 }

--- a/lib/resourcedelete/admissionregistration.go
+++ b/lib/resourcedelete/admissionregistration.go
@@ -30,12 +30,12 @@ func DeleteValidatingWebhookConfigurationv1(ctx context.Context,
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ValidatingWebhookConfigurations().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/apiext.go
+++ b/lib/resourcedelete/apiext.go
@@ -28,12 +28,12 @@ func DeleteCustomResourceDefinitionv1(ctx context.Context, client apiextclientv1
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.CustomResourceDefinitions().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/apps.go
+++ b/lib/resourcedelete/apps.go
@@ -28,12 +28,12 @@ func DeleteDeploymentv1(ctx context.Context, client appsclientv1.DeploymentsGett
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.Deployments(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -57,12 +57,12 @@ func DeleteDaemonSetv1(ctx context.Context, client appsclientv1.DaemonSetsGetter
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.DaemonSets(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/batch.go
+++ b/lib/resourcedelete/batch.go
@@ -26,11 +26,11 @@ func DeleteJobv1(ctx context.Context, client batchclientv1.JobsGetter, required 
 	}
 	deleteRequested, err := GetDeleteProgress(resource, err)
 	if err != nil {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	if !deleteRequested && updateMode {
 		if err := client.Jobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-			return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+			return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 		}
 		SetDeleteRequested(existing, resource)
 	}
@@ -54,11 +54,11 @@ func DeleteCronJobv1(ctx context.Context, client batchclientv1.CronJobsGetter, r
 	}
 	deleteRequested, err := GetDeleteProgress(resource, err)
 	if err != nil {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	if !deleteRequested && updateMode {
 		if err := client.CronJobs(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-			return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+			return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 		}
 		SetDeleteRequested(existing, resource)
 	}

--- a/lib/resourcedelete/core.go
+++ b/lib/resourcedelete/core.go
@@ -28,12 +28,12 @@ func DeleteNamespacev1(ctx context.Context, client coreclientv1.NamespacesGetter
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.Namespaces().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -57,12 +57,12 @@ func DeleteServicev1(ctx context.Context, client coreclientv1.ServicesGetter, re
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.Services(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -86,12 +86,12 @@ func DeleteServiceAccountv1(ctx context.Context, client coreclientv1.ServiceAcco
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ServiceAccounts(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -115,12 +115,12 @@ func DeleteConfigMapv1(ctx context.Context, client coreclientv1.ConfigMapsGetter
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ConfigMaps(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/helper.go
+++ b/lib/resourcedelete/helper.go
@@ -37,7 +37,7 @@ func ValidDeleteAnnotation(annotations map[string]string) (bool, error) {
 	if value, ok := annotations[DeleteAnnotation]; !ok {
 		return false, nil
 	} else if value != "true" {
-		return true, fmt.Errorf("Invalid delete annotation \"%s\" value: \"%s\"", DeleteAnnotation, value)
+		return true, fmt.Errorf("invalid delete annotation \"%s\" value: \"%s\"", DeleteAnnotation, value)
 	}
 	return true, nil
 }
@@ -126,7 +126,7 @@ func GetDeleteProgress(resource Resource, getError error) (bool, error) {
 		return true, nil
 	}
 	if getError != nil {
-		return false, fmt.Errorf("Cannot get %s to delete, err=%v.", resource, getError)
+		return false, fmt.Errorf("cannot get %s to delete, err=%v", resource, getError)
 	}
 	return false, nil
 }

--- a/lib/resourcedelete/imagestream.go
+++ b/lib/resourcedelete/imagestream.go
@@ -28,12 +28,12 @@ func DeleteImageStreamv1(ctx context.Context, client imageclientv1.ImageStreamsG
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ImageStreams(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/operators.go
+++ b/lib/resourcedelete/operators.go
@@ -28,12 +28,12 @@ func DeleteOperatorGroupv1(ctx context.Context, client operatorsclientv1.Operato
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.OperatorGroups(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/rbac.go
+++ b/lib/resourcedelete/rbac.go
@@ -28,12 +28,12 @@ func DeleteClusterRoleBindingv1(ctx context.Context, client rbacclientv1.Cluster
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ClusterRoleBindings().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -57,12 +57,12 @@ func DeleteClusterRolev1(ctx context.Context, client rbacclientv1.ClusterRolesGe
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.ClusterRoles().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -86,12 +86,12 @@ func DeleteRoleBindingv1(ctx context.Context, client rbacclientv1.RoleBindingsGe
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.RoleBindings(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }
@@ -115,12 +115,12 @@ func DeleteRolev1(ctx context.Context, client rbacclientv1.RolesGetter, required
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.Roles(required.Namespace).Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcedelete/security.go
+++ b/lib/resourcedelete/security.go
@@ -28,12 +28,12 @@ func DeleteSecurityContextConstraintsv1(ctx context.Context, client securityclie
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.SecurityContextConstraints().Delete(ctx, required.Name, metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/lib/resourcemerge/admissionregistration.go
+++ b/lib/resourcemerge/admissionregistration.go
@@ -59,7 +59,7 @@ func ensureRuleWithOperationsDefaults(required *admissionregv1.RuleWithOperation
 // field of each webhook is not managed by the CVO when the service-ca controller is
 // responsible for the fields.
 func ensureValidatingWebhookConfigurationCaBundle(required *admissionregv1.ValidatingWebhookConfiguration, existing admissionregv1.ValidatingWebhookConfiguration) {
-	if val, ok := existing.ObjectMeta.Annotations[injectCABundleAnnotation]; !ok || val != "true" {
+	if val, ok := existing.Annotations[injectCABundleAnnotation]; !ok || val != "true" {
 		return
 	}
 	if len(existing.Webhooks) == 0 {

--- a/lib/resourcemerge/apiext.go
+++ b/lib/resourcemerge/apiext.go
@@ -33,7 +33,7 @@ func ensureCustomResourceDefinitionV1Defaults(required *apiextv1.CustomResourceD
 // spec.Conversion.Webhook.ClientConfig.CABundle of a CRD is not managed by the CVO when
 // the service-ca controller is responsible for the field.
 func ensureCustomResourceDefinitionV1CaBundle(required *apiextv1.CustomResourceDefinition, existing apiextv1.CustomResourceDefinition) {
-	if val, ok := existing.ObjectMeta.Annotations[injectCABundleAnnotation]; !ok || val != "true" {
+	if val, ok := existing.Annotations[injectCABundleAnnotation]; !ok || val != "true" {
 		return
 	}
 	req := required.Spec.Conversion

--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -184,7 +184,11 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, desiredArch, curre
 	if err != nil {
 		return current, nil, nil, &Error{Reason: "RemoteFailed", Message: err.Error(), cause: err}
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			klog.Errorf("Failed to close response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return current, nil, nil, &Error{Reason: "ResponseFailed", Message: fmt.Sprintf("unexpected HTTP status: %s", resp.Status)}

--- a/pkg/clusterconditions/cache/cache.go
+++ b/pkg/clusterconditions/cache/cache.go
@@ -179,7 +179,7 @@ func (c *Cache) calculateMostStale(now time.Time) (string, *configv1.ClusterCond
 		}
 		if thiefResult == nil ||
 			value.When.Before(thiefResult.When) || // refresh the most stale
-			(value.When == thiefResult.When && value.Access.Before(thiefResult.Access)) { // break ties in favor of the longest-queued
+			(value.When.Equal(thiefResult.When) && value.Access.Before(thiefResult.Access)) { // break ties in favor of the longest-queued
 			thiefKey = candidateKey
 			thiefResult = c.MatchResults[candidateKey]
 		}

--- a/pkg/clusterconditions/clusterconditions.go
+++ b/pkg/clusterconditions/clusterconditions.go
@@ -74,7 +74,7 @@ func (r *conditionRegistry) PruneInvalid(ctx context.Context, matchingRules []co
 	for _, config := range matchingRules {
 		condition, ok := r.registry[config.Type]
 		if !ok {
-			errs = append(errs, fmt.Errorf("Skipping unrecognized cluster condition type %q", config.Type))
+			errs = append(errs, fmt.Errorf("skipping unrecognized cluster condition type %q", config.Type))
 			continue
 		}
 		if err := condition.Valid(ctx, &config); err != nil {

--- a/pkg/customsignaturestore/customsignaturestore.go
+++ b/pkg/customsignaturestore/customsignaturestore.go
@@ -45,7 +45,7 @@ func (s *Store) Signatures(ctx context.Context, name string, digest string, fn s
 	}
 
 	if len(uris) == 0 {
-		return errors.New("ClusterVersion spec.signatureStores is an empty array.  Unset signatureStores entirely if you want to to enable the default signature stores.")
+		return errors.New("ClusterVersion spec.signatureStores is an empty array. Unset signatureStores entirely if you want to enable the default signature stores")
 	}
 
 	allDone := false
@@ -70,7 +70,7 @@ func (s *Store) Signatures(ctx context.Context, name string, digest string, fn s
 	if err := store.Signatures(ctx, name, digest, wrapper); err != nil || allDone {
 		return err
 	}
-	return errors.New("ClusterVersion spec.signatureStores exhausted without finding a valid signature.")
+	return errors.New("ClusterVersion spec.signatureStores exhausted without finding a valid signature")
 }
 
 func (s *Store) refreshConfiguration(ctx context.Context) ([]*url.URL, error) {

--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -492,10 +492,10 @@ const (
 var reasonPattern = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`)
 
 func newRecommendedReason(now, want string) string {
-	switch {
-	case now == recommendedReasonRisksNotExposed:
+	switch now {
+	case recommendedReasonRisksNotExposed:
 		return want
-	case now == want:
+	case want:
 		return now
 	default:
 		return recommendedReasonMultiple

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -117,7 +117,7 @@ func newMockOSUSServer(data conditionalEdgeTestData) (*httptest.Server, *url.Val
 	var params url.Values
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params = r.URL.Query()
-		fmt.Fprintf(w, `{
+		_, _ = fmt.Fprintf(w, `{
   "nodes": [{"version": "%s", "payload": "%s"}, {"version": "%s", "payload": "%s"}],
   "conditionalEdges": [
     {

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -617,7 +617,7 @@ func (optr *Operator) clusterOperatorEventHandler() cache.ResourceEventHandler {
 			oldVersion := clusterOperatorVersion(oldStruct, versionName)
 			newVersion := clusterOperatorVersion(newStruct, versionName)
 			if oldVersion != newVersion {
-				msg := fmt.Sprintf("Cluster operator %s changed versions[name=%q] from %q to %q", newStruct.ObjectMeta.Name, versionName, oldVersion, newVersion)
+				msg := fmt.Sprintf("Cluster operator %s changed versions[name=%q] from %q to %q", newStruct.Name, versionName, oldVersion, newVersion)
 				optr.configSync.NotifyAboutManagedResourceActivity(msg)
 				return
 			}
@@ -629,7 +629,7 @@ func (optr *Operator) clusterOperatorEventHandler() cache.ResourceEventHandler {
 				oldStatus := clusterOperatorConditionStatus(oldStruct, cond)
 				newStatus := clusterOperatorConditionStatus(newStruct, cond)
 				if oldStatus != newStatus {
-					msg := fmt.Sprintf("Cluster operator %s changed %s from %q to %q", newStruct.ObjectMeta.Name, cond, oldStatus, newStatus)
+					msg := fmt.Sprintf("Cluster operator %s changed %s from %q to %q", newStruct.Name, cond, oldStatus, newStatus)
 					optr.configSync.NotifyAboutManagedResourceActivity(msg)
 					return
 				}

--- a/pkg/cvo/cvo_scenarios_test.go
+++ b/pkg/cvo/cvo_scenarios_test.go
@@ -4009,13 +4009,13 @@ func waitForCompleted(status SyncWorkerStatus) bool {
 	return status.Completed == 1
 }
 
-func waitForStatus(t *testing.T, maxLoopCount int, timeOutSeconds time.Duration, ch <-chan SyncWorkerStatus, f func(s SyncWorkerStatus) bool) {
+func waitForStatus(t *testing.T, maxLoopCount int, d time.Duration, ch <-chan SyncWorkerStatus, f func(s SyncWorkerStatus) bool) {
 	count := 0
 	for {
 		var status SyncWorkerStatus
 		select {
 		case status = <-ch:
-		case <-time.After(timeOutSeconds * time.Second):
+		case <-time.After(d * time.Second):
 			t.Fatalf("never saw expected apply event")
 		}
 		if f(status) {
@@ -4033,13 +4033,13 @@ func verifyAllStatus(t *testing.T, ch <-chan SyncWorkerStatus, items ...SyncWork
 	verifyAllStatusOptionalDone(t, "", false, ch, items...)
 }
 
-func clearAllStatusWithWait(t *testing.T, name string, timeOutSeconds time.Duration, ch <-chan SyncWorkerStatus) {
+func clearAllStatusWithWait(t *testing.T, name string, d time.Duration, ch <-chan SyncWorkerStatus) {
 	testName := t.Name() + ":" + name
 	t.Helper()
 	t.Logf("%s: Clearing all status...", testName)
 	select {
 	case <-ch:
-	case <-time.After(timeOutSeconds * time.Second):
+	case <-time.After(d * time.Second):
 		break
 	}
 }
@@ -4194,10 +4194,7 @@ func waitForStatusCompleted(t *testing.T, worker *SyncWorker) {
 
 func clearAllStatus(t *testing.T, ch <-chan SyncWorkerStatus) {
 	count := 0
-	for {
-		if len(ch) <= 0 {
-			break
-		}
+	for len(ch) > 0 {
 		<-ch
 		t.Log("Waiting for SyncWorkerStatus to clear")
 		count++

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	kfake "k8s.io/client-go/kubernetes/fake"
-	clienttesting "k8s.io/client-go/testing"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -2503,7 +2502,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		{
 			name: "set available updates and clear error state when success and empty",
 			handler: func(w http.ResponseWriter, req *http.Request) {
-				fmt.Fprintf(w, `
+				_, _ = fmt.Fprintf(w, `
 				{
 					"nodes": [
 						{
@@ -2571,7 +2570,7 @@ func TestOperator_availableUpdatesSync(t *testing.T) {
 		{
 			name: "calculate available update edges",
 			handler: func(w http.ResponseWriter, req *http.Request) {
-				fmt.Fprintf(w, `
+				_, _ = fmt.Fprintf(w, `
 				{
 					"nodes": [
 						{"version":"4.0.1",            "payload": "image/image:v4.0.1"},
@@ -3779,7 +3778,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 	f := kfake.NewSimpleClientset()
 
 	// A catch-all watch reactor that allows us to inject the watcherStarted channel.
-	f.PrependWatchReactor("*", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+	f.PrependWatchReactor("*", func(action ktesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := f.Tracker().Watch(gvr, ns)
@@ -4007,7 +4006,7 @@ func Test_gateApplicableToCurrentVersion(t *testing.T) {
 
 func expectGet(t *testing.T, a ktesting.Action, resource, namespace, name string) {
 	t.Helper()
-	if "get" != a.GetVerb() {
+	if a.GetVerb() != "get" {
 		t.Fatalf("unexpected verb: %s", a.GetVerb())
 	}
 	switch at := a.(type) {

--- a/pkg/cvo/internal/generic.go
+++ b/pkg/cvo/internal/generic.go
@@ -33,7 +33,7 @@ func deleteUnstructured(ctx context.Context, client dynamic.ResourceInterface, r
 	updateMode bool) (bool, error) {
 
 	if required.GetName() == "" {
-		return false, fmt.Errorf("Error running delete, invalid object: name cannot be empty")
+		return false, fmt.Errorf("error running delete, invalid object: name cannot be empty")
 	}
 	if delAnnoFound, err := resourcedelete.ValidDeleteAnnotation(required.GetAnnotations()); !delAnnoFound || err != nil {
 		return delAnnoFound, err
@@ -48,12 +48,12 @@ func deleteUnstructured(ctx context.Context, client dynamic.ResourceInterface, r
 		// Only request deletion when in update mode.
 		if !deleteRequested && updateMode {
 			if err := client.Delete(ctx, required.GetName(), metav1.DeleteOptions{}); err != nil {
-				return true, fmt.Errorf("Delete request for %s failed, err=%v", resource, err)
+				return true, fmt.Errorf("delete request for %s failed, err=%v", resource, err)
 			}
 			resourcedelete.SetDeleteRequested(existing, resource)
 		}
 	} else {
-		return true, fmt.Errorf("Error running delete for %s, err=%v", resource, err)
+		return true, fmt.Errorf("error running delete for %s, err=%v", resource, err)
 	}
 	return true, nil
 }

--- a/pkg/cvo/internal/operatorstatus.go
+++ b/pkg/cvo/internal/operatorstatus.go
@@ -105,8 +105,9 @@ func (b *clusterOperatorBuilder) Do(ctx context.Context) error {
 		b.modifier(co)
 	}
 
-	// create the object, and if we successfully created, update the status
-	if b.mode == resourcebuilder.PrecreatingMode {
+	switch b.mode {
+	case resourcebuilder.PrecreatingMode:
+		// create the object, and if we successfully created, update the status
 		clusterOperator, err := b.createClient.Create(ctx, co, metav1.CreateOptions{})
 		if err != nil {
 			if kerrors.IsAlreadyExists(err) {
@@ -122,7 +123,7 @@ func (b *clusterOperatorBuilder) Do(ctx context.Context) error {
 			return err
 		}
 		return nil
-	} else if b.mode == resourcebuilder.ReconcilingMode {
+	case resourcebuilder.ReconcilingMode:
 		existing, err := b.client.Get(ctx, co.Name)
 		if err != nil {
 			return err
@@ -142,6 +143,7 @@ func (b *clusterOperatorBuilder) Do(ctx context.Context) error {
 				return err
 			}
 		}
+	default:
 	}
 
 	err := checkOperatorHealth(ctx, b.client, co, b.mode)

--- a/pkg/cvo/sync_test.go
+++ b/pkg/cvo/sync_test.go
@@ -440,7 +440,7 @@ func (t *testBuilder) WithModifier(m resourcebuilder.MetaV1ObjectModifierFunc) r
 }
 
 func (t *testBuilder) Do(_ context.Context) error {
-	a := t.recorder.Invoke(t.m.GVK, t.m.Obj.GetNamespace(), t.m.Obj.GetName())
+	a := t.Invoke(t.m.GVK, t.m.Obj.GetNamespace(), t.m.Obj.GetName())
 	return t.reactors[a]
 }
 

--- a/pkg/cvo/sync_worker.go
+++ b/pkg/cvo/sync_worker.go
@@ -764,7 +764,7 @@ func (w *statusWrapper) Report(status SyncWorkerStatus) {
 // Update).
 func (w *SyncWork) calculateNextFrom(desired *SyncWork) bool {
 	sameVersion, sameOverrides, sameCapabilities := equalSyncWork(w, desired, "calculating next work")
-	changed := !(sameVersion && sameOverrides && sameCapabilities)
+	changed := !sameVersion || !sameOverrides || !sameCapabilities
 
 	// if this is the first time through the loop, initialize reconciling to
 	// the state Update() calculated (to allow us to start in reconciling)

--- a/pkg/cvo/upgradeable.go
+++ b/pkg/cvo/upgradeable.go
@@ -311,7 +311,7 @@ func (check *clusterManifestDeleteInProgressUpgradeable) Check() *configv1.Clust
 func gateApplicableToCurrentVersion(gateName string, currentVersion string) (bool, error) {
 	var applicable bool
 	if ackVersion := adminAckGateRegexp.FindString(gateName); ackVersion == "" {
-		return false, fmt.Errorf("%s configmap gate name %s has invalid format; must comply with %q.",
+		return false, fmt.Errorf("%s configmap gate name %s has invalid format; must comply with %q",
 			internal.AdminGatesConfigMap, gateName, adminAckGateFmt)
 	} else {
 		parts := strings.Split(ackVersion, "-")
@@ -531,7 +531,7 @@ func (optr *Operator) adminGatesEventHandler() cache.ResourceEventHandler {
 // The cv parameter is expected to be non-nil.
 func (intervals *upgradeableCheckIntervals) throttlePeriod(cv *configv1.ClusterVersion) time.Duration {
 	if cond := resourcemerge.FindOperatorStatusCondition(cv.Status.Conditions, internal.ReleaseAccepted); cond != nil {
-		deadline := cond.LastTransitionTime.Time.Add(intervals.afterPreconditionsFailed)
+		deadline := cond.LastTransitionTime.Add(intervals.afterPreconditionsFailed)
 		if cond.Reason == "PreconditionChecks" && cond.Status == configv1.ConditionFalse && time.Now().Before(deadline) {
 			return intervals.minOnFailedPreconditions
 		}

--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -292,7 +292,7 @@ func loadPayloadMetadata(releaseDir, releaseImage string) (*Update, error) {
 	}
 
 	if imageRef.Name != release.Version {
-		return nil, fmt.Errorf("Version from %s (%s) differs from %s (%s)", imageReferencesFile, imageRef.Name, cincinnatiJSONFile, release.Version)
+		return nil, fmt.Errorf("version from %s (%s) differs from %s (%s)", imageReferencesFile, imageRef.Name, cincinnatiJSONFile, release.Version)
 	}
 
 	return &Update{
@@ -361,7 +361,7 @@ func loadReleaseMetadata(releaseDir string) (configv1.Release, error) {
 	}
 
 	if _, err := semver.Parse(metadata.Version); err != nil {
-		return release, fmt.Errorf("Cincinnati metadata version %q is not a valid semantic version: %v", metadata.Version, err)
+		return release, fmt.Errorf("invalid Cincinnati metadata version %q: %w", metadata.Version, err)
 	}
 
 	release, err = cincinnati.ParseMetadata(metadata.Metadata)

--- a/pkg/payload/precondition/clusterversion/gianthop_test.go
+++ b/pkg/payload/precondition/clusterversion/gianthop_test.go
@@ -116,7 +116,7 @@ func TestGiantHopRun(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.clusterVersion.ObjectMeta.Name = "version"
+			tc.clusterVersion.Name = "version"
 			cvLister := fakeClusterVersionLister(t, &tc.clusterVersion)
 			instance := NewGiantHop(cvLister)
 

--- a/pkg/payload/precondition/clusterversion/rollback_test.go
+++ b/pkg/payload/precondition/clusterversion/rollback_test.go
@@ -187,7 +187,7 @@ func TestRollbackRun(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.clusterVersion.ObjectMeta.Name = "version"
+			tc.clusterVersion.Name = "version"
 			cvLister := fakeClusterVersionLister(t, &tc.clusterVersion)
 			instance := NewRollback(cvLister)
 

--- a/pkg/payload/task_graph.go
+++ b/pkg/payload/task_graph.go
@@ -379,7 +379,7 @@ func (g *TaskGraph) Tree() string {
 	for i, node := range g.Nodes {
 		label := make([]string, 0, len(node.Tasks))
 		for _, task := range node.Tasks {
-			label = append(label, strings.Replace(task.String(), "\"", "", -1))
+			label = append(label, strings.ReplaceAll(task.String(), "\"", ""))
 		}
 		if len(label) == 0 {
 			label = append(label, "no manifests")

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -455,7 +455,7 @@ func createResourceLock(cb *ClientBuilder, namespace, name string) (resourcelock
 
 	uuid, err := uuid.NewRandom()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to generate UUID: %v", err)
+		return nil, fmt.Errorf("failed to generate UUID: %v", err)
 	}
 
 	// add a uniquifier so that two processes on the same host don't accidentally both become active

--- a/pkg/start/start_integration_test.go
+++ b/pkg/start/start_integration_test.go
@@ -169,7 +169,11 @@ func TestIntegrationCVO_initializeAndUpgrade(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("failed to delete the directory %s: %v", dir, err)
+		}
+	}()
 	if err := createContent(filepath.Join(dir, "0.0.1"), version_0_0_1, map[string]string{"NAMESPACE": ns}); err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +314,11 @@ func TestIntegrationCVO_gracefulStepDown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("failed to delete the directory %s: %v", dir, err)
+		}
+	}()
 	if err := createContent(filepath.Join(dir, "0.0.1"), version_0_0_1, map[string]string{"NAMESPACE": ns}); err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +496,11 @@ func TestIntegrationCVO_cincinnatiRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("failed to delete the directory %s: %v", dir, err)
+		}
+	}()
 	if err := createContent(filepath.Join(dir, "0.0.1"), version_0_0_1, map[string]string{"NAMESPACE": ns}); err != nil {
 		t.Fatal(err)
 	}

--- a/test/cvo/cvo.go
+++ b/test/cvo/cvo.go
@@ -1,8 +1,8 @@
 package cvo
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"    //nolint:staticcheck
 
 	"github.com/openshift/cluster-version-operator/test/oc"
 	ocapi "github.com/openshift/cluster-version-operator/test/oc/api"


### PR DESCRIPTION
```console
$ go version
go version go1.25.5 darwin/arm64
$ golangci-lint --version
golangci-lint has version 2.8.0 built with go1.25.5 from e2e4002 on 2026-01-07T21:23:22Z
```

We are not there yet (`go1.25.5` and `golangci-lint 2.8.0`) but they are our future.
The log from [this job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/73631/rehearse-73631-pull-ci-openshift-cluster-version-operator-main-lint/2013526558966288384) shows the issues.


Most changes are quite obvious. I try to keep the change minimal while making linter happy.
The only exception is the [dot-import](https://staticcheck.dev/docs/configuration/options/#dot_import_whitelist) on `github.com/onsi/ginkgo/v2` and `github.com/onsi/gomega`. 

Now i am adding comments to ignore it.
When we migrate to `golangci-lint v2`, I will add a configuration for this.

```console
$ cat .golangci.yaml
version: "2"
linters:
  settings:
    staticcheck:
      dot-import-whitelist:
        - github.com/onsi/ginkgo/v2
        - github.com/onsi/gomega
```

Currently, I cannot do the configuration because it is not compatible with `v1`.