### PR TITLE
OTA-1997: Allow the CVO to use the agentic-skills payload image when creating proposals

### DIFF
--- a/install/0000_00_cluster-version-operator_30_deployment.yaml
+++ b/install/0000_00_cluster-version-operator_30_deployment.yaml
@@ -73,8 +73,6 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_PROFILE
           value: '{{ .ClusterProfile }}'
-        - name: LIGHTSPEED_SKILLS_IMAGE
-          value: "quay.io/openshift/ci:ocp_5.0_agentic-skills"
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default

--- a/install/image-references
+++ b/install/image-references
@@ -2,6 +2,10 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
+  - name: agentic-skills
+    from:
+      kind: DockerImage
+      name: placeholder.url.oc.will.replace.this.example.org:agentic-skills
   - name: cluster-update-console-plugin
     from:
       kind: DockerImage

--- a/pkg/agenticrun/controller.go
+++ b/pkg/agenticrun/controller.go
@@ -113,8 +113,7 @@ type Config struct {
 // DefaultConfig returns the default configuration, checking env vars for overrides.
 func DefaultConfig() Config {
 	return Config{
-		Namespace:   envOrDefault("LIGHTSPEED_AGENTIC_RUN_NAMESPACE", "openshift-lightspeed"),
-		SkillsImage: envOrDefault("LIGHTSPEED_SKILLS_IMAGE", "quay.io/openshift/ci:ocp_5.0_agentic-skills"),
+		Namespace: envOrDefault("LIGHTSPEED_AGENTIC_RUN_NAMESPACE", "openshift-lightspeed"),
 	}
 }
 
@@ -148,6 +147,10 @@ func (c *Controller) SetConsolePluginImage(image string) {
 		c.consolePluginImage = image
 		c.consolePluginEnsured = false
 	}
+}
+
+func (c *Controller) SetSkillsImage(image string) {
+	c.config.SkillsImage = image
 }
 
 func (c *Controller) crdAvailable() bool {
@@ -211,6 +214,11 @@ func (c *Controller) Sync(ctx context.Context, key string) error {
 		} else {
 			c.consolePluginEnsured = true
 		}
+	}
+
+	if c.config.SkillsImage == "" {
+		klog.V(i.Normal).Infof("Skipping agentic run creation: skills image is not set")
+		return nil
 	}
 
 	updates, conditionalUpdates, err := c.updatesGetterFunc()

--- a/pkg/agenticrun/controller_test.go
+++ b/pkg/agenticrun/controller_test.go
@@ -102,7 +102,7 @@ Update path: Recommended
 								Tools: agenticrunv1alpha1.ToolsSpec{
 									Skills: []agenticrunv1alpha1.SkillsSource{
 										{
-											Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+											Image: "registry.example.com/agentic-skills:latest",
 											Paths: []string{
 												"/skills/cluster-update/update-advisor",
 												"/skills/cluster-update/product-lifecycle",
@@ -129,6 +129,7 @@ Update path: Recommended
 			c := NewController(tt.updatesGetterFunc, tt.client, nil, tt.cvGetterFunc, func() string {
 				return "4.22.1"
 			})
+			c.config.SkillsImage = "registry.example.com/agentic-skills:latest"
 			c.crdAvailableCache = true
 			c.crdLastChecked = time.Now()
 			actual := c.Sync(context.Background(), tt.name)
@@ -775,7 +776,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -824,7 +825,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -882,7 +883,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -924,7 +925,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -971,7 +972,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -1018,7 +1019,7 @@ Other recommended versions available:
 						Tools: agenticrunv1alpha1.ToolsSpec{
 							Skills: []agenticrunv1alpha1.SkillsSource{
 								{
-									Image: "quay.io/openshift/ci:ocp_5.0_agentic-skills",
+									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
 										"/skills/cluster-update/update-advisor",
 										"/skills/cluster-update/product-lifecycle",
@@ -1073,7 +1074,7 @@ Other recommended versions available:
 				tt.currentVersion,
 				tt.channel,
 				tt.systemPrompt,
-				"quay.io/openshift/ci:ocp_5.0_agentic-skills",
+				"registry.example.com/agentic-skills:latest",
 			)
 
 			if diff := cmp.Diff(err, tt.expectError, cmp.Transformer("Error", func(e error) string {
@@ -1292,7 +1293,7 @@ func TestGetAgenticRuns_WithReadinessData(t *testing.T) {
 		"4.21.5",
 		"stable-4.21",
 		"Test prompt",
-		"quay.io/openshift/ci:ocp_5.0_agentic-skills",
+		"registry.example.com/agentic-skills:latest",
 	)
 	if err != nil {
 		t.Fatalf("getAgenticRuns returned error: %v", err)

--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -443,9 +443,14 @@ func (optr *Operator) InitializeFromPayload(ctx context.Context, restConfig *res
 
 	if update.ImageRef != nil {
 		for _, tag := range update.ImageRef.Spec.Tags {
-			if tag.Name == "cluster-update-console-plugin" && tag.From != nil && tag.From.Kind == "DockerImage" {
+			if tag.From == nil || tag.From.Kind != "DockerImage" {
+				continue
+			}
+			switch tag.Name {
+			case "cluster-update-console-plugin":
 				optr.agenticRunController.SetConsolePluginImage(tag.From.Name)
-				break
+			case "agentic-skills":
+				optr.agenticRunController.SetSkillsImage(tag.From.Name)
 			}
 		}
 	}

--- a/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
+++ b/pkg/payload/testdata/TestRenderManifest_expected_cvo_deployment.yaml
@@ -73,8 +73,6 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_PROFILE
           value: 'some-profile'
-        - name: LIGHTSPEED_SKILLS_IMAGE
-          value: "quay.io/openshift/ci:ocp_5.0_agentic-skills"
       # this pod is hostNetwork and uses the internal LB DNS name when possible, which the kubelet also uses.
       # this dnsPolicy allows us to use the same dnsConfig as the kubelet, without access to read it ourselves.
       dnsPolicy: Default


### PR DESCRIPTION
Hello. This is a PR to address some issues that were implemented by [the previous iteration of this PR.](https://github.com/openshift/cluster-version-operator/pull/1427) 
It had to [be reverted](https://github.com/openshift/cluster-version-operator/pull/1431), because it introduced a field in the CVO deployment that the 4.22 CVO couldn't render, so it broke during upgrades.
This PR should hopefully address that issue.
Thanks! 

Assisted-by: [Claude Code](https://claude.com/product/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster deployments now use the configured `CLUSTER_PROFILE` setting.
  * Added an `agentic-skills` image reference for AgenticRun skills.
  * Agentic plugin images (console and skills) can be derived from release payload Docker image tags.
* **Bug Fixes**
  * AgenticRun creation is skipped when no skills image is configured, avoiding incomplete runs.
* **Tests**
  * Updated expectations to use the new Agentic skills image reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->