### PR TITLE
OTA-1966: Install namespace/openshift-lightspeed only when TechPreview is enabled

### DIFF
--- a/install/0000_00_cluster-version-operator_45_openshift-lightspeed_namespace.yaml
+++ b/install/0000_00_cluster-version-operator_45_openshift-lightspeed_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-lightspeed
   annotations:
-    kubernetes.io/description: This manifest is only for testing purpose and will be removed when its own operator becomes available on the cluster.
+    kubernetes.io/description: This manifest is only for testing purpose and will be removed before 5.0 GA or figure out how to install the cluster-update-advisory-prompt ConfigMap on a cluster where the openshift-lightspeed Namespace is installed by the OLM-installed OpenShift Lightspeed operator.
     include.release.openshift.io/self-managed-high-availability: "true"
     workload.openshift.io/allowed: "management"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/install/0000_00_cluster-version-operator_50_lightspeed-prompts.yaml
+++ b/install/0000_00_cluster-version-operator_50_lightspeed-prompts.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ota-advisory-prompt
+  name: cluster-update-advisory-prompt
   namespace: openshift-lightspeed
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/pkg/proposal/controller.go
+++ b/pkg/proposal/controller.go
@@ -85,7 +85,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Namespace:       envOrDefault("LIGHTSPEED_PROPOSAL_NAMESPACE", "openshift-lightspeed"),
-		PromptConfigMap: envOrDefault("LIGHTSPEED_PROMPT_CONFIGMAP", "ota-advisory-prompt"),
+		PromptConfigMap: envOrDefault("LIGHTSPEED_PROMPT_CONFIGMAP", "cluster-update-advisory-prompt"),
 	}
 }
 

--- a/pkg/proposal/controller_test.go
+++ b/pkg/proposal/controller_test.go
@@ -138,12 +138,15 @@ Update path: Recommended
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewController(tt.updatesGetterFunc, tt.client, tt.cvGetterFunc, func(_ context.Context, namespace, name string, _ metav1.GetOptions) (*corev1.ConfigMap, error) {
-				return &corev1.ConfigMap{
-					Data: map[string]string{
-						"prompt": "prompt-abc",
-						"foo":    "bar",
-					},
-				}, nil
+				if namespace == "openshift-lightspeed" && name == "cluster-update-advisory-prompt" {
+					return &corev1.ConfigMap{
+						Data: map[string]string{
+							"prompt": "prompt-abc",
+							"foo":    "bar",
+						},
+					}, nil
+				}
+				return nil, fmt.Errorf("ConfigMap %s not found in namespace %s", name, namespace)
 			}, func() string {
 				return "4.22.1"
 			})


### PR DESCRIPTION
I forgot to do this in https://github.com/openshift/cluster-version-operator/pull/1382.

The feature of creating proposals is [enabled only on TP clusters](https://github.com/openshift/cluster-version-operator/blob/fa129da3b3cba865873715ec88a0fafde98f6585/pkg/cvo/cvo.go#L1215-L1219). The namespace is only for testing that feature. Installing it only on TP clusters is to keep the damage away from any production clusters.

The renaming of ConfigMap from `ota-advisory-prompt` to `cluster-update-advisory-prompt` is to avoid using an obsolete team name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a TechPreviewNoUpgrade feature-set annotation to cluster metadata.
  * Renamed the cluster advisory prompt resource to a clearer name for update notices.

* **Documentation**
  * Clarified namespace description to specify removal timeframe ("before 5.0 GA") and added guidance for clusters using the Lightspeed operator, including installing the advisory prompt when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->