### PR TITLE
OCPBUGS-8252: pkg/cvo report unavailable multi-arch transitions

### DIFF
--- a/pkg/cvo/cvo.go
+++ b/pkg/cvo/cvo.go
@@ -837,7 +837,7 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 	config := validation.ClearInvalidFields(original, errs)
 
 	// identify the desired next version
-	desired, found := findUpdateFromConfig(config, optr.release.Architecture)
+	desired, found, selectionErr := findUpdateFromConfig(config, optr.release.Architecture)
 	initialized := optr.configSync.Initialized()
 	if found && initialized {
 		klog.V(2).Infof("Desired version from spec is %#v after initialization", desired)
@@ -881,6 +881,19 @@ func (optr *Operator) sync(ctx context.Context, key string) error {
 
 	// inform the config sync loop about our desired state
 	status := optr.configSync.Update(ctx, config.Generation, desired, config, state, optr.getEnabledFeatureGates())
+
+	// surface the multi-arch transition failure through the existing status/condition path
+	if selectionErr != nil && initialized {
+		updateErr, _ := selectionErr.(*payload.UpdateError)
+		if updateErr != nil {
+			status.loadPayloadStatus = LoadPayloadStatus{
+				Step:    updateErr.Reason,
+				Message: updateErr.Message,
+				Failure: updateErr,
+				Update:  *config.Spec.DesiredUpdate,
+			}
+		}
+	}
 
 	// write cluster version status
 	return optr.syncStatus(ctx, original, config, status, errs)

--- a/pkg/cvo/cvo_test.go
+++ b/pkg/cvo/cvo_test.go
@@ -2297,6 +2297,131 @@ func TestOperator_sync(t *testing.T) {
 	}
 }
 
+// TestOperator_sync_multiArchTransitionUnavailable verifies that an unavailable single-to-multi transition produces ReleaseAccepted=False.
+func TestOperator_sync_multiArchTransitionUnavailable(t *testing.T) {
+	id := uuid.Must(uuid.NewRandom()).String()
+
+	optr := &Operator{
+		release: configv1.Release{
+			Version: "4.15.0",
+			Image:   "image/image:v4.15.0",
+		},
+		namespace: "test",
+		name:      "default",
+		client: fakeClientsetWithUpdates(
+			&configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "default",
+					ResourceVersion: "1",
+					UID:             types.UID(id),
+				},
+				Spec: configv1.ClusterVersionSpec{
+					ClusterID: configv1.ClusterID(id),
+					Channel:   "stable-4.15",
+					DesiredUpdate: &configv1.Update{
+						Architecture: configv1.ClusterVersionArchitectureMulti,
+						Version:      "",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired:          configv1.Release{Version: "4.15.0", Image: "image/image:v4.15.0"},
+					AvailableUpdates: nil,
+					History: []configv1.UpdateHistory{
+						{State: configv1.CompletedUpdate, Version: "4.15.0", Image: "image/image:v4.15.0", StartedTime: defaultStartedTime, CompletionTime: &defaultCompletionTime},
+					},
+					Conditions: []configv1.ClusterOperatorStatusCondition{
+						{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+						{Type: configv1.OperatorProgressing, Status: configv1.ConditionFalse},
+						{Type: configv1.RetrievedUpdates, Status: configv1.ConditionFalse},
+					},
+				},
+			},
+		),
+		configSync: &fakeSyncRecorder{
+			Returns: &SyncWorkerStatus{
+				Reconciling: true,
+				Completed:   1,
+				Actual:      configv1.Release{Version: "4.15.0", Image: "image/image:v4.15.0"},
+			},
+		},
+	}
+
+	optr.queue = workqueue.NewTypedRateLimitingQueue[any](workqueue.DefaultTypedControllerRateLimiter[any]())
+	optr.proxyLister = &clientProxyLister{client: optr.client}
+	optr.cvLister = &clientCVLister{client: optr.client}
+	optr.coLister = &clientCOLister{client: optr.client}
+	optr.eventRecorder = record.NewFakeRecorder(100)
+	optr.enabledCVOFeatureGates = featuregates.DefaultCvoGates("version")
+	registry := clusterconditions.NewConditionRegistry()
+	registry.Register("Always", &always.Always{})
+	optr.conditionRegistry = registry
+
+	ctx := context.Background()
+	err := optr.sync(ctx, optr.queueKey())
+	if err != nil {
+		t.Fatalf("Operator.sync() unexpected error: %v", err)
+	}
+
+	// verify the worker received the current release fallback, not a fabricated multi-arch image
+	actual := optr.configSync.(*fakeSyncRecorder).Updates
+	expectedSync := []configv1.Update{
+		{Version: "4.15.0", Image: "image/image:v4.15.0"},
+	}
+	if !reflect.DeepEqual(expectedSync, actual) {
+		t.Fatalf("expected sync worker to receive current release fallback %#v, got %#v", expectedSync, actual)
+	}
+
+	// extract the status update action
+	f := optr.client.(*fake.Clientset)
+	act := f.Actions()
+	var statusUpdate *configv1.ClusterVersion
+	for _, a := range act {
+		if a.GetVerb() == "update" && a.GetSubresource() == "status" {
+			statusUpdate = a.(ktesting.UpdateAction).GetObject().(*configv1.ClusterVersion)
+		}
+	}
+	if statusUpdate == nil {
+		t.Fatal("expected a status update action")
+	}
+
+	// verify ReleaseAccepted=False with the correct reason
+	var releaseAccepted *configv1.ClusterOperatorStatusCondition
+	for i := range statusUpdate.Status.Conditions {
+		if statusUpdate.Status.Conditions[i].Type == internal.ReleaseAccepted {
+			releaseAccepted = &statusUpdate.Status.Conditions[i]
+			break
+		}
+	}
+	if releaseAccepted == nil {
+		t.Fatal("expected ReleaseAccepted condition to be set")
+	}
+	if releaseAccepted.Status != configv1.ConditionFalse {
+		t.Errorf("expected ReleaseAccepted status %q, got %q", configv1.ConditionFalse, releaseAccepted.Status)
+	}
+	if releaseAccepted.Reason != "MultiArchTransitionUnavailable" {
+		t.Errorf("expected ReleaseAccepted reason %q, got %q", "MultiArchTransitionUnavailable", releaseAccepted.Reason)
+	}
+	if releaseAccepted.Message == "" {
+		t.Error("expected non-empty ReleaseAccepted message")
+	}
+
+	// verify Failing is NOT set to True by this condition-only path
+	for _, cond := range statusUpdate.Status.Conditions {
+		if cond.Type == internal.ClusterStatusFailing && cond.Status == configv1.ConditionTrue {
+			t.Error("expected Failing condition to not be set to True for this status-only path")
+		}
+	}
+
+	// verify spec.desiredUpdate is not rewritten
+	if statusUpdate.Spec.DesiredUpdate == nil {
+		t.Fatal("expected spec.desiredUpdate to remain set")
+	}
+	if statusUpdate.Spec.DesiredUpdate.Architecture != configv1.ClusterVersionArchitectureMulti {
+		t.Errorf("expected spec.desiredUpdate.architecture to remain %q, got %q",
+			configv1.ClusterVersionArchitectureMulti, statusUpdate.Spec.DesiredUpdate.Architecture)
+	}
+}
+
 func TestOperator_availableUpdatesSync(t *testing.T) {
 	id := uuid.Must(uuid.NewRandom()).String()
 	tests := []struct {

--- a/pkg/cvo/updatepayload.go
+++ b/pkg/cvo/updatepayload.go
@@ -438,22 +438,31 @@ func (r *payloadRetriever) prunePods(ctx context.Context) error {
 // the desired architecture is changed to multi it resolves the payload using the current
 // version since that's the only valid available update. Otherwise it attempts to resolve
 // the payload using the specified desired version.
-func findUpdateFromConfig(config *configv1.ClusterVersion, currentArch configv1.ClusterVersionArchitecture) (configv1.Update, bool) {
+func findUpdateFromConfig(config *configv1.ClusterVersion, currentArch configv1.ClusterVersionArchitecture) (configv1.Update, bool, error) {
 	update := config.Spec.DesiredUpdate
 	if update == nil {
-		return configv1.Update{}, false
+		return configv1.Update{}, false, nil
 	}
 	if len(update.Image) == 0 {
 		version := update.Version
 
+		isMultiArchTransition := update.Architecture == configv1.ClusterVersionArchitectureMulti &&
+			currentArch != configv1.ClusterVersionArchitectureMulti
+
 		// Architecture changed to multi so only valid update is the multi arch version of current version
-		if update.Architecture == configv1.ClusterVersionArchitectureMulti &&
-			currentArch != configv1.ClusterVersionArchitectureMulti {
+		if isMultiArchTransition {
 			version = config.Status.Desired.Version
 		}
-		return findUpdateFromConfigVersion(config, version, update.Force)
+		resolved, found := findUpdateFromConfigVersion(config, version, update.Force)
+		if !found && isMultiArchTransition {
+			return resolved, found, &payload.UpdateError{
+				Reason:  "MultiArchTransitionUnavailable",
+				Message: fmt.Sprintf("Unable to start multi-architecture transition for version %q: no matching multi-architecture payload is available in status.availableUpdates", version),
+			}
+		}
+		return resolved, found, nil
 	}
-	return *update, true
+	return *update, true, nil
 }
 
 func findUpdateFromConfigVersion(config *configv1.ClusterVersion, version string, force bool) (configv1.Update, bool) {

--- a/pkg/cvo/updatepayload_test.go
+++ b/pkg/cvo/updatepayload_test.go
@@ -345,3 +345,183 @@ func TestPayloadRetrieverRetrievePayload(t *testing.T) {
 		})
 	}
 }
+
+// Test_findUpdateFromConfig verifies desired-update selection for all update paths including multi-arch transitions.
+func Test_findUpdateFromConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *configv1.ClusterVersion
+		currentArch configv1.ClusterVersionArchitecture
+		wantUpdate  configv1.Update
+		wantFound   bool
+		wantErr     string
+	}{
+		{
+			name: "nil desired update",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{},
+			},
+			currentArch: "amd64",
+			wantUpdate:  configv1.Update{},
+			wantFound:   false,
+		},
+		{
+			name: "explicit image returns unchanged",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "4.15.0",
+						Image:   "quay.io/release:4.15.0",
+					},
+				},
+			},
+			currentArch: "amd64",
+			wantUpdate: configv1.Update{
+				Version: "4.15.0",
+				Image:   "quay.io/release:4.15.0",
+			},
+			wantFound: true,
+		},
+		{
+			name: "normal version update found",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "4.16.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					AvailableUpdates: []configv1.Release{
+						{Version: "4.16.0", Image: "quay.io/release:4.16.0"},
+					},
+				},
+			},
+			currentArch: "amd64",
+			wantUpdate: configv1.Update{
+				Version: "4.16.0",
+				Image:   "quay.io/release:4.16.0",
+			},
+			wantFound: true,
+		},
+		{
+			name: "normal version update missing returns not found without error",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "4.16.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					AvailableUpdates: nil,
+				},
+			},
+			currentArch: "amd64",
+			wantUpdate:  configv1.Update{},
+			wantFound:   false,
+		},
+		{
+			name: "single-to-multi with matching current release succeeds",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Architecture: configv1.ClusterVersionArchitectureMulti,
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "4.15.0", Image: "quay.io/release:4.15.0"},
+					AvailableUpdates: []configv1.Release{
+						{Version: "4.15.0", Image: "quay.io/release-multi:4.15.0"},
+					},
+				},
+			},
+			currentArch: "amd64",
+			wantUpdate: configv1.Update{
+				Version: "4.15.0",
+				Image:   "quay.io/release-multi:4.15.0",
+			},
+			wantFound: true,
+		},
+		{
+			name: "single-to-multi with no matching current release returns error",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Architecture: configv1.ClusterVersionArchitectureMulti,
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired:          configv1.Release{Version: "4.15.0", Image: "quay.io/release:4.15.0"},
+					AvailableUpdates: nil,
+				},
+			},
+			currentArch: "amd64",
+			wantUpdate:  configv1.Update{},
+			wantFound:   false,
+			wantErr:     "MultiArchTransitionUnavailable",
+		},
+		{
+			name: "already multi-architecture with normal update follows existing lookup",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version: "4.16.0",
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					AvailableUpdates: []configv1.Release{
+						{Version: "4.16.0", Image: "quay.io/release:4.16.0"},
+					},
+				},
+			},
+			currentArch: configv1.ClusterVersionArchitectureMulti,
+			wantUpdate: configv1.Update{
+				Version: "4.16.0",
+				Image:   "quay.io/release:4.16.0",
+			},
+			wantFound: true,
+		},
+		{
+			name: "already multi-architecture with missing update returns not found without error",
+			config: &configv1.ClusterVersion{
+				Spec: configv1.ClusterVersionSpec{
+					DesiredUpdate: &configv1.Update{
+						Version:      "4.16.0",
+						Architecture: configv1.ClusterVersionArchitectureMulti,
+					},
+				},
+				Status: configv1.ClusterVersionStatus{
+					Desired:          configv1.Release{Version: "4.15.0"},
+					AvailableUpdates: nil,
+				},
+			},
+			currentArch: configv1.ClusterVersionArchitectureMulti,
+			wantUpdate:  configv1.Update{},
+			wantFound:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUpdate, gotFound, gotErr := findUpdateFromConfig(tt.config, tt.currentArch)
+			if gotFound != tt.wantFound {
+				t.Errorf("found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if diff := cmp.Diff(tt.wantUpdate, gotUpdate); diff != "" {
+				t.Errorf("update mismatch (-want +got):\n%s", diff)
+			}
+			if tt.wantErr != "" {
+				if gotErr == nil {
+					t.Fatalf("expected error with reason %q, got nil", tt.wantErr)
+				}
+				updateErr, ok := gotErr.(*payload.UpdateError)
+				if !ok {
+					t.Fatalf("expected *payload.UpdateError, got %T", gotErr)
+				}
+				if updateErr.Reason != tt.wantErr {
+					t.Errorf("error reason = %q, want %q", updateErr.Reason, tt.wantErr)
+				}
+			} else if gotErr != nil {
+				t.Errorf("unexpected error: %v", gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When a single-architecture cluster requests `--to-multi-arch` while CVO has `RetrievedUpdates=False` and no usable multi-architecture payload in `status.availableUpdates`, CVO now sets `ReleaseAccepted=False` with reason `MultiArchTransitionUnavailable` and a message explaining the transition cannot start.
- The existing current-release fallback is preserved so the worker never receives an empty or fabricated payload.
- All existing behavior for nil desired updates, explicit images, ordinary version lookups, successful single-to-multi migrations, and already-multi clusters is unchanged.

## Changes

| File | What |
|------|------|
| `pkg/cvo/updatepayload.go` | `findUpdateFromConfig` returns a typed `*payload.UpdateError` when a single-to-multi transition cannot resolve the current release from `availableUpdates` |
| `pkg/cvo/cvo.go` | `Operator.sync` carries the selection error through `LoadPayloadStatus` so `setReleaseAcceptedCondition` produces `ReleaseAccepted=False` |
| `pkg/cvo/updatepayload_test.go` | 8 table-driven tests for `findUpdateFromConfig` covering all desired-update paths |
| `pkg/cvo/cvo_test.go` | Controller-level regression test proving the fallback, condition, and spec preservation |

## Test plan

- [x] `go test ./pkg/cvo/ -count=1` — all tests pass
- [x] `make format` — no formatting changes
- [x] `make build` — binary builds cleanly
- [x] New `Test_findUpdateFromConfig` covers: nil desired, explicit image, normal found/missing, single-to-multi success/failure, already-multi paths
- [x] New `TestOperator_sync_multiArchTransitionUnavailable` verifies: worker gets current release fallback, `ReleaseAccepted=False` with correct reason/message, `Failing` not set to True, `spec.desiredUpdate` preserved

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-8252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a requested release or architecture transition is unavailable.
  - The cluster now falls back to its current release while preserving the requested update.
  - Status reports the update as not accepted with a clear `DesiredReleaseUnavailable` reason and message, without incorrectly marking the cluster as failing.

- **Tests**
  - Added coverage for unavailable releases, historical versions, and single- to multi-architecture transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->