### PR TITLE
OTA-2110: remove cluster_id from LLM-bound readiness payload

### DIFF
--- a/pkg/readiness/checks_test.go
+++ b/pkg/readiness/checks_test.go
@@ -473,10 +473,6 @@ func TestClusterConditionsCheck(t *testing.T) {
 	if result["channel"] != "stable-4.21" {
 		t.Errorf("channel = %v, want stable-4.21", result["channel"])
 	}
-	if result["cluster_id"] != "test-cluster-id-123" {
-		t.Errorf("cluster_id = %v, want test-cluster-id-123", result["cluster_id"])
-	}
-
 	history, ok := result["recent_history"].([]map[string]any)
 	if !ok {
 		t.Fatal("recent_history not a slice")

--- a/pkg/readiness/cluster_conditions.go
+++ b/pkg/readiness/cluster_conditions.go
@@ -82,9 +82,7 @@ func (c *ClusterConditionsCheck) Run(ctx context.Context, dc dynamic.Interface, 
 	}
 	result["recent_history"] = historyEntries
 
-	// Channel and cluster identity
 	result["channel"] = NestedString(cv.Object, "spec", "channel")
-	result["cluster_id"] = NestedString(cv.Object, "spec", "clusterID")
 
 	return result, nil
 }

--- a/test/cvo/readiness.go
+++ b/test/cvo/readiness.go
@@ -224,8 +224,6 @@ var _ = g.Describe(`[Jira:"Cluster Version Operator"] cluster-version-operator r
 		o.Expect(result.Status).To(o.Equal("ok"))
 		o.Expect(result.Data["channel"]).To(o.Equal(cv.Spec.Channel),
 			"channel should match ClusterVersion spec")
-		o.Expect(result.Data["cluster_id"]).To(o.Equal(string(cv.Spec.ClusterID)),
-			"cluster ID should match ClusterVersion spec")
 	})
 
 	g.It("should complete all checks within 60 seconds", func() {


### PR DESCRIPTION
## Summary
- Remove `cluster_id` (spec.clusterID) from the readiness JSON sent to the LLM in agentic runs
- The cluster UUID adds no analytical value for upgrade risk assessment but creates an unnecessary correlation surface at the LLM provider
- The identifier remains available in CR metadata for audit purposes

## References
- Fixes: https://redhat.atlassian.net/browse/OTA-2110
- Source: Security Architecture Review (SAR) — Agentic Updates OLS 2.0

## Test plan
- [x] `go test ./pkg/readiness/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Readiness results no longer include the internal cluster identifier.
- Cluster readiness information continues to report the release channel correctly.
- Cluster condition reporting now reflects progressing and upgradeable status more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->