### PR TITLE
NO-JIRA: Resolve PDB readiness test flake

### DIFF
--- a/test/cvo/readiness.go
+++ b/test/cvo/readiness.go
@@ -185,7 +185,14 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator r
 	})
 
 	g.It("should report PDB count matching actual PodDisruptionBudgets", func() {
-		// Ground truth: list PDBs across all namespaces
+		// Run the readiness check first to capture cluster state at a specific point in time
+		output := readiness.RunAll(ctx, dynamicClient, currentVersion, targetVersion)
+		result := output.Checks["pdb_drain"]
+		o.Expect(result.Status).To(o.Equal("ok"))
+
+		// Immediately list PDBs to minimize timing drift between the check and verification.
+		// PDBs can be created or deleted by controllers during test execution, so we list
+		// after the check to reduce the window for discrepancies caused by cluster state changes.
 		pdbList, err := kubeClient.PolicyV1().PodDisruptionBudgets("").List(ctx, metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -197,10 +204,6 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator r
 			}
 		}
 
-		// Our check
-		output := readiness.RunAll(ctx, dynamicClient, currentVersion, targetVersion)
-		result := output.Checks["pdb_drain"]
-		o.Expect(result.Status).To(o.Equal("ok"))
 		o.Expect(result.Data["total_pdbs"]).To(o.Equal(expectedTotal),
 			"PDB count should match actual PDBs in cluster")
 


### PR DESCRIPTION
Issue
The PDB readiness test was intermittently failing with count mismatch errors (e.g., expecting 28 PDBs but finding 29). This flake was caused by a timing race condition: the test was fetching the "ground truth" list of PDBs from the Kubernetes API before executing the custom readiness.RunAll() check.

Because background controllers in a live cluster constantly create or delete pods and PDBs, this execution order left a wide time window where the cluster state could change between the two API queries, leading to mismatched counts.

```
❯ : [Jira:"Cluster Version Operator"] cluster-version-operator readiness checks should report PDB count matching actual PodDisruptionBudgets expand_less    1s                                                      
  {  fail [github.com/openshift/cluster-version-operator/test/cvo/readiness.go:207]: PDB count should match actual PDBs in cluster                                                                                  
  Expected                                                                                                                                                                                                          
      <int>: 29                                                                                                                                                                                                     
  to equal                                                                                                                                                                                                          
      <int>: 28} why this test is failing    
```

Fix
The execution order was reversed to run the heavier readiness.RunAll() check first, followed immediately by querying the typed Kubernetes client for the ground truth snapshot. This change drastically shrinks the time window between the two data collection points to milliseconds, minimizing the chances of background cluster modifications causing a test flake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of readiness checks by reducing timing-related drift during cluster validation.
  * Made the validation flow more consistent so results better match the cluster’s current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->