### PR TITLE
OCPBUGS-60579: install: Remove manual BoundServiceAccountTokenVolume configuration

### DIFF
--- a/install/0000_00_cluster-version-operator_30_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_30_deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         k8s-app: cluster-version-operator
     spec:
-      automountServiceAccountToken: false
       serviceAccountName: cluster-version-operator
       containers:
       - name: cluster-version-operator
@@ -59,9 +58,6 @@ spec:
           readOnly: true
         - mountPath: /etc/tls/service-ca
           name: service-ca
-          readOnly: true
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
           readOnly: true
         env:
         # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
@@ -116,21 +112,3 @@ spec:
       - name: service-ca
         configMap:
           name: openshift-service-ca.crt
-      - name: kube-api-access
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3600
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         k8s-app: cluster-version-operator
     spec:
-      automountServiceAccountToken: false
       serviceAccountName: cluster-version-operator
       containers:
       - name: cluster-version-operator
@@ -59,9 +58,6 @@ spec:
           readOnly: true
         - mountPath: /etc/tls/service-ca
           name: service-ca
-          readOnly: true
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
           readOnly: true
         env:
         # Unfortunately the placeholder is not replaced, reported as OCPBUGS-30080
@@ -116,21 +112,3 @@ spec:
       - name: service-ca
         configMap:
           name: openshift-service-ca.crt
-      - name: kube-api-access
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3600
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace


### PR DESCRIPTION
BoundServiceAccountTokenVolume has been GA since Kubernetes 1.22, so Kubernetes automatically creates a projected volume at /var/run/secrets/kubernetes.io/serviceaccount with the service account token, CA certificate, and namespace. The manual configuration with automountServiceAccountToken: false and an explicit kube-api-access projected volume is redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the cluster-version-operator's service account configuration. The operator now handles Kubernetes API credential retrieval through a modified mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->