### PR TITLE
NO-JIRA: Handle the tests on Microshift environment

### DIFF
--- a/test/cvo/readiness.go
+++ b/test/cvo/readiness.go
@@ -39,6 +39,9 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator r
 		restCfg, err = util.GetRestConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
+		err = util.SkipIfMicroshift(ctx, restCfg)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to determine if cluster is MicroShift")
+
 		dynamicClient, err = dynamic.NewForConfig(restCfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
This PR adds the fix for the tests being failing on Microshift environment 

**Fixes**
```
{  fail [github.com/openshift/cluster-version-operator/test/cvo/readiness.go:53]: Unexpected error:                                                                                                               
      <*errors.StatusError | 0xc000356280>:                                                                                                                                                                         
      the server could not find the requested resource (get clusterversions.config.openshift.io version)                                                                                                            
      {                                                                                                                                                                                                             
          ErrStatus: {                                                                                                                                                                                              
              TypeMeta: {Kind: "", APIVersion: ""},                                                                                                                                                                 
              ListMeta: {                                                                                                                                                                                           
                  SelfLink: "",                                                                                                                                                                                     
                  ResourceVersion: "",                                                                                                                                                                              
                  Continue: "",                                                                                                                                                                                     
                  RemainingItemCount: nil,                                                                                                                                                                          
              },                                                                                                                                                                                                    
              Status: "Failure",                                                                                                                                                                                    
              Message: "the server could not find the requested resource (get clusterversions.config.openshift.io version)",                                                                                        
              Reason: "NotFound",                                                                                                                                                                                   
              Details: {                                                                                                                                                                                            
                  Name: "version",                                                                                                                                                                                  
                  Group: "config.openshift.io",                                                                                                                                                                     
                  Kind: "clusterversions",                                                                                                                                                                          
                  UID: "",                                                                                                                                                                                          
                  Causes: [                                                                                                                                                                                         
                      {                                                                                                                                                                                             
                          Type: "UnexpectedServerResponse",                                                                                                                                                         
                          Message: "404 page not found",                                                                                                                                                            
                          Field: "",                                                                                                                                                                                
                      },                                                                                                                                                                                            
                  ],                                                                                                                                                                                                
                  RetryAfterSeconds: 0,                                                                                                                                                                             
              },                                                                                                                                                                                                    
              Code: 404,                                                                                                                                                                                            
          },                                                                                                                                                                                                        
      }                                                                                                                                                                                                             
  occurred}   
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the readiness test to conditionally skip on MicroShift environments, improving compatibility in mixed deployment setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->