### PR TITLE
NO-JIRA: fix(pkg/cincinnati): log the correct root CA pool size

### DIFF
--- a/pkg/cincinnati/cincinnati.go
+++ b/pkg/cincinnati/cincinnati.go
@@ -160,7 +160,7 @@ func (c Client) GetUpdates(ctx context.Context, uri *url.URL, desiredArch, curre
 	}
 	req.Header.Set("Accept", GraphMediaType)
 	if c.transport != nil && c.transport.TLSClientConfig != nil {
-		if c.transport.TLSClientConfig.ClientCAs == nil {
+		if c.transport.TLSClientConfig.RootCAs == nil {
 			klog.V(2).Infof("Using a root CA pool with 0 root CA subjects to request updates from %s", uri)
 		} else {
 			//nolint:staticcheck // SA1019: TLSClientConfig.RootCAs.Subjects() is deprecated because


### PR DESCRIPTION
GetUpdates checked TLSClientConfig.ClientCAs to decide whether to log the root CA subject count, but the client transport only ever populates RootCAs (ClientCAs is a server-side field, never set for this outbound client). The nil check was therefore always true: the log always reported "0 root CA subjects" and the branch reporting the real count was dead. Check RootCAs instead, which also correctly guards the RootCAs.Subjects() dereference in the else branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate handling when fetching updates.
  * Fixed an issue where the app could inspect the wrong certificate pool, which affected root CA logging and could cause errors when no root CA list was set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->