### PR TITLE
OTA-2108: restrict console plugin NetworkPolicy to openshift-console namespace

### DIFF
--- a/pkg/agenticrun/bindata/assets/networkpolicy-allow-console.yaml
+++ b/pkg/agenticrun/bindata/assets/networkpolicy-allow-console.yaml
@@ -10,7 +10,11 @@ spec:
     matchLabels:
       app: cluster-update-console-plugin
   ingress:
-  - ports:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-console
+    ports:
     - port: 9001
       protocol: TCP
   policyTypes:


### PR DESCRIPTION
## Summary
- The `allow-console-ingress` NetworkPolicy opened port 9001/TCP to any pod in the cluster,
  despite the annotation stating it allows ingress "from the console" only.
- Added a `from: namespaceSelector` matching `kubernetes.io/metadata.name: openshift-console`
  to enforce least-privilege networking and align the policy with its stated intent.

Fixes https://redhat.atlassian.net/browse/OTA-2108

## Test plan
- [x] Unit tests pass (`gotestsum --packages="./pkg/agenticrun/..."` — 49 tests)
- [ ] Deploy to a test cluster and verify the console plugin remains accessible from the OpenShift console
- [ ] Verify that pods in other namespaces can no longer reach port 9001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow incoming traffic only from the OpenShift Console namespace.
  * Continued allowing TCP traffic on port 9001.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->