### PR TITLE
OTA-1962: lightspeed: Add a new image holding Lightspeed skills

### DIFF
--- a/lightspeed/Containerfile.skills
+++ b/lightspeed/Containerfile.skills
@@ -1,0 +1,2 @@
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9-minimal
+COPY skill/ /skill/

--- a/lightspeed/README.md
+++ b/lightspeed/README.md
@@ -1,0 +1,13 @@
+# OpenShift Lightspeed Integration
+
+[Red Hat OpenShift Lightspeed][docs] is a generative AI service that helps developers and administrators solve problems by providing context-aware recommendations for OpenShift Container Platform.
+This directory contains skills ([Claude Skills][claude-skills], [OpenAI Skills][openai-skills]) maintained by the cluster-version operator maintainers, which are designed to help agents with ClusterVersion activities such as preparing for cluster updates.
+
+[`Containerfile.skills`](Containerfile.skills) builds a container image with [the skills](skill) in `/skill/`.
+OpenShift policy does not currently allow `FROM scratch` images, so we're just using the stock `FROM` base image that we use in the cluster-version operator's [`Dockerfile.rhel`](../Dockerfile.rhel).
+The resulting image can be [mounted as an image volume with a `subPath`][image-volume-sub-path] into any container that wishes to consume the skills.
+
+[claude-skills]: https://code.claude.com/docs/en/skills
+[docs]: https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0/html/about/ols-about-openshift-lightspeed
+[openai-skills]: https://developers.openai.com/api/docs/guides/tools-skills
+[image-volume-sub-path]: https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/#use-subpath-or-subpathexpr

--- a/lightspeed/skill/update-advisor/SKILL.md
+++ b/lightspeed/skill/update-advisor/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: openshift-cluster-update-advisor
+description: Assess OpenShift cluster update readiness and risk.  Use when evaluating whether a cluster is safe to update, when an update is available, or when the user asks about update risks, prerequisites, blockers, or best practices.
+---
+
+FIXME: just a draft at the moment, fill in with an actual skill later.


### PR DESCRIPTION
Eventually we'll integrate this into the OpenShift payload, and have some wiring to plug it into Lightspeed in-cluster.  For now, just provide some scaffolding to create the image, so we can start working on https://github.com/openshift/release integration ([docs][1]).

[1]: https://docs.ci.openshift.org/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OpenShift Lightspeed integration with an initial cluster update advisor skill, providing generative AI-powered assessments of cluster update readiness and risk identification.

* **Documentation**
  * Added comprehensive documentation covering the OpenShift Lightspeed integration overview, skills architecture and maintenance, containerized skills packaging and deployment, and image mounting configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->