### PR TITLE
NO-JIRA: Fix make build target cd issue

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Go to the root of the repo
-cd "$(git rev-parse --show-cdup)"
+cd "$(git rev-parse --show-cdup)./"
 
 # Source build variables
 source hack/build-info.sh


### PR DESCRIPTION
Fix make build target error 

```
$ make build       
hack/build-go.sh
hack/build-go.sh: line 6: cd: null directory
make: *** [Makefile:5: build] Error 1

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor build script improvements to ensure proper repository directory navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->