### PR TITLE
OTA-1956: pkg/payload: Add Images map and tolerate unknown template fields during upgrades

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -153,7 +153,7 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 		return nil, err
 	}
 
-	tasks := loadPayloadTasks(releaseDir, cvoDir, releaseImage, profile)
+	tasks := loadPayloadTasks(releaseDir, cvoDir, releaseImage, profile, payload.ImageRef)
 
 	var onlyKnownCaps *configv1.ClusterVersionCapabilitiesStatus
 
@@ -195,7 +195,13 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 			if task.preprocess != nil {
 				raw, err = task.preprocess(raw)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("preprocess %s: %w", file.Name(), err))
+					// Template rendering may fail when an older CVO binary
+					// loads a newer payload that uses template fields the
+					// older binary does not know about (e.g. .Images). Skip
+					// the manifest with a warning — the new CVO binary will
+					// re-load the full payload after it replaces the old one
+					// at run-level 0.
+					klog.Warningf("Skipping manifest %s: template rendering failed (may require newer CVO): %v", file.Name(), err)
 					continue
 				}
 			}
@@ -317,13 +323,14 @@ type payloadTasks struct {
 	skipFiles  sets.Set[string]
 }
 
-func loadPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string) []payloadTasks {
+func loadPayloadTasks(releaseDir, cvoDir, releaseImage, clusterProfile string, imageRef *imagev1.ImageStream) []payloadTasks {
 	cjf := filepath.Join(releaseDir, cincinnatiJSONFile)
 	irf := filepath.Join(releaseDir, imageReferencesFile)
 
 	mrc := manifestRenderConfig{
 		ReleaseImage:   releaseImage,
 		ClusterProfile: clusterProfile,
+		Images:         imagesFromImageRef(imageRef),
 	}
 
 	return []payloadTasks{{

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -150,6 +150,28 @@ func TestLoadUpdate(t *testing.T) {
 	}
 }
 
+func TestLoadUpdateSkipsUnknownTemplateFields(t *testing.T) {
+	update, err := LoadUpdate("testdata/payload-unknown-template", "image:test", "", "", DefaultClusterProfile, nil, sets.Set[string]{})
+	if err != nil {
+		t.Fatalf("LoadUpdate should not fail when a manifest uses unknown template fields, got: %v", err)
+	}
+
+	// The valid manifest (using known .ReleaseImage) should be loaded
+	var foundValid bool
+	for _, m := range update.Manifests {
+		if m.OriginalFilename == "0000_00_valid.yaml" {
+			foundValid = true
+		}
+		// The manifest with unknown .FutureField should be skipped (not loaded)
+		if m.OriginalFilename == "0000_50_unknown-field.yaml" {
+			t.Error("manifest with unknown template field should have been skipped, but was loaded")
+		}
+	}
+	if !foundValid {
+		t.Error("expected valid manifest (0000_00_valid.yaml) to be loaded")
+	}
+}
+
 func TestLoadUpdateArchitecture(t *testing.T) {
 	type args struct {
 		dir          string

--- a/pkg/payload/render.go
+++ b/pkg/payload/render.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/api/config"
 	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/library-go/pkg/manifest"
 )
 
@@ -37,6 +38,12 @@ func Render(outputDir, releaseImage, clusterVersionManifestPath, featureGateMani
 			ClusterProfile: clusterProfile,
 		}
 	)
+
+	imageRef, err := loadImageReferences(releaseManifestsDir)
+	if err != nil {
+		return fmt.Errorf("error loading image references for manifest rendering: %w", err)
+	}
+	renderConfig.Images = imagesFromImageRef(imageRef)
 
 	overrides, err := parseClusterVersionManifest(clusterVersionManifestPath)
 	if err != nil {
@@ -181,6 +188,21 @@ func renderDir(renderConfig manifestRenderConfig, idir, odir string, overrides [
 type manifestRenderConfig struct {
 	ReleaseImage   string
 	ClusterProfile string
+	Images         map[string]string
+}
+
+// imagesFromImageRef builds a map from image short names to their resolved URIs.
+func imagesFromImageRef(imageRef *imagev1.ImageStream) map[string]string {
+	images := make(map[string]string)
+	if imageRef == nil {
+		return images
+	}
+	for _, tag := range imageRef.Spec.Tags {
+		if tag.From != nil && tag.From.Kind == "DockerImage" {
+			images[tag.Name] = tag.From.Name
+		}
+	}
+	return images
 }
 
 // renderManifest Executes go text template from `manifestBytes` with `config`.

--- a/pkg/payload/render_test.go
+++ b/pkg/payload/render_test.go
@@ -11,13 +11,81 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/library-go/pkg/manifest"
 )
+
+func TestImagesFromImageRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef *imagev1.ImageStream
+		expected map[string]string
+	}{
+		{
+			name:     "nil ImageStream returns empty map",
+			imageRef: nil,
+			expected: map[string]string{},
+		},
+		{
+			name: "maps DockerImage tags to their names",
+			imageRef: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							Name: "console",
+							From: &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/openshift/console:latest"},
+						},
+						{
+							Name: "cluster-update-console-plugin",
+							From: &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/openshift/plugin:v1"},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"console":                       "quay.io/openshift/console:latest",
+				"cluster-update-console-plugin": "quay.io/openshift/plugin:v1",
+			},
+		},
+		{
+			name: "skips non-DockerImage tags",
+			imageRef: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							Name: "docker-tag",
+							From: &corev1.ObjectReference{Kind: "DockerImage", Name: "example.com/img:v1"},
+						},
+						{
+							Name: "image-stream-tag",
+							From: &corev1.ObjectReference{Kind: "ImageStreamTag", Name: "other:latest"},
+						},
+						{
+							Name: "no-from",
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"docker-tag": "example.com/img:v1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := imagesFromImageRef(tt.imageRef)
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("imagesFromImageRef mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestRenderManifest(t *testing.T) {
 

--- a/pkg/payload/testdata/payload-unknown-template/manifests/0000_00_valid.yaml
+++ b/pkg/payload/testdata/payload-unknown-template/manifests/0000_00_valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-manifest
+  namespace: test
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  release-image: '{{.ReleaseImage}}'

--- a/pkg/payload/testdata/payload-unknown-template/manifests/0000_50_unknown-field.yaml
+++ b/pkg/payload/testdata/payload-unknown-template/manifests/0000_50_unknown-field.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: future-manifest
+  namespace: test
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  image: '{{index .FutureField "some-key"}}'

--- a/pkg/payload/testdata/payload-unknown-template/release-manifests/image-references
+++ b/pkg/payload/testdata/payload-unknown-template/release-manifests/image-references
@@ -1,0 +1,7 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "1.0.0-test"
+  }
+}

--- a/pkg/payload/testdata/payload-unknown-template/release-manifests/release-metadata
+++ b/pkg/payload/testdata/payload-unknown-template/release-manifests/release-metadata
@@ -1,0 +1,1 @@
+{"kind":"cincinnati-metadata-v0","version":"1.0.0-test"}


### PR DESCRIPTION
## Summary

Two changes to the CVO manifest template engine:

**1. Add `Images` map to `manifestRenderConfig`**

Populated from the release payload's `image-references` ImageStream. CVO manifests in `/manifests/` can now reference component images by short name using Go template syntax: `{{index .Images "component-name"}}`.

**2. Tolerate unknown template fields during `LoadUpdate`**

When an older CVO binary loads a newer payload that uses template fields the older binary does not know about (e.g. `.Images`), the manifest is skipped with a warning instead of failing the entire payload load. The new CVO binary re-loads the full payload after replacing the old one at run-level 0.

This is needed for upgrade safety. Without it, adding any new template field to a CVO manifest would break upgrades — the old CVO would fail to load the new payload before it can replace itself.

## How it works during upgrade

```
Old CVO (no .Images) loads new payload:
  ✅ CVO deployment.yaml     → {{.ReleaseImage}} renders fine
  ⚠️  console-plugin.yaml    → {{.Images}} unknown → skipped with warning

Old CVO applies run-level 00 → replaces itself

New CVO (has .Images) re-loads payload:
  ✅ CVO deployment.yaml     → {{.ReleaseImage}} renders fine
  ✅ console-plugin.yaml     → {{.Images}} renders fine → applied
```

## Related

- [openshift/oc#2287](https://github.com/openshift/oc/pull/2287) — keeps CVO's image-references entries in the release
- [openshift/cluster-version-operator#1398](https://github.com/openshift/cluster-version-operator/pull/1398) — console plugin manifests (follow-up, merges after this lands in a nightly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during manifest preprocessing/template rendering: failed manifests are now skipped with a warning instead of impacting the overall result.

* **Improvements**
  * Enhanced manifest rendering by resolving release image references and injecting derived image mappings into template inputs (including OpenShift image stream support).

* **Tests**
  * Added coverage to ensure manifests with unknown template fields are skipped.
  * Added unit tests for image-reference-to-template mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->