### PR TITLE
OTA-1956: install: Split multi-document YAML and add missing annotations

### DIFF
--- a/install/0000_50_cluster-update-console-plugin_10_namespace.yaml
+++ b/install/0000_50_cluster-update-console-plugin_10_namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: The OpenShift cluster-update console plugin provides a web-console interface for managing ClusterVersion updates.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    workload.openshift.io/allowed: management
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/install/0000_50_cluster-update-console-plugin_15_serviceaccount.yaml
+++ b/install/0000_50_cluster-update-console-plugin_15_serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-update-console-plugin
+  namespace: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: The OpenShift cluster-update console plugin provides a web-console interface for managing ClusterVersion updates.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"

--- a/install/0000_50_cluster-update-console-plugin_20_networkpolicy.yaml
+++ b/install/0000_50_cluster-update-console-plugin_20_networkpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: This NetworkPolicy is used to deny all ingress and egress traffic by default in this namespace, matching all Pods, and serving as a baseline.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/install/0000_50_cluster-update-console-plugin_30_configmap.yaml
+++ b/install/0000_50_cluster-update-console-plugin_30_configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-update-console-plugin
+  namespace: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: Nginx configuration for the cluster-update console plugin.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+data:
+  nginx.conf: |
+    error_log /dev/stderr;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              9001 ssl;
+        listen              [::]:9001 ssl;
+        ssl_certificate     /var/cert/tls.crt;
+        ssl_certificate_key /var/cert/tls.key;
+        root                /usr/share/nginx/html;
+      }
+    }

--- a/install/0000_50_cluster-update-console-plugin_50_deployment.yaml
+++ b/install/0000_50_cluster-update-console-plugin_50_deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-update-console-plugin
+  namespace: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: The OpenShift cluster-update console plugin provides a web-console interface for managing ClusterVersion updates.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  selector:
+    matchLabels:
+      app: cluster-update-console-plugin
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v3
+      labels:
+        app: cluster-update-console-plugin
+    spec:
+      serviceAccountName: cluster-update-console-plugin
+      automountServiceAccountToken: false
+      containers:
+      - name: plugin
+        image: '{{index .Images "cluster-update-console-plugin"}}'
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: https
+          containerPort: 9001
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/cert
+          name: cluster-update-console-plugin-cert
+          readOnly: true
+        - mountPath: /etc/nginx/nginx.conf
+          name: nginx-conf
+          readOnly: true
+          subPath: nginx.conf
+      dnsPolicy: ClusterFirst
+      hostUsers: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      volumes:
+      - name: cluster-update-console-plugin-cert
+        secret:
+          defaultMode: 420
+          secretName: cluster-update-console-plugin-cert
+      - name: nginx-conf
+        configMap:
+          name: cluster-update-console-plugin
+          defaultMode: 420

--- a/install/0000_50_cluster-update-console-plugin_60_service.yaml
+++ b/install/0000_50_cluster-update-console-plugin_60_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openshift-cluster-update-console-plugin
+  namespace: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: The OpenShift cluster-update console plugin provides a web-console interface for managing ClusterVersion updates.
+    service.beta.openshift.io/serving-cert-secret-name: cluster-update-console-plugin-cert
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  type: ClusterIP
+  selector:
+    app: cluster-update-console-plugin
+  ports:
+  - name: https
+    port: 9001
+    targetPort: https

--- a/install/0000_50_cluster-update-console-plugin_90_consoleplugin.yaml
+++ b/install/0000_50_cluster-update-console-plugin_90_consoleplugin.yaml
@@ -1,0 +1,21 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: openshift-cluster-update-console-plugin
+  annotations:
+    kubernetes.io/description: The OpenShift cluster-update console plugin provides a web-console interface for managing ClusterVersion updates.
+    capability.openshift.io/name: Console
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  displayName: Cluster Updates
+  i18n:
+    loadType: Preload
+  backend:
+    type: Service
+    service:
+      name: openshift-cluster-update-console-plugin
+      namespace: openshift-cluster-update-console-plugin
+      port: 9001
+      basePath: /

--- a/install/image-references
+++ b/install/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-update-console-plugin
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.example.org:cluster-update-console-plugin

--- a/pkg/payload/render_test.go
+++ b/pkg/payload/render_test.go
@@ -381,6 +381,9 @@ func Test_cvoManifests(t *testing.T) {
 	config := manifestRenderConfig{
 		ReleaseImage:   "quay.io/cvo/release:latest",
 		ClusterProfile: "some-profile",
+		Images: map[string]string{
+			"cluster-update-console-plugin": "quay.io/openshift/cluster-update-console-plugin:latest",
+		},
 	}
 
 	tests := []struct {
@@ -406,6 +409,10 @@ func Test_cvoManifests(t *testing.T) {
 				}
 
 				if d.IsDir() {
+					return nil
+				}
+
+				if _, fileName := filepath.Split(path); fileName == "image-references" {
 					return nil
 				}
 


### PR DESCRIPTION
Reverts openshift/cluster-version-operator#1420
Original PR https://github.com/openshift/cluster-version-operator/pull/1398

ccing @wking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Cluster Update Console Plugin and its supporting deployment resources.
  * Enabled secure HTTPS serving through an internal service.
  * Registered the plugin for the OpenShift web console with ClusterVersion update management capabilities.
  * Added image configuration for deploying the plugin.

* **Tests**
  * Updated manifest validation to support the plugin image and image reference configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->