### PR TITLE
OCPBUGS-122172: pkg/readiness/cluster_conditions: Conditionally include Upgradeable

### DIFF
--- a/pkg/readiness/checks_test.go
+++ b/pkg/readiness/checks_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func newFakeDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
@@ -436,17 +438,6 @@ func TestClusterConditionsCheck(t *testing.T) {
 	if result["cluster_id"] != "test-cluster-id-123" {
 		t.Errorf("cluster_id = %v, want test-cluster-id-123", result["cluster_id"])
 	}
-	if result["update_in_progress"] != false {
-		t.Errorf("update_in_progress = %v, want false", result["update_in_progress"])
-	}
-
-	upgradeable, ok := result["upgradeable"].(map[string]any)
-	if !ok {
-		t.Fatal("upgradeable not a map")
-	}
-	if upgradeable["status"] != "True" {
-		t.Errorf("upgradeable.status = %v, want True", upgradeable["status"])
-	}
 
 	history, ok := result["recent_history"].([]map[string]any)
 	if !ok {
@@ -457,17 +448,6 @@ func TestClusterConditionsCheck(t *testing.T) {
 	}
 	if history[0]["version"] != "4.21.5" {
 		t.Errorf("history[0].version = %v, want 4.21.5", history[0]["version"])
-	}
-
-	summary, ok := result["summary"].(map[string]any)
-	if !ok {
-		t.Fatal("summary not a map")
-	}
-	if summary["upgradeable"] != true {
-		t.Errorf("summary.upgradeable = %v, want true", summary["upgradeable"])
-	}
-	if summary["update_in_progress"] != false {
-		t.Errorf("summary.update_in_progress = %v, want false", summary["update_in_progress"])
 	}
 }
 
@@ -488,18 +468,30 @@ func TestClusterConditionsCheck_ProgressingTrue(t *testing.T) {
 	client := newFakeDynamicClient(cv)
 	check := &ClusterConditionsCheck{}
 
-	result, err := check.Run(context.Background(), client, "4.21.5", "4.21.8")
+	result, err := check.Run(context.Background(), client, "4.21.5", "4.22.8")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if result["update_in_progress"] != true {
-		t.Errorf("update_in_progress = %v, want true", result["update_in_progress"])
+	conditions, ok := result["conditions"].(map[string]any)
+	if !ok {
+		t.Fatalf("conditions not a map: %v", result)
 	}
 
-	summary := result["summary"].(map[string]any)
-	if summary["upgradeable"] != false {
-		t.Errorf("summary.upgradeable = %v, want false", summary["upgradeable"])
+	progressing, ok := conditions[string(configv1.OperatorProgressing)].(Condition)
+	if !ok {
+		t.Fatalf("conditions[%v] not a condition: %v", configv1.OperatorProgressing, conditions)
+	}
+	if progressing.Status != ConditionTrue {
+		t.Fatalf("conditions[%v].status not %q: %q", configv1.OperatorProgressing, ConditionTrue, progressing.Status)
+	}
+
+	upgradeable, ok := conditions[string(configv1.OperatorUpgradeable)].(Condition)
+	if !ok {
+		t.Fatalf("conditions[%v] not a condition: %v", configv1.OperatorUpgradeable, conditions)
+	}
+	if upgradeable.Status != ConditionFalse {
+		t.Fatalf("conditions[%v].status not %q: %q", configv1.OperatorUpgradeable, ConditionFalse, upgradeable.Status)
 	}
 }
 

--- a/pkg/readiness/client.go
+++ b/pkg/readiness/client.go
@@ -77,7 +77,6 @@ func ListAllNamespacedResources(ctx context.Context, c dynamic.Interface, gvr sc
 	return ListResources(ctx, c, gvr, labelSelector)
 }
 
-// Condition represents a parsed Kubernetes status condition.
 type Condition struct {
 	Status         string `json:"status"`
 	Reason         string `json:"reason"`
@@ -145,7 +144,6 @@ const (
 const (
 	ConditionAvailable   = "Available"
 	ConditionDegraded    = "Degraded"
-	ConditionProgressing = "Progressing"
 	ConditionUpgradeable = "Upgradeable"
 	ConditionUpdating    = "Updating"
 	ConditionRecommended = "Recommended"

--- a/pkg/readiness/cluster_conditions.go
+++ b/pkg/readiness/cluster_conditions.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/blang/semver/v4"
+
 	"k8s.io/client-go/dynamic"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/cluster-version-operator/pkg/internal"
 )
 
 // ClusterConditionsCheck reads existing CVO-computed conditions from ClusterVersion status.
 // This does NOT re-evaluate anything — it reports what CVO has already determined,
-// including Upgradeable sub-conditions, RetrievedUpdates, and precondition state.
-type ClusterConditionsCheck struct{}
+// including Upgradeable, Progressing, and Failing conditions.
+type ClusterConditionsCheck struct {
+}
 
 func (c *ClusterConditionsCheck) Name() string { return "cluster_conditions" }
 
@@ -22,24 +29,36 @@ func (c *ClusterConditionsCheck) Run(ctx context.Context, dc dynamic.Interface, 
 		return nil, fmt.Errorf("failed to get ClusterVersion: %w", err)
 	}
 
-	// Read all conditions CVO has already set
 	conditions := GetConditions(cv)
 	condMap := map[string]any{}
-	for k, v := range conditions {
-		condMap[k] = v
+
+	for _, key := range []configv1.ClusterStatusConditionType{
+		configv1.OperatorAvailable,
+		configv1.OperatorProgressing,
+		internal.ClusterStatusFailing,
+	} {
+		if v, ok := conditions[string(key)]; ok {
+			condMap[string(key)] = v
+		}
 	}
+
+	// slim version of the pkg/payload/precondition/clusterversion/upgradeable.go logic
+	currentVersion, err := semver.Parse(current)
+	if err != nil {
+		return nil, fmt.Errorf("current version %q is not a Semantic Version: %w", current, err)
+	}
+	targetVersion, err := semver.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("target version %q is not a Semantic Version: %w", target, err)
+	}
+	patchOnly := targetVersion.Major == currentVersion.Major && targetVersion.Minor == currentVersion.Minor
+	if targetVersion.GTE(currentVersion) && !patchOnly {
+		if v, ok := conditions[string(configv1.OperatorUpgradeable)]; ok {
+			condMap[string(configv1.OperatorUpgradeable)] = v
+		}
+	}
+
 	result["conditions"] = condMap
-
-	// Extract key signals for the agent
-	upgradeable := conditions[ConditionUpgradeable]
-	result["upgradeable"] = map[string]any{
-		"status":  upgradeable.Status,
-		"reason":  upgradeable.Reason,
-		"message": upgradeable.Message,
-	}
-
-	progressing := conditions[ConditionProgressing]
-	result["update_in_progress"] = progressing.Status == ConditionTrue
 
 	// Read update history for context
 	history := NestedSlice(cv.Object, "status", "history")
@@ -64,13 +83,6 @@ func (c *ClusterConditionsCheck) Run(ctx context.Context, dc dynamic.Interface, 
 	// Channel and cluster identity
 	result["channel"] = NestedString(cv.Object, "spec", "channel")
 	result["cluster_id"] = NestedString(cv.Object, "spec", "clusterID")
-
-	// Summary for quick agent parsing
-	result["summary"] = map[string]any{
-		"upgradeable":        upgradeable.Status == ConditionTrue,
-		"update_in_progress": progressing.Status == ConditionTrue,
-		"current_version":    current,
-	}
 
 	return result, nil
 }


### PR DESCRIPTION
Manually rebased from 9c2f489f19 (#1463) back to 5.0, to resolve conflicts due to 5.0 lacking 4c8fa5b29e(#1443).  The diff was just dropping some truncateMessage calls:

```console
$ diff -u0 <(git log --oneline -1 -p origin/pr/1463) <(git log --oneline -1 -p) | grep '^[+-][+-][[:space:]]'
--		v.Message = truncateMessage(v.Message)
-+			v.Message = truncateMessage(v.Message)
--		"message": truncateMessage(upgradeable.Message),
+-		"message": upgradeable.Message,
-+			v.Message = truncateMessage(v.Message)
```