### PR TITLE
CNTRLPLANE-3426: restart operator upon tls config change

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/crypto"
 
 	"github.com/openshift/cluster-version-operator/lib/resourcemerge"
@@ -267,6 +268,69 @@ type MetricsOptions struct {
 
 	DisableAuthentication bool
 	DisableAuthorization  bool
+
+	// TLS configuration observed from APIServer cluster object
+	MinTLSVersion uint16
+	CipherSuites  []uint16
+}
+
+// ObserveAPIServerTLSConfig extracts and converts TLS configuration from the
+// APIServer object. Always returns valid defaults even if APIServer object is
+// missing or invalid (errors are logged).
+func ObserveAPIServerTLSConfig(lister configlistersv1.APIServerLister) (uint16, []uint16) {
+	defaultProfileConfig := configv1.TLSProfiles[crypto.DefaultTLSProfileType]
+	defaultMinTLS := crypto.TLSVersionOrDie(string(defaultProfileConfig.MinTLSVersion))
+	defaultCipherSuites := crypto.CipherSuitesOrDie(crypto.OpenSSLToIANACipherSuites(defaultProfileConfig.Ciphers))
+
+	apiServer, err := lister.Get("cluster")
+	if err != nil {
+		klog.Warningf("Unable to read APIServer object, using default TLS profile: %v", err)
+		return defaultMinTLS, defaultCipherSuites
+	}
+
+	profile := apiServer.Spec.TLSSecurityProfile
+	if profile == nil {
+		return defaultMinTLS, defaultCipherSuites
+	}
+
+	profileConfig := configv1.TLSProfiles[profile.Type]
+	if profile.Type == configv1.TLSProfileCustomType {
+		if profile.Custom == nil {
+			klog.Warningf("APIServer TLS profile type is Custom but no custom spec provided, using default TLS profile")
+			return defaultMinTLS, defaultCipherSuites
+		}
+		profileConfig = &profile.Custom.TLSProfileSpec
+	}
+
+	if profileConfig == nil {
+		klog.Warningf("TLS config for profile %q not found, using default TLS profile", profile.Type)
+		return defaultMinTLS, defaultCipherSuites
+	}
+
+	minTLSVersion, err := crypto.TLSVersion(string(profileConfig.MinTLSVersion))
+	if err != nil {
+		klog.Warningf("Invalid minTLSVersion %q in APIServer TLS profile, using default TLS profile: %v", profileConfig.MinTLSVersion, err)
+		return defaultMinTLS, defaultCipherSuites
+	}
+
+	// convert OpenSSL cipher names to IANA names.
+	ianaCiphers := crypto.OpenSSLToIANACipherSuites(profileConfig.Ciphers)
+	if len(ianaCiphers) == 0 {
+		klog.Warningf("Failed to convert APIServer cipher suites %v to IANA format, using default TLS profile", profileConfig.Ciphers)
+		return defaultMinTLS, defaultCipherSuites
+	}
+
+	cipherSuites := make([]uint16, 0, len(ianaCiphers))
+	for _, cipherName := range ianaCiphers {
+		cipher, err := crypto.CipherSuite(cipherName)
+		if err != nil {
+			klog.Warningf("Invalid cipher suite %q in APIServer TLS profile, using default TLS profile: %v", cipherName, err)
+			return defaultMinTLS, defaultCipherSuites
+		}
+		cipherSuites = append(cipherSuites, cipher)
+	}
+
+	return minTLSVersion, cipherSuites
 }
 
 // RunMetrics launches an HTTPS server bound to listenAddress serving
@@ -362,6 +426,11 @@ func RunMetrics(runContext context.Context, shutdownContext context.Context, res
 	// which generates updated configs via GetConfigForClient callback on each TLS handshake.
 	// This enables automatic certificate rotation without server restarts.
 	baseTlSConfig := crypto.SecureTLSConfig(&tls.Config{ClientAuth: clientAuth})
+
+	// Apply APIServer TLS configuration from options
+	baseTlSConfig.MinVersion = options.MinTLSVersion
+	baseTlSConfig.CipherSuites = options.CipherSuites
+
 	servingCertController := dynamiccertificates.NewDynamicServingCertificateController(
 		baseTlSConfig,
 		clientCA,

--- a/pkg/cvo/metrics_test.go
+++ b/pkg/cvo/metrics_test.go
@@ -17,7 +17,9 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/client-go/tools/record"
@@ -1427,4 +1429,128 @@ func (m *mockCAProvider) VerifyOptions() (x509.VerifyOptions, bool) {
 }
 
 func (m *mockCAProvider) AddListener(_ dynamiccertificates.Listener) {
+}
+
+type apiServerLister struct {
+	apiServer *configv1.APIServer
+}
+
+func (r *apiServerLister) List(selector labels.Selector) ([]*configv1.APIServer, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *apiServerLister) Get(name string) (*configv1.APIServer, error) {
+	if r.apiServer != nil && r.apiServer.Name == name {
+		return r.apiServer, nil
+	}
+	return nil, apierrors.NewNotFound(configv1.Resource("apiserver"), name)
+}
+
+func TestObserveAPIServerTLSConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		apiServer        *configv1.APIServer
+		expectMinVersion uint16
+		checkCiphers     bool
+	}{
+		{
+			name: "custom TLS profile",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								MinTLSVersion: configv1.VersionTLS13,
+								Ciphers: []string{
+									"TLS_AES_128_GCM_SHA256",
+									"TLS_AES_256_GCM_SHA384",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectMinVersion: tls.VersionTLS13,
+			checkCiphers:     true,
+		},
+		{
+			name: "intermediate TLS profile",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileIntermediateType,
+					},
+				},
+			},
+			expectMinVersion: tls.VersionTLS12,
+			checkCiphers:     true,
+		},
+		{
+			name:             "no APIServer object (uses defaults)",
+			apiServer:        nil,
+			expectMinVersion: tls.VersionTLS12, // default is intermediate
+			checkCiphers:     true,
+		},
+		{
+			name: "nil TLS profile (uses defaults)",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       configv1.APIServerSpec{},
+			},
+			expectMinVersion: tls.VersionTLS12,
+			checkCiphers:     true,
+		},
+		{
+			name: "custom TLS profile type but no custom spec (uses defaults)",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+					},
+				},
+			},
+			expectMinVersion: tls.VersionTLS12,
+			checkCiphers:     true,
+		},
+		{
+			name: "invalid TLS version and cipher suites (uses defaults)",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								MinTLSVersion: "InvalidTLSVersion",
+								Ciphers: []string{
+									"RANDOM_CIPHER_123",
+									"INVALID_CIPHER_XYZ",
+									"NOT_A_REAL_CIPHER",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectMinVersion: tls.VersionTLS12,
+			checkCiphers:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &apiServerLister{apiServer: tt.apiServer}
+			minVer, ciphers := ObserveAPIServerTLSConfig(lister)
+			if minVer != tt.expectMinVersion {
+				t.Errorf("expected minTLSVersion 0x%04x, got 0x%04x", tt.expectMinVersion, minVer)
+			}
+			if tt.checkCiphers && len(ciphers) == 0 {
+				t.Errorf("expected cipher suites to be non-empty")
+			}
+		})
+	}
 }

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	coreclientsetv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -326,6 +328,9 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 	resultChannel := make(chan asyncResult, 1)
 	resultChannelCount := 0
 
+	apiServerLister := controllerCtx.ConfigInformerFactory.Config().V1().APIServers().Lister()
+	apiServerSharedIndexInformer := controllerCtx.ConfigInformerFactory.Config().V1().APIServers().Informer()
+
 	informersDone := postMainContext.Done()
 	// FIXME: would be nice if there was a way to collect these.
 	controllerCtx.ClusterVersionInformerFactory.Start(informersDone)
@@ -335,6 +340,13 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 	controllerCtx.OperatorInformerFactory.Start(informersDone)
 
 	allSynced := controllerCtx.ClusterVersionInformerFactory.WaitForCacheSync(informersDone)
+	for _, synced := range allSynced {
+		if !synced {
+			klog.Fatalf("Caches never synchronized: %v", postMainContext.Err())
+		}
+	}
+
+	allSynced = controllerCtx.ConfigInformerFactory.WaitForCacheSync(informersDone)
 	for _, synced := range allSynced {
 		if !synced {
 			klog.Fatalf("Caches never synchronized: %v", postMainContext.Err())
@@ -355,6 +367,27 @@ func (o *Options) run(ctx context.Context, controllerCtx *Context, lock resource
 				OnStartedLeading: func(_ context.Context) { // no need for this passed-through postMainContext, because goroutines we launch inside will use runContext
 					launchedMain = true
 					if o.MetricsOptions.ListenAddress != "" {
+						startMinTLSVersion, startCipherSuites := cvo.ObserveAPIServerTLSConfig(apiServerLister)
+						apiServerHandler := func() {
+							currentMinTLS, currentCiphers := cvo.ObserveAPIServerTLSConfig(apiServerLister)
+							if currentMinTLS == startMinTLSVersion && slices.Equal(currentCiphers, startCipherSuites) {
+								return
+							}
+							klog.Infof("APIServer TLS configuration changed; requesting shutdown")
+							runCancel()
+						}
+
+						if _, err := apiServerSharedIndexInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+							UpdateFunc: func(_, _ any) { apiServerHandler() },
+							AddFunc:    func(_ any) { apiServerHandler() },
+							DeleteFunc: func(_ any) { apiServerHandler() },
+						}); err != nil {
+							klog.Warningf("Failed to add watcher for APIServer Config: %v", err)
+						}
+
+						o.MetricsOptions.MinTLSVersion = startMinTLSVersion
+						o.MetricsOptions.CipherSuites = startCipherSuites
+
 						resultChannelCount++
 						go func() {
 							defer utilruntime.HandleCrash()


### PR DESCRIPTION
when the cluster wide tls config changes we now restart the operator by cancelling the run context. by doing so we ensure that the metrics end point will always use the correct tls version and ciphers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics endpoint now honors the cluster TLS security profile (minimum TLS version and cipher suites) and applies those settings to the metrics server.
  * Added optional TLS override settings to explicitly specify minimum TLS version and cipher suites.
  * Operator watches cluster TLS profile and will restart the metrics server when settings change.

* **Tests**
  * Added tests validating observation of APIServer TLS profiles and derived TLS settings across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->