### PR TITLE
OCPBUGS-98572: Tolerate unknown template fields during payload loading

### DIFF
--- a/pkg/payload/payload.go
+++ b/pkg/payload/payload.go
@@ -195,7 +195,13 @@ func LoadUpdate(dir, releaseImage, excludeIdentifier string, requiredFeatureSet 
 			if task.preprocess != nil {
 				raw, err = task.preprocess(raw)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("preprocess %s: %w", file.Name(), err))
+					// Template rendering may fail when an older CVO binary
+					// loads a newer payload that uses template fields the
+					// older binary does not know about (e.g. .Images). Skip
+					// the manifest with a warning — the new CVO binary will
+					// re-load the full payload after it replaces the old one
+					// at run-level 0.
+					klog.Warningf("Skipping manifest %s: template rendering failed (may require newer CVO): %v", file.Name(), err)
 					continue
 				}
 			}

--- a/pkg/payload/payload_test.go
+++ b/pkg/payload/payload_test.go
@@ -150,6 +150,26 @@ func TestLoadUpdate(t *testing.T) {
 	}
 }
 
+func TestLoadUpdateSkipsUnknownTemplateFields(t *testing.T) {
+	update, err := LoadUpdate("testdata/payload-unknown-template", "image:test", "", "", DefaultClusterProfile, nil, sets.Set[string]{})
+	if err != nil {
+		t.Fatalf("LoadUpdate should not fail when a manifest uses unknown template fields, got: %v", err)
+	}
+
+	var foundValid bool
+	for _, m := range update.Manifests {
+		if m.OriginalFilename == "0000_00_valid.yaml" {
+			foundValid = true
+		}
+		if m.OriginalFilename == "0000_50_unknown-field.yaml" {
+			t.Error("manifest with unknown template field should have been skipped, but was loaded")
+		}
+	}
+	if !foundValid {
+		t.Error("expected valid manifest (0000_00_valid.yaml) to be loaded")
+	}
+}
+
 func TestLoadUpdateArchitecture(t *testing.T) {
 	type args struct {
 		dir          string

--- a/pkg/payload/testdata/payload-unknown-template/manifests/0000_00_valid.yaml
+++ b/pkg/payload/testdata/payload-unknown-template/manifests/0000_00_valid.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: valid-manifest
+  namespace: test
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  release-image: '{{.ReleaseImage}}'

--- a/pkg/payload/testdata/payload-unknown-template/manifests/0000_50_unknown-field.yaml
+++ b/pkg/payload/testdata/payload-unknown-template/manifests/0000_50_unknown-field.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: future-manifest
+  namespace: test
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  image: '{{index .FutureField "some-key"}}'

--- a/pkg/payload/testdata/payload-unknown-template/release-manifests/image-references
+++ b/pkg/payload/testdata/payload-unknown-template/release-manifests/image-references
@@ -1,0 +1,7 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "1.0.0-test"
+  }
+}

--- a/pkg/payload/testdata/payload-unknown-template/release-manifests/release-metadata
+++ b/pkg/payload/testdata/payload-unknown-template/release-manifests/release-metadata
@@ -1,0 +1,1 @@
+{"kind":"cincinnati-metadata-v0","version":"1.0.0-test"}


### PR DESCRIPTION
## Summary

- Make template rendering errors non-fatal during `LoadUpdate`
- When the CVO encounters a manifest with unknown template fields, skip it with a warning instead of failing the entire payload load

## Why

Backport of the tolerance logic from [PR #1410](https://github.com/openshift/cluster-version-operator/pull/1410) (5.0). Without this, **4.22→5.0 major upgrades are blocked**: the 4.22 CVO tries to render 5.0 manifests that use `{{index .Images "..."}}`, fails because `.Images` doesn't exist in the 4.22 `manifestRenderConfig`, and sets `ReleaseAccepted=False`.

With this fix, the 4.22 CVO skips unrenderable manifests with a warning. The new 5.0 CVO re-loads the full payload after it replaces the old one at run-level 0, correctly rendering all manifests.

This was one of two issues that caused the [revert of CVO#1398](https://github.com/openshift/cluster-version-operator/pull/1420) and blocked 5.0 nightly payloads for 69+ hours ([TRT-2776](https://redhat.atlassian.net/browse/TRT-2776)).

## Test plan

- [ ] New unit test `TestLoadUpdateSkipsUnknownTemplateFields` verifies manifests with unknown template fields are skipped while valid manifests are loaded
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)