### PR TITLE
OCPBUGS-105406: pkg: Drop conditionals around default-enabled ImageStreamImportMode feature gate

### DIFF
--- a/pkg/cvo/availableupdates.go
+++ b/pkg/cvo/availableupdates.go
@@ -233,7 +233,7 @@ func (u *availableUpdates) RecentlyChanged(interval time.Duration) bool {
 	return u.LastSyncOrConfigChange.After(time.Now().Add(-interval))
 }
 
-func (u *availableUpdates) NeedsUpdate(original *configv1.ClusterVersion, statusReleaseArchitecture bool) *configv1.ClusterVersion {
+func (u *availableUpdates) NeedsUpdate(original *configv1.ClusterVersion) *configv1.ClusterVersion {
 	if u == nil {
 		return nil
 	}
@@ -245,21 +245,8 @@ func (u *availableUpdates) NeedsUpdate(original *configv1.ClusterVersion, status
 	var updates []configv1.Release
 	var conditionalUpdates []configv1.ConditionalUpdate
 
-	if statusReleaseArchitecture {
-		updates = u.Updates
-		conditionalUpdates = u.ConditionalUpdates
-	} else {
-		for _, update := range u.Updates {
-			c := update.DeepCopy()
-			c.Architecture = configv1.ClusterVersionArchitecture("")
-			updates = append(updates, *c)
-		}
-		for _, conditionalUpdate := range u.ConditionalUpdates {
-			c := conditionalUpdate.DeepCopy()
-			c.Release.Architecture = configv1.ClusterVersionArchitecture("")
-			conditionalUpdates = append(conditionalUpdates, *c)
-		}
-	}
+	updates = u.Updates
+	conditionalUpdates = u.ConditionalUpdates
 
 	if equality.Semantic.DeepEqual(updates, original.Status.AvailableUpdates) &&
 		equality.Semantic.DeepEqual(conditionalUpdates, original.Status.ConditionalUpdates) &&

--- a/pkg/cvo/status.go
+++ b/pkg/cvo/status.go
@@ -166,7 +166,7 @@ func (optr *Operator) syncStatus(ctx context.Context, original, config *configv1
 
 	cvUpdated := false
 	// update the config with the latest available updates
-	if updated := optr.getAvailableUpdates().NeedsUpdate(config, optr.enabledCVOFeatureGates.StatusReleaseArchitecture()); updated != nil {
+	if updated := optr.getAvailableUpdates().NeedsUpdate(config); updated != nil {
 		cvUpdated = true
 		config = updated
 	}
@@ -225,9 +225,6 @@ func updateClusterVersionStatus(
 		}
 	}
 	desired := mergeReleaseMetadata(status.Actual, getAvailableUpdates)
-	if !enabledGates.StatusReleaseArchitecture() {
-		desired.Architecture = configv1.ClusterVersionArchitecture("")
-	}
 
 	var riskNamesForDesiredImage []string
 	if shouldReconcileAcceptRisks() {

--- a/pkg/cvo/status_test.go
+++ b/pkg/cvo/status_test.go
@@ -203,11 +203,10 @@ func TestOperator_syncFailingStatus(t *testing.T) {
 }
 
 type fakeRiFlags struct {
-	desiredVersion            string
-	unknownVersion            bool
-	statusReleaseArchitecture bool
-	cvoConfiguration          bool
-	acceptRisks               bool
+	desiredVersion   string
+	unknownVersion   bool
+	cvoConfiguration bool
+	acceptRisks      bool
 }
 
 func (f fakeRiFlags) DesiredVersion() string {
@@ -216,10 +215,6 @@ func (f fakeRiFlags) DesiredVersion() string {
 
 func (f fakeRiFlags) UnknownVersion() bool {
 	return f.unknownVersion
-}
-
-func (f fakeRiFlags) StatusReleaseArchitecture() bool {
-	return f.statusReleaseArchitecture
 }
 
 func (f fakeRiFlags) CVOConfiguration() bool {

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -35,10 +35,6 @@ type CvoGateChecker interface {
 	// to restart when the flags change.
 	UnknownVersion() bool
 
-	// StatusReleaseArchitecture controls whether CVO populates
-	// Release.Architecture in status properties like status.desired and status.history[].
-	StatusReleaseArchitecture() bool
-
 	// CVOConfiguration controls whether the CVO reconciles the ClusterVersionOperator resource that corresponds
 	// to its configuration.
 	CVOConfiguration() bool
@@ -57,17 +53,12 @@ type CvoGates struct {
 
 	// individual flags mirror the CvoGateChecker interface
 	unknownVersion            bool
-	statusReleaseArchitecture bool
 	cvoConfiguration          bool
 	acceptRisks               bool
 }
 
 func (c CvoGates) DesiredVersion() string {
 	return c.desiredVersion
-}
-
-func (c CvoGates) StatusReleaseArchitecture() bool {
-	return c.statusReleaseArchitecture
 }
 
 func (c CvoGates) UnknownVersion() bool {
@@ -87,7 +78,6 @@ func DefaultCvoGates(version string) CvoGates {
 	return CvoGates{
 		desiredVersion:            version,
 		unknownVersion:            true,
-		statusReleaseArchitecture: false,
 		cvoConfiguration:          false,
 		acceptRisks:               false,
 	}
@@ -107,8 +97,6 @@ func CvoGatesFromFeatureGate(gate *configv1.FeatureGate, version string) CvoGate
 		enabledGates.unknownVersion = false
 		for _, enabled := range g.Enabled {
 			switch enabled.Name {
-			case features.FeatureGateImageStreamImportMode:
-				enabledGates.statusReleaseArchitecture = true
 			case features.FeatureGateCVOConfiguration:
 				enabledGates.cvoConfiguration = true
 			case features.FeatureGateClusterUpdateAcceptRisks:
@@ -117,8 +105,6 @@ func CvoGatesFromFeatureGate(gate *configv1.FeatureGate, version string) CvoGate
 		}
 		for _, disabled := range g.Disabled {
 			switch disabled.Name {
-			case features.FeatureGateImageStreamImportMode:
-				enabledGates.statusReleaseArchitecture = false
 			case features.FeatureGateCVOConfiguration:
 				enabledGates.cvoConfiguration = false
 			case features.FeatureGateClusterUpdateAcceptRisks:


### PR DESCRIPTION
With openshift/api@42f4458500 (openshift/api#2266) having enabled the feature gate by default last November, we no longer have to be conditional about whether or not the gate is enabled here. We can just assume it is always enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release architecture metadata is now preserved when synchronizing cluster version status, including when the related feature gate is not enabled.
  - Available update information now consistently reports update and conditional-update architectures as stored.

- **Changes**
  - Removed the `StatusReleaseArchitecture` feature gate and associated status tracking. Architecture information is no longer cleared based on this gate.
  - Updates and conditional updates now retain their architecture metadata consistently across status synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->