### PR TITLE
OTA-2111: set readOnlyRootFilesystem on console plugin container

### DIFF
--- a/pkg/agenticrun/bindata/assets/deployment.yaml
+++ b/pkg/agenticrun/bindata/assets/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/cert
@@ -49,6 +50,14 @@ spec:
           name: nginx-conf
           readOnly: true
           subPath: nginx.conf
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /var/cache/nginx
+          name: cache-nginx
+        - mountPath: /var/lib/nginx/tmp
+          name: lib-nginx-tmp
+        - mountPath: /run
+          name: run
       dnsPolicy: ClusterFirst
       hostUsers: false
       nodeSelector:
@@ -72,3 +81,11 @@ spec:
         configMap:
           name: cluster-update-console-plugin
           defaultMode: 420
+      - name: tmp
+        emptyDir: {}
+      - name: cache-nginx
+        emptyDir: {}
+      - name: lib-nginx-tmp
+        emptyDir: {}
+      - name: run
+        emptyDir: {}


### PR DESCRIPTION
## Summary
- Adds `readOnlyRootFilesystem: true` to the console plugin container's `securityContext`
- Mounts `emptyDir` volumes for `/tmp`, `/var/cache/nginx`, and `/run` — the paths nginx needs at runtime
- Aligns with existing hardening in the CVO deployment and bootstrap pod, which already set this field

## References
- Jira: https://redhat.atlassian.net/browse/OTA-2111

## Test plan
- [x] YAML validates without errors
- [x] Volume names match between `volumeMounts` and `volumes`
- [x] All 1114 unit tests pass (`make test`)
- [ ] Deploy to a test cluster and verify the console plugin pod starts and serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Enhanced plugin container security by using a read-only root filesystem.
  * Added required temporary writable storage for reliable nginx operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->