### PR TITLE
OCPBUGS-110322: pkg/agenticrun/controller: Pivot to cluster-update-advisor directory

### DIFF
--- a/pkg/agenticrun/controller.go
+++ b/pkg/agenticrun/controller.go
@@ -455,7 +455,7 @@ func getAgenticRun(namespace, currentVersion, targetVersion, channel, updateKind
 					{
 						Image: skillsImage,
 						Paths: []string{
-							"/skills/cluster-update/update-advisor",
+							"/skills/cluster-update/cluster-update-advisor",
 							"/skills/cluster-update/product-lifecycle",
 						},
 					},

--- a/pkg/agenticrun/controller_test.go
+++ b/pkg/agenticrun/controller_test.go
@@ -104,7 +104,7 @@ Update path: Recommended
 										{
 											Image: "registry.example.com/agentic-skills:latest",
 											Paths: []string{
-												"/skills/cluster-update/update-advisor",
+												"/skills/cluster-update/cluster-update-advisor",
 												"/skills/cluster-update/product-lifecycle",
 											},
 										},
@@ -778,7 +778,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -827,7 +827,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -885,7 +885,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -927,7 +927,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -974,7 +974,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -1021,7 +1021,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},


### PR DESCRIPTION
Catch up with openshift/agentic-skills@9d6d4b97c2 (openshift/agentic-skills#47).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AgenticRun skills configuration to use the correct `cluster-update-advisor` skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->