### PR TITLE
NO-JIRA: Risk from alert e2e blocking

### DIFF
--- a/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
+++ b/.openshift-tests-extension/openshift_payload_cluster-version-operator.json
@@ -2,7 +2,6 @@
   {
     "name": "[Jira:\"Cluster Version Operator\"] cluster-version-operator should work with risks from alerts",
     "labels": {
-      "Lifecycle:informing": {},
       "OTA-1813": {},
       "Serial": {}
     },
@@ -10,7 +9,7 @@
       "isolation": {}
     },
     "source": "openshift:payload:cluster-version-operator",
-    "lifecycle": "informing",
+    "lifecycle": "blocking",
     "environmentSelector": {}
   },
   {

--- a/test/cvo/accept_risks.go
+++ b/test/cvo/accept_risks.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
-	oteginkgo "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
@@ -61,7 +60,7 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator`,
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if du := cv.Spec.DesiredUpdate; du != nil {
 			logger.WithValues("AcceptRisks", du.AcceptRisks).Info("Accept risks before testing")
-			o.Expect(du.AcceptRisks).To(o.BeEmpty(), "found accept risks")
+			o.Expect(du.AcceptRisks).To(o.BeEmpty(), "found accept risks in Cluster/version before testing")
 		}
 		backup = *cv.Spec.DeepCopy()
 	})
@@ -72,15 +71,25 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator`,
 			o.Expect(err).To(o.BeNil())
 		}
 		if needRecover {
-			cv, err := configClient.ClusterVersions().Get(ctx, external.DefaultClusterVersionName, metav1.GetOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			cv.Spec = backup
-			_, err = configClient.ClusterVersions().Update(ctx, cv, metav1.UpdateOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
+			var updateErr error
+			err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true, func(context.Context) (done bool, err error) {
+				cv, err := configClient.ClusterVersions().Get(ctx, external.DefaultClusterVersionName, metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				cv.Spec = backup
+				_, updateErr = configClient.ClusterVersions().Update(ctx, cv, metav1.UpdateOptions{})
+				if errors.IsConflict(updateErr) {
+					return false, nil
+				}
+				if updateErr != nil {
+					return false, updateErr
+				}
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to recover cluster version with lastErr=%v while waiting", updateErr)
 		}
 	})
 
-	g.It("should work with risks from alerts", g.Label("OTA-1813"), g.Label("Serial"), oteginkgo.Informing(), func() {
+	g.It("should work with risks from alerts", g.Label("OTA-1813"), g.Label("Serial"), func() {
 		// This test case relies on a public service util.FauxinnatiAPIURL
 		o.Expect(util.SkipIfNetworkRestricted(ctx, c, util.FauxinnatiAPIURL)).To(o.BeNil())
 

--- a/test/cvo/accept_risks.go
+++ b/test/cvo/accept_risks.go
@@ -60,7 +60,7 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator`,
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if du := cv.Spec.DesiredUpdate; du != nil {
 			logger.WithValues("AcceptRisks", du.AcceptRisks).Info("Accept risks before testing")
-			o.Expect(du.AcceptRisks).To(o.BeEmpty(), "found accept risks in Cluster/version before testing")
+			o.Expect(du.AcceptRisks).To(o.BeEmpty(), "found accept risks in ClusterVersion before testing")
 		}
 		backup = *cv.Spec.DeepCopy()
 	})


### PR DESCRIPTION
Current passing percentage in [Sippy](https://sippy-auth.dptools.openshift.org/sippy-ng/tests/5.0?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522current_runs%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25227%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522has%2520entry%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522has%2520entry%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%252C%257B%2522columnField%2522%253A%2522current_flake_percentage%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522%253D%2522%252C%2522value%2522%253A%2522100%2522%257D%252C%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522cluster-version-operator%2520should%2520work%2520with%2520risks%2520from%2520alerts%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=net_improvement) is 96.3 (189 runs).

<img width="1499" height="429" alt="Screenshot 2026-06-04 at 10 04 41" src="https://github.com/user-attachments/assets/b711b3f1-e6e2-490e-9f60-8cbec86b264b" />


I checked the failures there (7 in total):

<img width="1452" height="367" alt="Screenshot 2026-06-04 at 09 54 51" src="https://github.com/user-attachments/assets/313fd3b4-c96e-42b4-bbad-1ed99d5b7d20" />


* (5 times) `Operation cannot be fulfilled on clusterversions.config.openshift.io "version": the object has been modified; please apply your changes to the latest version and try again` [1],
* `found accept risks` before testing [2],
* `fail [github.com/openshift/cluster-version-operator/test/cvo/accept_risks.go:181]: still no recommended conditional updates after the risk from alert is accepted` [3].

This pull addresses the first two above by adding retries to recover the backup, and the 3rd seems just flakiness. I am expecting it to fix the issue. We may `Patch` only the relevant part instead of `Update` the whole object if retries do not help.

I feel that it is ready to make the test blocking so that we do not need to check the passing rate proactively.

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-azure-ovn-serial-rhcos9-10-techpreview-2of2/2062374999892692992

[2]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-e2e-aws-ovn-techpreview-serial-1of3/2061405840442658816

[3]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-main-nightly-5.0-ocp-e2e-aws-ovn-techpreview-serial-multi-a-a-1of3/2060037920001101824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability: cleanup/recovery now retries configuration restores until successful or timed out.
  * Stricter test lifecycle and expectations: a cluster-version-operator test was reclassified from informing to blocking and related assertions were updated to reflect the stricter lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->