### PR TITLE
OCPBUGS-86798: Bug: Poll for CRD Established status after creation to fix TOCTOU race

### DIFF
--- a/lib/resourcebuilder/apiext.go
+++ b/lib/resourcebuilder/apiext.go
@@ -3,15 +3,22 @@ package resourcebuilder
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 )
 
-func (b *builder) checkCustomResourceDefinitionHealth(ctx context.Context, crd *apiextv1.CustomResourceDefinition) error {
-	if b.mode == InitializingMode {
-		return nil
-	}
+const (
+	crdEstablishedPollInterval = 100 * time.Millisecond
+	crdEstablishedPollTimeout  = 5 * time.Second
+)
 
+// checkCRDEstablished checks whether a CRD has Established=True in its status
+// conditions. Returns nil if established, or an error describing the current state.
+func checkCRDEstablished(crd *apiextv1.CustomResourceDefinition) error {
 	for _, condition := range crd.Status.Conditions {
 		if condition.Type == apiextv1.Established {
 			if condition.Status == apiextv1.ConditionTrue {
@@ -22,4 +29,37 @@ func (b *builder) checkCustomResourceDefinitionHealth(ctx context.Context, crd *
 	}
 
 	return fmt.Errorf("CustomResourceDefinition %s does not declare an Established status condition: %v", crd.Name, crd.Status.Conditions)
+}
+
+func (b *builder) checkCustomResourceDefinitionHealth(ctx context.Context, crd *apiextv1.CustomResourceDefinition) error {
+	if b.mode == InitializingMode {
+		return nil
+	}
+
+	if err := checkCRDEstablished(crd); err == nil {
+		return nil
+	}
+
+	// When status conditions are empty, the CRD was likely just created and the
+	// API server has not yet populated conditions. This is a known TOCTOU race:
+	// CVO creates the CRD and immediately checks Established, but the API server
+	// needs time to validate the schema and set conditions. Poll briefly to allow
+	// the API server to complete CRD registration before returning an error.
+	if len(crd.Status.Conditions) == 0 {
+		klog.V(4).Infof("CRD %s has empty status conditions, polling for Established", crd.Name)
+		pollErr := wait.PollUntilContextTimeout(ctx, crdEstablishedPollInterval, crdEstablishedPollTimeout, false, func(ctx context.Context) (bool, error) {
+			updated, err := b.apiextensionsClientv1.CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			crd = updated
+			return checkCRDEstablished(crd) == nil, nil
+		})
+		if pollErr == nil {
+			return nil
+		}
+		klog.V(2).Infof("CRD %s did not reach Established=True after polling for %s: %v", crd.Name, crdEstablishedPollTimeout, pollErr)
+	}
+
+	return checkCRDEstablished(crd)
 }

--- a/lib/resourcebuilder/apiext_test.go
+++ b/lib/resourcebuilder/apiext_test.go
@@ -1,6 +1,7 @@
 package resourcebuilder
 
 import (
+	"strings"
 	"testing"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -96,7 +97,7 @@ func TestCheckCRDEstablished(t *testing.T) {
 				if err == nil {
 					t.Error("expected error, got nil")
 				} else if tt.errSubstr != "" {
-					if !containsSubstring(err.Error(), tt.errSubstr) {
+					if !strings.Contains(err.Error(), tt.errSubstr) {
 						t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
 					}
 				}
@@ -138,15 +139,3 @@ func TestCheckCustomResourceDefinitionHealthEstablished(t *testing.T) {
 	}
 }
 
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstringImpl(s, substr))
-}
-
-func containsSubstringImpl(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/lib/resourcebuilder/apiext_test.go
+++ b/lib/resourcebuilder/apiext_test.go
@@ -1,0 +1,152 @@
+package resourcebuilder
+
+import (
+	"testing"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCheckCRDEstablished(t *testing.T) {
+	tests := []struct {
+		name      string
+		crd       *apiextv1.CustomResourceDefinition
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "Established=True returns nil",
+			crd: &apiextv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextv1.CustomResourceDefinitionCondition{
+						{
+							Type:   apiextv1.NamesAccepted,
+							Status: apiextv1.ConditionTrue,
+						},
+						{
+							Type:   apiextv1.Established,
+							Status: apiextv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Established=False returns error with reason",
+			crd: &apiextv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextv1.CustomResourceDefinitionCondition{
+						{
+							Type:    apiextv1.Established,
+							Status:  apiextv1.ConditionFalse,
+							Reason:  "Installing",
+							Message: "not yet established",
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "Established=False",
+		},
+		{
+			name: "empty conditions returns error",
+			crd: &apiextv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextv1.CustomResourceDefinitionCondition{},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "does not declare an Established status condition",
+		},
+		{
+			name: "nil conditions returns error",
+			crd: &apiextv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+				Status:     apiextv1.CustomResourceDefinitionStatus{},
+			},
+			wantErr:   true,
+			errSubstr: "does not declare an Established status condition",
+		},
+		{
+			name: "NamesAccepted but no Established returns error",
+			crd: &apiextv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+				Status: apiextv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextv1.CustomResourceDefinitionCondition{
+						{
+							Type:   apiextv1.NamesAccepted,
+							Status: apiextv1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "does not declare an Established status condition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkCRDEstablished(tt.crd)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tt.errSubstr != "" {
+					if !containsSubstring(err.Error(), tt.errSubstr) {
+						t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected nil error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckCustomResourceDefinitionHealthInitializingMode(t *testing.T) {
+	b := &builder{mode: InitializingMode}
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+		Status:     apiextv1.CustomResourceDefinitionStatus{},
+	}
+	if err := b.checkCustomResourceDefinitionHealth(t.Context(), crd); err != nil {
+		t.Errorf("InitializingMode should skip health check, got: %v", err)
+	}
+}
+
+func TestCheckCustomResourceDefinitionHealthEstablished(t *testing.T) {
+	b := &builder{mode: ReconcilingMode}
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test.example.io"},
+		Status: apiextv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextv1.CustomResourceDefinitionCondition{
+				{
+					Type:   apiextv1.Established,
+					Status: apiextv1.ConditionTrue,
+				},
+			},
+		},
+	}
+	if err := b.checkCustomResourceDefinitionHealth(t.Context(), crd); err != nil {
+		t.Errorf("Established=True CRD should pass health check, got: %v", err)
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstringImpl(s, substr))
+}
+
+func containsSubstringImpl(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes a TOCTOU (Time-Of-Check-Time-Of-Use) race condition in CVO's CRD apply logic where newly-created CRDs are checked for `Established=True` before the API server has had time to populate `status.conditions`.

- When CVO creates a new CRD, it immediately checks for `Established=True` in `status.conditions`
- The API server needs 100–500ms to validate the schema and set conditions
- CVO checks within 9–107ms — before conditions are populated
- This produces spurious error-level log entries that are noisy and confusing

## Root Cause

In `lib/resourcebuilder/apiext.go`, `checkCustomResourceDefinitionHealth()` checks the CRD object returned directly from `Create()`. At that point, `status.conditions` is still empty because the API server hasn't finished CRD registration yet.

## What Changed

- **`lib/resourcebuilder/apiext.go`**: Extracted Established check into a reusable `checkCRDEstablished()` helper. When `status.conditions` is empty (indicating the CRD was just created), poll the API server for up to 5 seconds at 100ms intervals before returning an error.
- **`lib/resourcebuilder/apiext_test.go`**: Added unit tests for `checkCRDEstablished()` covering all condition states (Established=True, Established=False, empty conditions, nil conditions, missing Established condition).

## Evidence — Reproduced on Fresh OCP 4.22.0-rc.4 Cluster

On a freshly installed cluster (no prior `CustomNoUpgrade`), enabling a feature gate triggered the race for **10 different CRDs**:

| CRD | Create → Check Gap |
|-----|-------------------|
| `dnsnameresolvers.network.openshift.io` | 107ms |
| `clusterversionoperators.operator.openshift.io` | 58ms |
| `etcdbackups.operator.openshift.io` | 9ms |
| `backups.config.openshift.io` | 105ms |
| `compatibilityrequirements.apiextensions.openshift.io` | 63ms |
| `clustermonitorings.config.openshift.io` | 98ms |
| `internalreleaseimages.machineconfiguration.openshift.io` | 13ms |
| `criocredentialproviderconfigs.config.openshift.io` | 11ms |
| `osimagestreams.machineconfiguration.openshift.io` | 14ms |
| `pkis.config.openshift.io` | 15ms |

CVO log showing the race (CRD created, then immediately failed Established check):
```
I0601 13:20:29.976973  1 apiext.go:21] CRD compatibilityrequirements.apiextensions.openshift.io not found, creating
E0601 13:20:30.039500  1 task.go:128] "Unhandled Error" err="error running apply for
  customresourcedefinition \"compatibilityrequirements.apiextensions.openshift.io\" (95 of 1039):
  CustomResourceDefinition compatibilityrequirements.apiextensions.openshift.io
  does not declare an Established status condition: []"
```

All 10 CRDs eventually reached `Established=True` and the sync succeeded on retry — confirming the CRDs are valid and this is purely a timing issue.

## Why This Wasn't Caught Before

- **Existing clusters**: CRDs already exist with `Established=True`, so CVO updates them (no race)
- **TechPreviewNoUpgrade at install**: CRDs are created during bootstrap, not during live CVO sync
- **CustomNoUpgrade at runtime**: This is the only path that triggers CRD creation during a live sync cycle

## Risk Assessment

**Low risk.** The change:
- Only affects the CRD **creation** path (not update — existing behavior unchanged)
- Preserves the Established safety check (CRDs that genuinely fail still error after 5s)
- Uses the standard `wait.PollUntilContextTimeout` pattern already used elsewhere in CVO
- All existing tests pass unchanged

## Test Plan

- [x] Unit tests for `checkCRDEstablished()` — all 5 condition states
- [x] Unit tests for `checkCustomResourceDefinitionHealth()` — InitializingMode skip + Established pass
- [x] Full `lib/` package tests pass (`go test ./lib/...`)
- [ ] E2E: Enable `CustomNoUpgrade` on a fresh 4.22 cluster — verify no "does not declare an Established" errors in CVO logs
- [ ] E2E: Verify all CRDs reach `Established=True` and cluster reaches healthy state

## Related

- [CVO PR #771](https://github.com/openshift/cluster-version-operator/pull/771) — Restored the Established check (correct behavior, but races on creation)
- Discovered during [OCPSTRAT-2485](https://issues.redhat.com/browse/OCPSTRAT-2485) feature gate testing


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRD readiness checks by adding timed polling for cases with initially empty status conditions, reducing false negatives and improving reliability; adds additional debug/verbose logging around polling and failures.

* **Tests**
  * Added unit tests covering CRD establishment and health-check behavior across modes and varied condition states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->