### PR TITLE
NO-ISSUE: Fix TestOperator_upgradeableSync

### DIFF
--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -3813,6 +3813,7 @@ func TestOperator_upgradeableSync(t *testing.T) {
 		t.Errorf("error adding ConfigMap event handler: %v", err)
 	}
 	configManagedInformer.Start(ctx.Done())
+	configManagedInformer.WaitForCacheSync(ctx.Done())
 
 	_, err := f.CoreV1().ConfigMaps("test").Create(ctx, &defaultGateCm, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
We have discussed [internally](https://redhat-internal.slack.com/archives/CJ1J9C3V4/p1727780218907479?thread_ts=1727759381.029409&cid=CJ1J9C3V4) about this a while ago and thanks to @DavidHurta to provide the solution.

```console
$ go test -run TestOperator_upgradeableSync ./pkg/cvo/... -count=1000
ok      github.com/openshift/cluster-version-operator/pkg/cvo   134.432s
ok      github.com/openshift/cluster-version-operator/pkg/cvo/configuration     0.746s [no tests to run]
ok      github.com/openshift/cluster-version-operator/pkg/cvo/internal  1.951s [no tests to run]
?       github.com/openshift/cluster-version-operator/pkg/cvo/internal/dynamicclient    [no test files]
```

It seems to bite us more often than before in CI, e.g., [job1](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-version-operator/1371/pull-ci-openshift-cluster-version-operator-main-unit/2042797754249383936), and
[job2](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-version-operator/1360/pull-ci-openshift-cluster-version-operator-main-unit/2039307795836178432) and
[job3](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-version-operator/1355/pull-ci-openshift-cluster-version-operator-main-unit/2035211529078444032).

I still do not fully understand why we have to add `configManagedInformer.WaitForCacheSync(ctx.Done())` or cannot prove that it is the best way to avoid racing but we use it in [the core code](https://github.com/openshift/cluster-version-operator/blob/e9c1c39e21ec353ff5993d386c42bc1b15063dbf/pkg/start/start.go#L257) too. Considering we change only testing code, I would like to have it to avoid unnecessary failures CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring cache synchronization completes before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->