### PR TITLE
OCPBUGS-84513: set terminationMessagePolicy on update-payload pods

### DIFF
--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -218,6 +218,7 @@ func (r *payloadRetriever) fetchUpdatePayloadToDir(ctx context.Context, dir stri
 				corev1.ResourceEphemeralStorage: resource.MustParse("2Mi"),
 			},
 		}
+		container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 		return container
 	}
 


### PR DESCRIPTION
## Summary
- Set `terminationMessagePolicy=FallbackToLogsOnError` on all containers in update-payload pods created by CVO
- The fix is a one-line addition in `setContainerDefaults()` in `pkg/cvo/updatepayload.go`, which covers all 4 init containers and the 1 main container

## Problem
The update-payload pods dynamically created by CVO to retrieve release images were missing `terminationMessagePolicy=FallbackToLogsOnError`, causing the monitor test `[Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-cluster-version must have terminationMessagePolicy=FallbackToLogsOnError` to flake.

Affected containers:
- `initContainers[cleanup]`
- `initContainers[make-temporary-directory]`
- `initContainers[copy-operator-manifests-to-temporary-directory]`
- `initContainers[copy-release-manifests-to-temporary-directory]`
- `containers[rename-to-final-location]`

Note: The CVO deployment manifest (`install/0000_00_cluster-version-operator_30_deployment.yaml`) already had the policy set correctly — only the dynamically-created payload pods were missing it.

## Follow-up
After this merges, the exemption in `openshift/origin` ([monitortest.go L155](https://github.com/openshift/origin/blob/653bd69094e0e5109059d10c75da4d038f1d453e/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go#L155)) should be removed.

Fixes https://redhat.atlassian.net/browse/OCPBUGS-84513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how payload retrieval containers handle termination messages, so error details are more reliably captured from logs when a container fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->