### PR TITLE
OTA-1997: Allow the CVO to use the agentic-skills payload image when creating proposals.

### DIFF
--- a/install/0000_00_cluster-version-operator_30_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_30_deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: CLUSTER_PROFILE
           value: '{{ .ClusterProfile }}'
         - name: LIGHTSPEED_SKILLS_IMAGE
-          value: "quay.io/openshift/ci:ocp_5.0_agentic-skills"
+          value: '{{ index .Images "agentic-skills" }}'
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default

--- a/install/image-references
+++ b/install/image-references
@@ -2,6 +2,10 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
+  - name: agentic-skills
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.example.org:agentic-skills
   - name: cluster-update-console-plugin
     from:
       kind: DockerImage

--- a/pkg/agenticrun/controller.go
+++ b/pkg/agenticrun/controller.go
@@ -111,7 +111,7 @@ func DefaultConfig() Config {
 	return Config{
 		Namespace:       envOrDefault("LIGHTSPEED_AGENTIC_RUN_NAMESPACE", "openshift-lightspeed"),
 		PromptConfigMap: envOrDefault("LIGHTSPEED_PROMPT_CONFIGMAP", "cluster-update-advisory-prompt"),
-		SkillsImage:     envOrDefault("LIGHTSPEED_SKILLS_IMAGE", "quay.io/openshift/ci:ocp_5.0_agentic-skills"),
+		SkillsImage:     os.Getenv("LIGHTSPEED_SKILLS_IMAGE"),
 	}
 }
 
@@ -206,6 +206,11 @@ func (c *Controller) Sync(ctx context.Context, key string) error {
 		} else {
 			c.consolePluginEnsured = true
 		}
+	}
+
+	if c.config.SkillsImage == "" {
+		klog.V(i.Normal).Infof("Skipping agentic run creation: LIGHTSPEED_SKILLS_IMAGE is not set")
+		return nil
 	}
 
 	updates, conditionalUpdates, err := c.updatesGetterFunc()

--- a/pkg/agenticrun/controller_test.go
+++ b/pkg/agenticrun/controller_test.go
@@ -103,7 +103,7 @@ Update path: Recommended
 								Tools: agenticrunv1alpha1.ToolsSpec{
 									Skills: []agenticrunv1alpha1.SkillsSource{
 										{
-											Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+											Image: "registry.example.com/agentic-skills:latest",
 											Paths: []string{
 												"/skills/cluster-update/update-advisor",
 												"/skills/cluster-update/product-lifecycle",
@@ -140,6 +140,7 @@ Update path: Recommended
 			}, func() string {
 				return "4.22.1"
 			})
+			c.config.SkillsImage = "registry.example.com/agentic-skills:latest"
 			c.crdAvailableCache = true
 			c.crdLastChecked = time.Now()
 			actual := c.Sync(context.Background(), tt.name)
@@ -786,7 +787,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -835,7 +836,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -893,7 +894,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -935,7 +936,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -982,7 +983,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -1029,7 +1030,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -1084,7 +1085,7 @@ Other recommended versions available:
 				tt.currentVersion,
 				tt.channel,
 				tt.systemPrompt,
-				"quay.io/openshift/ci:ocp_5.0_agentic-skills",
+				"registry.example.com/agentic-skills:latest",
 			)
 
 			if diff := cmp.Diff(err, tt.expectError, cmp.Transformer("Error", func(e error) string {
@@ -1303,7 +1304,7 @@ func TestGetAgenticRuns_WithReadinessData(t *testing.T) {
 		"4.21.5",
 		"stable-4.21",
 		"Test prompt",
-		"quay.io/openshift/ci:ocp_5.0_agentic-skills",
+		"registry.example.com/agentic-skills:latest",
 	)
 	if err != nil {
 		t.Fatalf("getAgenticRuns returned error: %v", err)

--- a/pkg/payload/render_test.go
+++ b/pkg/payload/render_test.go
@@ -101,6 +101,9 @@ func TestRenderManifest(t *testing.T) {
 			config: manifestRenderConfig{
 				ReleaseImage:   "quay.io/cvo/release:latest",
 				ClusterProfile: "some-profile",
+				Images: map[string]string{
+					"agentic-skills": "registry.example.com/agentic-skills:latest",
+				},
 			},
 			manifestFile:         "../../install/0000_00_cluster-version-operator_30_deployment.yaml",
 			expectedManifestFile: "./testdata/TestRenderManifest_expected_cvo_deployment.yaml",

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: CLUSTER_PROFILE
           value: 'some-profile'
         - name: LIGHTSPEED_SKILLS_IMAGE
-          value: "quay.io/openshift/ci:ocp_5.0_agentic-skills"
+          value: 'registry.example.com/agentic-skills:latest'
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default


### PR DESCRIPTION
Hello. This is a draft PR to get some feedback on this PR for [OTA-1997](https://redhat.atlassian.net/browse/OTA-1997). Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated the default Agentic Skills image to `registry.redhat.io/openshift-lightspeed/agentic-skills:latest`.
  * Deployment now uses the configured `agentic-skills` image reference for the Cluster Version Operator.
  * Added an `agentic-skills` tag to the ImageStream to align image selection.
* **Bug Fixes**
  * Improved consistency between configured, rendered, and deployed Agentic Skills image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->