### PR TITLE
NO-JIRA: chore: exclude e2e tests from make test unconditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,10 @@ gotestsum:
 .PHONY: gotestsum
 
 JUNIT_DIR := "_output"
-PACKAGES := "./..."
+# tests in github.com/openshift/cluster-version-operator/test/ are e2e tests executed separately
+PACKAGES := $(shell go list ./... | grep -v "github.com/openshift/cluster-version-operator/test/" | xargs)
 ifeq ($(CI),true)
 JUNIT_DIR := "$(ARTIFACT_DIR)"
-# tests in github.com/openshift/cluster-version-operator/test/ will be executed separately in CI
-PACKAGES := $(shell go list ./... | grep -v "github.com/openshift/cluster-version-operator/test/" | xargs)
 endif
 
 test: gotestsum


### PR DESCRIPTION
The `test/cvo` e2e tests require a live OCP cluster and were excluded from make test only when CI=true. This caused make test to fail locally when no cluster is available.
This commit makes the exclusion unconditional so make test behaves consistently

