### PR TITLE
OCPBUGS-74520: Remove UpgradeStatus featuregate

### DIFF
--- a/pkg/featuregates/featurechangestopper_test.go
+++ b/pkg/featuregates/featurechangestopper_test.go
@@ -67,7 +67,7 @@ func TestTechPreviewChangeStopper(t *testing.T) {
 				FeatureGates: []configv1.FeatureGateDetails{
 					{
 						Version: versionForGates,
-						Enabled: []configv1.FeatureGateAttributes{{Name: features.FeatureGateUpgradeStatus}},
+						Enabled: []configv1.FeatureGateAttributes{{Name: features.FeatureGateCVOConfiguration}},
 					},
 				},
 			},


### PR DESCRIPTION
## What this PR does

Removes the last non-vendored reference to the `UpgradeStatus` feature gate from the Cluster Version Operator, as tracked by [OCPBUGS-74520](https://issues.redhat.com/browse/OCPBUGS-74520).

The `UpgradeStatus` gate has been enabled by default since 4.21 (or prior) and has graduated. Per the OCP feature gate lifecycle policy, GA'd gates should be removed to avoid accumulating tech debt. Removal is a two-step, cross-repo effort:

1. **This PR** — drop all references to the gate from the CVO component.
2. **Follow-up** — remove the gate definition from `features/features.go` in `openshift/api` (can only merge once every consumer has stopped referencing it), followed by a revendor here.

## The change

The only non-vendored reference in this repo is in `pkg/featuregates/featurechangestopper_test.go`, where `features.FeatureGateUpgradeStatus` was used purely as an arbitrary *enabled* gate inside fabricated `FeatureGateStatus` test data for the `TestTechPreviewChangeStopper` "cvo flags changed" case. The specific gate name does not affect the assertion (shutdown is driven by the `CvoGates` comparison).

It is replaced with `features.FeatureGateCVOConfiguration` (`ClusterVersionOperatorConfiguration`) — another CVO-owned gate that is **not** in the legacy-gate removal list — so the test stays topical to the component.

The vendored copies under `vendor/github.com/openshift/api/` are intentionally left untouched; they will update via revendor after the `openshift/api` PR merges.

> `TestTechPreviewChangeStopper` is a Go unit test, not a component-readiness e2e test whose title carries the gate name, so the "do not rename component-readiness tests" guidance from the bug does not apply here.

## Testing

```
$ go build ./pkg/featuregates/...
$ go test ./pkg/featuregates/...
ok  	github.com/openshift/cluster-version-operator/pkg/featuregates
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-74520`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated feature-gate validation coverage to reflect the correct enabled configuration gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->