### PR TITLE
NO-JIRA: Updated cluster update advisor skill directory references

### DIFF
--- a/pkg/agenticrun/controller.go
+++ b/pkg/agenticrun/controller.go
@@ -36,7 +36,7 @@ var prompt string = `You are an OpenShift upgrade advisor. Analyze the cluster r
 
 The request contains a "Cluster Readiness Data" section with a JSON block. This was collected by the Cluster Version Operator — do not re-collect it. Parse the JSON, evaluate each check's results, and classify findings as blockers, warnings, or informational.
 
-Use the update-advisor skill for the decision framework and blocker classification rules. When findings need deeper investigation, use prometheus metrics and product-lifecycle skills.
+Use the cluster-update-advisor skill for the decision framework and blocker classification rules. When findings need deeper investigation, use prometheus metrics and product-lifecycle skills.
 
 When the readiness data includes olm_operator_lifecycle results, use the product-lifecycle skill to cross-reference each operator's package name against the Red Hat Product Life Cycle API. Report support phase, EOL dates, and OCP compatibility from Product Lifecycle alongside the OLM data.
 
@@ -455,7 +455,7 @@ func getAgenticRun(namespace, currentVersion, targetVersion, channel, updateKind
 					{
 						Image: skillsImage,
 						Paths: []string{
-							"/skills/cluster-update/update-advisor",
+							"/skills/cluster-update/cluster-update-advisor",
 							"/skills/cluster-update/product-lifecycle",
 						},
 					},

--- a/pkg/agenticrun/controller_test.go
+++ b/pkg/agenticrun/controller_test.go
@@ -104,7 +104,7 @@ Update path: Recommended
 										{
 											Image: "registry.example.com/agentic-skills:latest",
 											Paths: []string{
-												"/skills/cluster-update/update-advisor",
+												"/skills/cluster-update/cluster-update-advisor",
 												"/skills/cluster-update/product-lifecycle",
 											},
 										},
@@ -778,7 +778,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -827,7 +827,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -885,7 +885,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -927,7 +927,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -974,7 +974,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},
@@ -1021,7 +1021,7 @@ Other recommended versions available:
 								{
 									Image: "registry.example.com/agentic-skills:latest",
 									Paths: []string{
-										"/skills/cluster-update/update-advisor",
+										"/skills/cluster-update/cluster-update-advisor",
 										"/skills/cluster-update/product-lifecycle",
 									},
 								},


### PR DESCRIPTION
Update references for the Cluster Update Advisor skill directory on agenticrun controller from `/skills/cluster-update/update-advisor` to `/skills/cluster-update/cluster-update-advisor` in order to match the current skill folder location on agentic-skills, just updated by https://github.com/openshift/agentic-skills/pull/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the upgrade advisor skill reference to use the correct `cluster-update-advisor` path.
  - Improved consistency in upgrade guidance shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->