### PR TITLE
OCPBUGS-39539: clear rogue controller ownerReferences during merge

### DIFF
--- a/lib/resourcemerge/meta.go
+++ b/lib/resourcemerge/meta.go
@@ -73,4 +73,23 @@ func mergeOwnerRefs(modified *bool, existing *[]metav1.OwnerReference, required 
 			*existing = append(*existing, required[ridx])
 		}
 	}
+
+	// If a required ref claims Controller=true, clear Controller on any
+	// existing refs not in the required set to avoid the API server
+	// rejecting the update with "only one reference can have Controller
+	// set to true".
+	for ridx := range required {
+		if required[ridx].Controller == nil || !*required[ridx].Controller {
+			continue
+		}
+		for eidx := range *existing {
+			if (*existing)[eidx].UID == required[ridx].UID {
+				continue
+			}
+			if (*existing)[eidx].Controller != nil && *(*existing)[eidx].Controller {
+				*modified = true
+				(*existing)[eidx].Controller = nil
+			}
+		}
+	}
 }

--- a/lib/resourcemerge/meta_test.go
+++ b/lib/resourcemerge/meta_test.go
@@ -100,6 +100,52 @@ func TestMergeOwnerRefs(t *testing.T) {
 			Controller: ptr.To(true),
 			UID:        types.UID("uid-1"),
 		}},
+	}, {
+		// Rogue controller ref on existing should be cleared when
+		// a required ref claims Controller=true (OCPBUGS-39539).
+		existing: []metav1.OwnerReference{{
+			Kind:       "ClusterServiceVersion",
+			Name:       "rogue-operator.1.0.0",
+			Controller: ptr.To(true),
+			UID:        types.UID("uid-rogue"),
+		}},
+		input: []metav1.OwnerReference{{
+			Kind:       "ClusterVersion",
+			Name:       "version",
+			Controller: ptr.To(true),
+			UID:        types.UID("uid-cv"),
+		}},
+
+		expectedModified: true,
+		expected: []metav1.OwnerReference{{
+			Kind: "ClusterServiceVersion",
+			Name: "rogue-operator.1.0.0",
+			UID:  types.UID("uid-rogue"),
+		}, {
+			Kind:       "ClusterVersion",
+			Name:       "version",
+			Controller: ptr.To(true),
+			UID:        types.UID("uid-cv"),
+		}},
+	}, {
+		// Non-controller existing ref should not be modified.
+		existing: []metav1.OwnerReference{{
+			Kind: "SomeOther",
+			UID:  types.UID("uid-other"),
+		}},
+		input: []metav1.OwnerReference{{
+			Controller: ptr.To(true),
+			UID:        types.UID("uid-cv"),
+		}},
+
+		expectedModified: true,
+		expected: []metav1.OwnerReference{{
+			Kind: "SomeOther",
+			UID:  types.UID("uid-other"),
+		}, {
+			Controller: ptr.To(true),
+			UID:        types.UID("uid-cv"),
+		}},
 	}}
 
 	for idx, test := range tests {


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-39539](https://redhat.atlassian.net/browse/OCPBUGS-39539): CVO wedges with `Failing=True` when reconciling a CRD that has a rogue `ownerReference` with `controller: true` set by another operator (e.g. OLM).

The Kubernetes API rejects updates when two ownerReferences both claim `controller: true`. The `mergeOwnerRefs` function was additive-only — it never cleared conflicting controller flags on existing refs, so the rogue ref persisted alongside CVO's own controller ref, causing the update to fail indefinitely.

This fix adds a post-merge pass: when a required ownerReference has `Controller=true`, any existing ownerReference (not in the required set) that also has `Controller=true` gets its `Controller` field cleared. The rogue reference itself is preserved — only its controller claim is demoted.

## Test plan

- [x] Added unit test: rogue `Controller=true` ref is cleared when CVO's required ref claims controller
- [x] Added unit test: existing refs without `Controller` are left untouched
- [x] All existing `TestMergeOwnerRefs` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resources from retaining multiple controller references during metadata merging.
  * Existing controller references are cleared when a new required controller reference is added.
  * Non-controller owner references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->