### PR TITLE
NO-JIRA: Fix linter issues on dot-imports

### DIFF
--- a/test/cvo/cvo.go
+++ b/test/cvo/cvo.go
@@ -1,27 +1,27 @@
 package cvo
 
 import (
-	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
-	. "github.com/onsi/gomega"    //nolint:staticcheck
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
 
 	"github.com/openshift/cluster-version-operator/test/oc"
 	ocapi "github.com/openshift/cluster-version-operator/test/oc/api"
 )
 
-var logger = GinkgoLogr.WithName("cluster-version-operator-tests")
+var logger = g.GinkgoLogr.WithName("cluster-version-operator-tests")
 
-var _ = Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator-tests`, func() {
-	It("should support passing tests", func() {
-		Expect(true).To(BeTrue())
+var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator-tests`, func() {
+	g.It("should support passing tests", func() {
+		o.Expect(true).To(o.BeTrue())
 	})
 
-	It("can use oc to get the version information", func() {
+	g.It("can use oc to get the version information", func() {
 		ocClient, err := oc.NewOC(logger)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ocClient).NotTo(BeNil())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ocClient).NotTo(o.BeNil())
 
 		output, err := ocClient.Version(ocapi.VersionOptions{Client: true})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(output).To(ContainSubstring("Client Version:"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring("Client Version:"))
 	})
 })


### PR DESCRIPTION
I thought [1] to use a configuration file for `golangci-lint` to replace the inline `//nolint` markers after we migrate to `golangci-lint v2`.

But I found other components [2,3] respect the rule. I think I shoul too.

[1]. https://github.com/openshift/cluster-version-operator/pull/1299#issue-3828474077

[2]. https://github.com/openshift/origin/blob/4ccfd5ee03231d525ad405d5dba4c378f1aa8fa3/test/extended/machines/scale.go#L10-L11

[3]. https://github.com/openshift/oc/blob/dde15b85490a2c0bb5fce0c1142ff5e0a0cdbe75/test/e2e/e2e.go#L4-L5