### PR TITLE
WIP: pkg/internal/constants: Deprecate Upgradeable* subcondition constants

### DIFF
--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -638,11 +638,11 @@ func setUpgradeableCondition(ctx context.Context, cvStatus *configv1.ClusterVers
 	}
 
 	// remove obsolete subconditions
-	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableAdminAckRequired)
-	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableDeletesInProgress)
-	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableClusterOperators)
-	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableClusterVersionOverrides)
-	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableUpgradeInProgress)
+	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableAdminAckRequired)        //nolint:staticcheck // Ignore SA1019 until 5.1
+	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableDeletesInProgress)       //nolint:staticcheck // Ignore SA1019 until 5.1
+	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableClusterOperators)        //nolint:staticcheck // Ignore SA1019 until 5.1
+	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableClusterVersionOverrides) //nolint:staticcheck // Ignore SA1019 until 5.1
+	resourcemerge.RemoveOperatorStatusCondition(&cvStatus.Conditions, internal.UpgradeableUpgradeInProgress)       //nolint:staticcheck // Ignore SA1019 until 5.1
 
 	if len(risks) == 0 {
 		if err != nil {

--- a/pkg/internal/constants.go
+++ b/pkg/internal/constants.go
@@ -70,18 +70,33 @@ const (
 
 	// UpgradeableAdminAckRequired is False if there is API removed from the Kubernetes API server which requires admin
 	// consideration, and thus update to the next minor or major version is blocked.
+	//
+	// Deprecated: In 5.0, we stopped populating Upgradeable* subconditions, and now populate Upgradeable directly.
+	// The constants remain so we can remove them from 5.0 ClusterVersion status, but we will remove the constants themselves in 5.1.
 	UpgradeableAdminAckRequired configv1.ClusterStatusConditionType = "UpgradeableAdminAckRequired"
 	// UpgradeableDeletesInProgress is False if deleting resources is in progress, and thus update to the next minor or major
 	// version is blocked.
+	//
+	// Deprecated: In 5.0, we stopped populating Upgradeable* subconditions, and now populate Upgradeable directly.
+	// The constants remain so we can remove them from 5.0 ClusterVersion status, but we will remove the constants themselves in 5.1.
 	UpgradeableDeletesInProgress configv1.ClusterStatusConditionType = "UpgradeableDeletesInProgress"
 	// UpgradeableClusterOperators is False if something is wrong with Cluster Operators, and thus update to the next minor or major
 	// version is blocked.
+	//
+	// Deprecated: In 5.0, we stopped populating Upgradeable* subconditions, and now populate Upgradeable directly.
+	// The constants remain so we can remove them from 5.0 ClusterVersion status, but we will remove the constants themselves in 5.1.
 	UpgradeableClusterOperators configv1.ClusterStatusConditionType = "UpgradeableClusterOperators"
 	// UpgradeableClusterVersionOverrides is False if there are overrides in the Cluster Version, and thus update to the next minor or major
 	// version is blocked.
+	//
+	// Deprecated: In 5.0, we stopped populating Upgradeable* subconditions, and now populate Upgradeable directly.
+	// The constants remain so we can remove them from 5.0 ClusterVersion status, but we will remove the constants themselves in 5.1.
 	UpgradeableClusterVersionOverrides configv1.ClusterStatusConditionType = "UpgradeableClusterVersionOverrides"
 
 	// UpgradeableUpgradeInProgress is True if an update is in progress.
+	//
+	// Deprecated: In 5.0, we stopped populating Upgradeable* subconditions, and now populate Upgradeable directly.
+	// The constants remain so we can remove them from 5.0 ClusterVersion status, but we will remove the constants themselves in 5.1.
 	UpgradeableUpgradeInProgress configv1.ClusterStatusConditionType = "UpgradeableUpgradeInProgress"
 
 	// ConditionalUpdateConditionTypeRecommended is a type of the condition present on a conditional update


### PR DESCRIPTION
We only use these in `RemoveOperatorStatusCondition` calls since ea13ba6118 (#1368).  Mark them as deprecated with expected removals in the 5.1 dev cycle, to reduce the odds that other folks start consuming them now.  That's unlikely, because they're in `pkg/internal`, but it's easy to add [the standard deprecation Godocs][1].

[1]: https://go.dev/wiki/Deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation notes for several cluster condition constants to state that in 5.0 those subconditions are no longer populated and the consolidated Upgradeable condition is used instead.
  * Added guidance that the deprecated constants are planned for removal in 5.1 and clarified that there are no runtime behavior changes in 5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->