### PR TITLE
OCPBUGS-122168: pkg/readiness/cluster_conditions: Conditionally include Upgradeable

### DIFF
--- a/pkg/readiness/checks_test.go
+++ b/pkg/readiness/checks_test.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func newFakeDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
@@ -474,17 +476,6 @@ func TestClusterConditionsCheck(t *testing.T) {
 	if result["cluster_id"] != "test-cluster-id-123" {
 		t.Errorf("cluster_id = %v, want test-cluster-id-123", result["cluster_id"])
 	}
-	if result["update_in_progress"] != false {
-		t.Errorf("update_in_progress = %v, want false", result["update_in_progress"])
-	}
-
-	upgradeable, ok := result["upgradeable"].(map[string]any)
-	if !ok {
-		t.Fatal("upgradeable not a map")
-	}
-	if upgradeable["status"] != "True" {
-		t.Errorf("upgradeable.status = %v, want True", upgradeable["status"])
-	}
 
 	history, ok := result["recent_history"].([]map[string]any)
 	if !ok {
@@ -495,17 +486,6 @@ func TestClusterConditionsCheck(t *testing.T) {
 	}
 	if history[0]["version"] != "4.21.5" {
 		t.Errorf("history[0].version = %v, want 4.21.5", history[0]["version"])
-	}
-
-	summary, ok := result["summary"].(map[string]any)
-	if !ok {
-		t.Fatal("summary not a map")
-	}
-	if summary["upgradeable"] != true {
-		t.Errorf("summary.upgradeable = %v, want true", summary["upgradeable"])
-	}
-	if summary["update_in_progress"] != false {
-		t.Errorf("summary.update_in_progress = %v, want false", summary["update_in_progress"])
 	}
 }
 
@@ -526,18 +506,30 @@ func TestClusterConditionsCheck_ProgressingTrue(t *testing.T) {
 	client := newFakeDynamicClient(cv)
 	check := &ClusterConditionsCheck{}
 
-	result, err := check.Run(context.Background(), client, "4.21.5", "4.21.8")
+	result, err := check.Run(context.Background(), client, "4.21.5", "4.22.8")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if result["update_in_progress"] != true {
-		t.Errorf("update_in_progress = %v, want true", result["update_in_progress"])
+	conditions, ok := result["conditions"].(map[string]any)
+	if !ok {
+		t.Fatalf("conditions not a map: %v", result)
 	}
 
-	summary := result["summary"].(map[string]any)
-	if summary["upgradeable"] != false {
-		t.Errorf("summary.upgradeable = %v, want false", summary["upgradeable"])
+	progressing, ok := conditions[string(configv1.OperatorProgressing)].(Condition)
+	if !ok {
+		t.Fatalf("conditions[%v] not a condition: %v", configv1.OperatorProgressing, conditions)
+	}
+	if progressing.Status != ConditionTrue {
+		t.Fatalf("conditions[%v].status not %q: %q", configv1.OperatorProgressing, ConditionTrue, progressing.Status)
+	}
+
+	upgradeable, ok := conditions[string(configv1.OperatorUpgradeable)].(Condition)
+	if !ok {
+		t.Fatalf("conditions[%v] not a condition: %v", configv1.OperatorUpgradeable, conditions)
+	}
+	if upgradeable.Status != ConditionFalse {
+		t.Fatalf("conditions[%v].status not %q: %q", configv1.OperatorUpgradeable, ConditionFalse, upgradeable.Status)
 	}
 }
 

--- a/pkg/readiness/client.go
+++ b/pkg/readiness/client.go
@@ -77,7 +77,6 @@ func ListAllNamespacedResources(ctx context.Context, c dynamic.Interface, gvr sc
 	return ListResources(ctx, c, gvr, labelSelector)
 }
 
-// Condition represents a parsed Kubernetes status condition.
 type Condition struct {
 	Status         string `json:"status"`
 	Reason         string `json:"reason"`
@@ -145,7 +144,6 @@ const (
 const (
 	ConditionAvailable   = "Available"
 	ConditionDegraded    = "Degraded"
-	ConditionProgressing = "Progressing"
 	ConditionUpgradeable = "Upgradeable"
 	ConditionUpdating    = "Updating"
 	ConditionRecommended = "Recommended"

--- a/pkg/readiness/cluster_conditions.go
+++ b/pkg/readiness/cluster_conditions.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver/v4"
+
 	"k8s.io/client-go/dynamic"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/cluster-version-operator/pkg/internal"
 )
 
 // ClusterConditionsCheck reads existing CVO-computed conditions from ClusterVersion status.
 // This does NOT re-evaluate anything — it reports what CVO has already determined,
-// including Upgradeable sub-conditions, RetrievedUpdates, and precondition state.
-type ClusterConditionsCheck struct{}
+// including Upgradeable, Progressing, and Failing conditions.
+type ClusterConditionsCheck struct {
+}
 
 func (c *ClusterConditionsCheck) Name() string { return "cluster_conditions" }
 
@@ -22,25 +29,38 @@ func (c *ClusterConditionsCheck) Run(ctx context.Context, dc dynamic.Interface, 
 		return nil, fmt.Errorf("failed to get ClusterVersion: %w", err)
 	}
 
-	// Read all conditions CVO has already set
 	conditions := GetConditions(cv)
 	condMap := map[string]any{}
-	for k, v := range conditions {
-		v.Message = truncateMessage(v.Message)
-		condMap[k] = v
+
+	for _, key := range []configv1.ClusterStatusConditionType{
+		configv1.OperatorAvailable,
+		configv1.OperatorProgressing,
+		internal.ClusterStatusFailing,
+	} {
+		if v, ok := conditions[string(key)]; ok {
+			v.Message = truncateMessage(v.Message)
+			condMap[string(key)] = v
+		}
 	}
+
+	// slim version of the pkg/payload/precondition/clusterversion/upgradeable.go logic
+	currentVersion, err := semver.Parse(current)
+	if err != nil {
+		return nil, fmt.Errorf("current version %q is not a Semantic Version: %w", current, err)
+	}
+	targetVersion, err := semver.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("target version %q is not a Semantic Version: %w", target, err)
+	}
+	patchOnly := targetVersion.Major == currentVersion.Major && targetVersion.Minor == currentVersion.Minor
+	if targetVersion.GTE(currentVersion) && !patchOnly {
+		if v, ok := conditions[string(configv1.OperatorUpgradeable)]; ok {
+			v.Message = truncateMessage(v.Message)
+			condMap[string(configv1.OperatorUpgradeable)] = v
+		}
+	}
+
 	result["conditions"] = condMap
-
-	// Extract key signals for the agent
-	upgradeable := conditions[ConditionUpgradeable]
-	result["upgradeable"] = map[string]any{
-		"status":  upgradeable.Status,
-		"reason":  upgradeable.Reason,
-		"message": truncateMessage(upgradeable.Message),
-	}
-
-	progressing := conditions[ConditionProgressing]
-	result["update_in_progress"] = progressing.Status == ConditionTrue
 
 	// Read update history for context
 	history := NestedSlice(cv.Object, "status", "history")
@@ -65,13 +85,6 @@ func (c *ClusterConditionsCheck) Run(ctx context.Context, dc dynamic.Interface, 
 	// Channel and cluster identity
 	result["channel"] = NestedString(cv.Object, "spec", "channel")
 	result["cluster_id"] = NestedString(cv.Object, "spec", "clusterID")
-
-	// Summary for quick agent parsing
-	result["summary"] = map[string]any{
-		"upgradeable":        upgradeable.Status == ConditionTrue,
-		"update_in_progress": progressing.Status == ConditionTrue,
-		"current_version":    current,
-	}
 
 	return result, nil
 }


### PR DESCRIPTION
Since 6f8f984547 (#1314), `Upgradeable` has no impact on patch releases.  This commit makes the inclusion of that data in the AgenticRun prompt more intentional, to avoid confusion like a recent test that showed:

> Cluster Conditions: fail: ClusterVersion readiness data reports `upgradeable=false`, so the update should not proceed...

for a 5.0.0-ec.6 to mock 5.0.1 update, where the `Upgradeable` condition was unrelated to that 5.0.1 transition.  And in fact, the thing that tripped up the AI seems to have been the `summary` entry, because it said:

> The readiness JSON summary explicitly reports `upgradeable=false` while no reason or message is populated...

I'm also dropping the entire `summary` section, because the data in that section seemed unusably terse, and having a summary doesn't save you parsing effort if you have to read through the detail section to understand what to do about anything summary is telling you anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cluster readiness checks now report clear availability, progress, and failure conditions.
  * Upgradeability status is included only for eligible non-patch version targets.
  * Current and target versions are validated before readiness results are generated.
  * Legacy summary, update-in-progress, and top-level upgradeability fields have been removed from readiness results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->