### PR TITLE
OTA-1861: cmd/cluster-version-operator/render: Add --cluster-version-manifest-path option

### DIFF
--- a/cmd/cluster-version-operator/render.go
+++ b/cmd/cluster-version-operator/render.go
@@ -19,9 +19,10 @@ var (
 	}
 
 	renderOpts struct {
-		releaseImage            string
-		featureGateManifestPath string
-		outputDir               string
+		releaseImage               string
+		clusterVersionManifestPath string
+		featureGateManifestPath    string
+		outputDir                  string
 	}
 )
 
@@ -29,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(renderCmd)
 	renderCmd.PersistentFlags().StringVar(&renderOpts.outputDir, "output-dir", "", "The output directory where the manifests will be rendered.")
 	renderCmd.PersistentFlags().StringVar(&renderOpts.releaseImage, "release-image", "", "The Openshift release image url.")
+	renderCmd.PersistentFlags().StringVar(&renderOpts.clusterVersionManifestPath, "cluster-version-manifest-path", "", "ClusterVersion manifest input path.")
 	renderCmd.PersistentFlags().StringVar(&renderOpts.featureGateManifestPath, "feature-gate-manifest-path", "", "FeatureGate manifest input path.")
 }
 
@@ -42,7 +44,7 @@ func runRenderCmd(cmd *cobra.Command, args []string) {
 	if renderOpts.releaseImage == "" {
 		klog.Fatalf("missing --release-image flag, it is required")
 	}
-	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, renderOpts.featureGateManifestPath, clusterProfile()); err != nil {
+	if err := payload.Render(renderOpts.outputDir, renderOpts.releaseImage, renderOpts.clusterVersionManifestPath, renderOpts.featureGateManifestPath, clusterProfile()); err != nil {
 		klog.Fatalf("Render command failed: %v", err)
 	}
 }


### PR DESCRIPTION
Like a3a6a16c2e (#1078), but for ClusterVersion `spec.overrides`.  We need this in place to avoid [bootstrapping failure][1] when the CVO renders the ClusterImagePolicy despite `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY` having been set to trigger the installer to set an override waiving the ClusterImagePolicy:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-serial-1of2/2020129461281755136/artifacts/e2e-aws-ovn-serial/ipi-install-install/artifacts/log-bundle-20260207143404.tar | tar -tvz | grep 'cluster.*image.*polic'
-rw-r--r-- core/core          1678 2026-02-07 06:34 log-bundle-20260207143404/rendered-assets/openshift/cvo-bootstrap/manifests/0000_90_openshift-cluster-image-policy.yaml
-rw-r--r-- core/core          1678 2026-02-07 06:34 log-bundle-20260207143404/rendered-assets/openshift/manifests/0000_90_openshift-cluster-image-policy.yaml
```

The rendered ClusterImagePolicy is consumed by the bootstrap machine-config operator, and it [breaks the ability of unsigned nightly control-plane nodes to launch][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-serial-1of2/2020129461281755136/artifacts/e2e-aws-ovn-serial/ipi-install-install/artifacts/log-bundle-20260207143404.tar | tar -tvz | grep 'control-plane.*journal.log.gz'
-rw-r--r-- core/core         98143 2026-02-07 06:34 log-bundle-20260207143404/control-plane/10.0.110.120/journals/journal.log.gz
-rw-r--r-- core/core        101064 2026-02-07 06:34 log-bundle-20260207143404/control-plane/10.0.5.2/journals/journal.log.gz
-rw-r--r-- core/core         96700 2026-02-07 06:34 log-bundle-20260207143404/control-plane/10.0.71.227/journals/journal.log.gz
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-serial-1of2/2020129461281755136/artifacts/e2e-aws-ovn-serial/ipi-install-install/artifacts/log-bundle-20260207143404.tar | tar -xOz log-bundle-20260207143404/control-plane/10.0.5.2/journals/journal.log.gz | zgrep 'signature was required' | head -n4
Sat 2026-02-07 13:51:08 UTC ip-10-0-5-2 machine-config-daemon-pull.service[2026]: Error: Source image rejected: A signature was required, but no signature exists
Sat 2026-02-07 13:51:08 UTC ip-10-0-5-2 machine-config-daemon-pull.service[2026]: 2026-02-07 13:51:08.129594235 +0000 UTC m=+0.399222333 image pull-error  quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b4b3cc836d480ea7156ea797712e9af742fb73e5fb56a9cf9e63aeae11875315 Source image rejected: A signature was required, but no signature exists
Sat 2026-02-07 13:51:09 UTC ip-10-0-5-2 machine-config-daemon-pull.service[2037]: Error: Source image rejected: A signature was required, but no signature exists
Sat 2026-02-07 13:51:09 UTC ip-10-0-5-2 machine-config-daemon-pull.service[2037]: 2026-02-07 13:51:09.533298454 +0000 UTC m=+0.389622944 image pull-error  quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b4b3cc836d480ea7156ea797712e9af742fb73e5fb56a9cf9e63aeae11875315 Source image rejected: A signature was required, but no signature exists
```

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-serial-1of2/2020129461281755136