### PR TITLE
OCPBUGS-54864: reduce verbosity of skipping metrics log messages

### DIFF
--- a/pkg/cvo/metrics.go
+++ b/pkg/cvo/metrics.go
@@ -662,7 +662,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 
 		for _, condition := range cv.Status.Conditions {
 			if condition.Status != configv1.ConditionFalse && condition.Status != configv1.ConditionTrue {
-				klog.V(2).Infof("skipping metrics for ClusterVersion condition %s=%s (neither True nor False)", condition.Type, condition.Status)
+				klog.V(4).Infof("skipping metrics for ClusterVersion condition %s=%s (neither True nor False)", condition.Type, condition.Status)
 				continue
 			}
 
@@ -725,7 +725,7 @@ func (m *operatorMetrics) Collect(ch chan<- prometheus.Metric) {
 		ch <- g
 		for _, condition := range op.Status.Conditions {
 			if condition.Status != configv1.ConditionFalse && condition.Status != configv1.ConditionTrue {
-				klog.V(2).Infof("skipping metrics for %s ClusterOperator condition %s=%s (neither True nor False)", op.Name, condition.Type, condition.Status)
+				klog.V(4).Infof("skipping metrics for %s ClusterOperator condition %s=%s (neither True nor False)", op.Name, condition.Type, condition.Status)
 				continue
 			}
 			g := m.clusterOperatorConditions.WithLabelValues(op.Name, string(condition.Type), string(condition.Reason))


### PR DESCRIPTION
## Bug

https://redhat.atlassian.net/browse/OCPBUGS-54864

The CVO pod logs excessive "skipping metrics" messages on healthy clusters. The "skipping metrics for ... ClusterOperator condition ...=Unknown (neither True nor False)" message fires on every Prometheus scrape (~30s) for every ClusterOperator condition that is Unknown, producing 61,919+ log lines per day on a fresh 4.17.z cluster.

## Root Cause

The log uses klog.V(2), but CVO runs with --v=2 in production, so these messages always appear. Since Unknown is a normal condition state (not an error), this is purely diagnostic noise.

## Fix

Change klog.V(2) to klog.V(4) for both "skipping metrics" log lines in pkg/cvo/metrics.go:
- Line 665: ClusterVersion conditions
- Line 728: ClusterOperator conditions

This keeps the log available for debugging (at --v=4) but silences it in production (--v=2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased diagnostic logging detail for skipped non-boolean cluster conditions.
  * Metric behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->