### PR TITLE
OCPBUGS-79358: pkg/cvo/egress: Disable Proxy respect on HyperShift

### DIFF
--- a/pkg/cvo/egress.go
+++ b/pkg/cvo/egress.go
@@ -55,6 +55,10 @@ func (optr *Operator) getTransport() (*http.Transport, error) {
 // getProxyConfig returns a proxy configuration.  It can be nil if
 // does not exist or there is an error.
 func (optr *Operator) getProxyConfig() (*httpproxy.Config, error) {
+	if optr.hypershift {
+		return nil, nil
+	}
+
 	proxy, err := optr.proxyLister.Get("cluster")
 
 	if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Since 4.14, HostedCluster has had spec.configuration.proxy to configure the data-plane egress [1].  In 4.18, the HyperShift API began documenting that setting as specific to data-plane egress [2]. However, the cluster-version operator running on the management-cluster control plane has assumed that hosted-cluster Proxy resource should configure its own egress as well.  I’m not sure how folks expect management-cluster-side control-plane egress to be configured, but we don’t want it to respect spec.configuration.proxy, because management-cluster networking and data-plane-compute networking are very different environments.  For now, just ignore the knob on HyperShift, to avoid data-plane-specific-network-config breaking Update Service access, with ClusterVersionRetrievedUpdates messages like:

    Unable to retrieve available updates: Get "https://api.openshift.com/api/upgrades_info/v1/graph?...": proxyconnect tcp: dial tcp: lookup ... on ...:53: no such host

[1]: https://github.com/openshift/hypershift/blame/b11c804b44516f34e50344eeb94901936018d9d1/api/v1beta1/hostedcluster_types.go#L2165-L2167
[2]: https://github.com/openshift/hypershift/blame/0d2075c649ed99657f6c5f90a0d273b8f99e9bc2/api/hypershift/v1beta1/hostedcluster_types.go#L1719-L1727