### PR TITLE
NO-JIRA: More flexible timeout option for oc-cli

### DIFF
--- a/test/cvo/cvo.go
+++ b/test/cvo/cvo.go
@@ -25,7 +25,7 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator-t
 	})
 
 	g.It("can use oc to get the version information", func() {
-		ocClient, err := oc.NewOC(logger)
+		ocClient, err := oc.NewOC(ocapi.Options{Logger: logger})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(ocClient).NotTo(o.BeNil())
 

--- a/test/oc/api/api.go
+++ b/test/oc/api/api.go
@@ -1,11 +1,22 @@
 package api
 
+import (
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
 type ReleaseExtractOptions struct {
 	To string
 }
 
 type VersionOptions struct {
 	Client bool
+}
+
+type Options struct {
+	Logger  logr.Logger
+	Timeout time.Duration
 }
 
 type OC interface {

--- a/test/oc/cli/cli.go
+++ b/test/oc/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -62,26 +61,21 @@ func newOCExecutor(oc string, timeout time.Duration, logger logr.Logger) (execut
 }
 
 // NewOCCli return a client for oc-cli.
-func NewOCCli(logger logr.Logger) (api.OC, error) {
+func NewOCCli(o api.Options) (api.OC, error) {
 	oc, err := exec.LookPath("oc")
 	if err != nil {
 		return nil, err
 	}
-	timeout := 30 * time.Second
-	timeoutStr := os.Getenv("OC_CLI_TIMEOUT")
-	if timeoutStr != "" {
-		timeout, err = time.ParseDuration(timeoutStr)
-		if err != nil {
-			return nil, err
-		}
+	if o.Timeout == 0 {
+		o.Timeout = 30 * time.Second
 	}
 
-	executor, err := newOCExecutor(oc, timeout, logger)
+	executor, err := newOCExecutor(oc, o.Timeout, o.Logger)
 	if err != nil {
 		return nil, err
 	}
 	ret := client{
-		logger:   logger,
+		logger:   o.Logger,
 		executor: executor,
 	}
 	return &ret, nil

--- a/test/oc/oc.go
+++ b/test/oc/oc.go
@@ -1,13 +1,11 @@
 package oc
 
 import (
-	"github.com/go-logr/logr"
-
 	"github.com/openshift/cluster-version-operator/test/oc/api"
 	"github.com/openshift/cluster-version-operator/test/oc/cli"
 )
 
 // NewOC returns OC that provides utility functions used by the e2e tests
-func NewOC(logger logr.Logger) (api.OC, error) {
-	return cli.NewOCCli(logger)
+func NewOC(o api.Options) (api.OC, error) {
+	return cli.NewOCCli(o)
 }


### PR DESCRIPTION
Follow up https://github.com/openshift/cluster-version-operator/pull/1309#discussion_r2752275622

We made an `option` type for oc cmd.

Currently, it is mostly `timeout` for running the command. The current implementation use it as the timeout for the context when spawning the process.

The `option` also gives the flexibility to introduce other options for oc.


/cc @JianLi-RH 