### PR TITLE
OTA-2097, OTA-2084: pkg/agenticrun/controller: Additional logging to AgenticRun CRD detection

### DIFF
--- a/pkg/agenticrun/controller.go
+++ b/pkg/agenticrun/controller.go
@@ -153,12 +153,14 @@ func (c *Controller) crdAvailable() bool {
 	}
 	c.crdLastChecked = time.Now()
 	if c.client == nil {
+		klog.V(i.Normal).Info("No AgenticRun controller client, assuming there are no AgenticRuns")
 		c.crdAvailableCache = false
 		return false
 	}
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 	err := c.client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: "agenticruns.agentic.openshift.io"}, crd)
 	c.crdAvailableCache = err == nil
+	klog.V(i.Normal).Infof("AgenticRun CustomResourceDefinition available? %t (%v)", c.crdAvailableCache, err)
 	return c.crdAvailableCache
 }
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -16,9 +16,11 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
@@ -531,7 +533,13 @@ func (cb *ClientBuilder) DynamicClientOrDie(name string, configFns ...func(*rest
 }
 
 func (cb *ClientBuilder) RuntimeControllerClientOrDie(name string, configFns ...func(*rest.Config)) runtimeclient.Client {
-	c, err := runtimeclient.New(rest.AddUserAgent(cb.RestConfig(configFns...), name), runtimeclient.Options{})
+	runtimeScheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(runtimeScheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(runtimeScheme))
+
+	c, err := runtimeclient.New(rest.AddUserAgent(cb.RestConfig(configFns...), name), runtimeclient.Options{
+		Scheme: runtimeScheme,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
@@ -536,6 +537,7 @@ func (cb *ClientBuilder) RuntimeControllerClientOrDie(name string, configFns ...
 	runtimeScheme := runtime.NewScheme()
 	utilruntime.Must(scheme.AddToScheme(runtimeScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(runtimeScheme))
+	utilruntime.Must(operatorv1.AddToScheme(runtimeScheme))
 
 	c, err := runtimeclient.New(rest.AddUserAgent(cb.RestConfig(configFns...), name), runtimeclient.Options{
 		Scheme: runtimeScheme,


### PR DESCRIPTION
Adding additional logging to the logic from f29721f788 (#1425), to make it easier to debug logs like:

```console
$ oc -n openshift-cluster-version logs -l k8s-app=cluster-version-operator --tail -1 | grep -i controller.go | tail -n3
I0723 23:05:41.142338       1 controller.go:184] Started syncing CVO configuration "ClusterVersionOperator/agenticrun-lifecycle-controller"
I0723 23:05:41.142835       1 controller.go:191] Failed to disable console plugin, skipping manifest cleanup: getting console operator config: no kind is registered for the type v1.Console in scheme "k8s.io/client-go/kubernetes/scheme/register.go:84"
I0723 23:05:41.142922       1 controller.go:186] Finished syncing CVO configuration (586.586µs)
```

where the cluster-version operator apparently thinks that there is no AgenticRun CRD.  Despite the AgenticRun CRD having existed in that cluster for hours by the time we got those CVO logs.

```console
$ oc get customresourcedefinitions agenticruns.agentic.openshift.io
NAME                               CREATED AT
agenticruns.agentic.openshift.io   2026-07-23T19:21:46Z
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved diagnostic logging when determining whether the AgenticRun custom resource definition is available, including clearer handling when no client connection is present and reporting the final availability result.
  - Updated startup client initialization to include the necessary API scheme so the runtime client correctly recognizes required API types.
  - No user-facing functionality or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->