### PR TITLE
OTA-2084: Register agenticrunv1alpha1 in the Runtime client scheme

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -44,6 +44,7 @@ import (
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/config/clusterstatus"
 	libgoleaderelection "github.com/openshift/library-go/pkg/config/leaderelection"
+	agenticrunv1alpha1 "github.com/openshift/lightspeed-agentic-operator/api/v1alpha1"
 
 	"github.com/openshift/cluster-version-operator/pkg/autoupdate"
 	"github.com/openshift/cluster-version-operator/pkg/clusterconditions"
@@ -538,6 +539,7 @@ func (cb *ClientBuilder) RuntimeControllerClientOrDie(name string, configFns ...
 	utilruntime.Must(scheme.AddToScheme(runtimeScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(runtimeScheme))
 	utilruntime.Must(operatorv1.AddToScheme(runtimeScheme))
+	utilruntime.Must(agenticrunv1alpha1.AddToScheme(runtimeScheme))
 
 	c, err := runtimeclient.New(rest.AddUserAgent(cb.RestConfig(configFns...), name), runtimeclient.Options{
 		Scheme: runtimeScheme,


### PR DESCRIPTION
## Summary

After #1428, the agenticrun-lifecycle-controller fails to list/get AgenticRun resources because the `agenticrunv1alpha1` types are not registered in the local runtime scheme introduced by that PR.

The controller logs the following errors on every sync:

```
I0727 18:12:05.599862       1 controller.go:189] Started syncing CVO configuration "ClusterVersionOperator/agenticrun-lifecycle-controller"
I0727 18:12:37.717030       1 cvo.go:791] Error handling ClusterVersionOperator/agenticrun-lifecycle-controller: [failed to list agentic runs: no kind is registered for the type v1alpha1.AgenticRunList in scheme "pkg/start/start.go:537", no kind is registered for the type v1alpha1.AgenticRun in scheme "pkg/start/start.go:537"]
```

Previously, `RuntimeControllerClientOrDie` used the default global scheme, which already had the agenticrun types registered via `internal.AddSchemes()`. The switch to a local scheme in #1428 correctly added apiextensions and operator types but missed `agenticrunv1alpha1`.

## Fix

Add `agenticrunv1alpha1.AddToScheme(runtimeScheme)` alongside the other scheme registrations in `RuntimeControllerClientOrDie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime controller compatibility by enabling recognition of Lightspeed agentic run resources.
  * Prevented issues when working with these resources through the Kubernetes runtime client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->