### PR TITLE
[ROSAENG-63153] Modify logging to trim trailing newline causing cloudwatch issues.

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -617,7 +617,7 @@ func unknownExposureMessage(risk configv1.ConditionalUpdateRisk, err error) stri
 	template := `Could not evaluate exposure to update risk %s (%v)
   %s description: %s
   %s URL: %s`
-	return fmt.Sprintf(template, risk.Name, err, risk.Name, risk.Message, risk.Name, risk.URL)
+	return fmt.Sprintf(template, risk.Name, err, risk.Name, strings.TrimSpace(risk.Message), risk.Name, risk.URL)
 }
 
 func newRecommendedStatus(now, want metav1.ConditionStatus) metav1.ConditionStatus {

--- a/pkg/cvo/availableupdates_test.go
+++ b/pkg/cvo/availableupdates_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -914,6 +915,24 @@ func Test_loadRiskConditions(t *testing.T) {
 				t.Errorf("%s: loadRiskConditions() mismatch (-want +got):\n%s", tt.name, diff)
 			}
 		})
+	}
+}
+
+func Test_unknownExposureMessage_trims_trailing_newline(t *testing.T) {
+	risk := configv1.ConditionalUpdateRisk{
+		Name:    "TestRisk",
+		Message: "Risk description with trailing newline\n",
+		URL:     "https://example.com/issue",
+	}
+	got := unknownExposureMessage(risk, errors.New("thanos-querier not found"))
+	if strings.Contains(got, "\n\n") {
+		t.Errorf("unknownExposureMessage() should not produce empty lines, got:\n%s", got)
+	}
+	expected := "Could not evaluate exposure to update risk TestRisk (thanos-querier not found)\n" +
+		"  TestRisk description: Risk description with trailing newline\n" +
+		"  TestRisk URL: https://example.com/issue"
+	if got != expected {
+		t.Errorf("unknownExposureMessage() produced unexpected output:\ngot:\n%q\nexpected:\n%q", got, expected)
 	}
 }
 


### PR DESCRIPTION
Trim a new line character from risk.Message entries that result in an empty line in the logs. This is causing issues for Rosa Log Router because cloudwatch does not allow empty log entries.

Added a string trim and a new test to ensure it works as expected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved risk-related error messages by removing unnecessary surrounding whitespace and trailing blank lines.
  * Ensured error details display cleanly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->